### PR TITLE
[hotfix] let release branch also trigger ci test.

### DIFF
--- a/.github/workflows/flink-remote-shuffle-tests.yaml
+++ b/.github/workflows/flink-remote-shuffle-tests.yaml
@@ -1,9 +1,9 @@
 name: Remote Shuffle Service
 on:
   push:
-    branches: [main]
+    branches: [main, release-*]
   pull_request:
-    branches: [main]
+    branches: [main, release-*]
 jobs:
   build-and-test:
     runs-on: ubuntu-18.04


### PR DESCRIPTION
<!--

*Thank you very much for contributing to remote-shuffle-service-for-flink. To help the community review your issue or contribution in the best possible way，please take a few minutes to fulfill following items.*

-->

## What is the purpose of the change

This pull request enables release branch also trigger ci test.


## Brief change log
  - *change flink-remote-shuffle-tests.yaml*


## Verifying this change

This change is a trivial rework without any test coverage.
