### PR TITLE
[hotfix] Modify documents link to wiki page

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,9 +53,8 @@ offer some help to prepare the patches for the Flink version you use.
 
 ## Document
 
-The remote shuffle service supports standalone, yarn and k8s deployment. You can find the full user
-guide [here](./docs/user_guide.md)
-. In the future, more internal implementation detail specifications will be supplemented.
+The remote shuffle service supports standalone, yarn and k8s deployment. You can find the full documents [here](https://github.com/flink-extended/flink-remote-shuffle/wiki).
+In the future, more internal implementation detail specifications will be supplemented.
 
 ## Building from Source
 


### PR DESCRIPTION
<!--

*Thank you very much for contributing to remote-shuffle-service-for-flink. To help the community review your issue or contribution in the best possible way，please take a few minutes to fulfill following items.*

-->

## What is the purpose of the change

Modify documents link to wiki page to improve ease of use.

## Brief change log

  - Modify documents link to wiki page


## Verifying this change

This change is a trivial code cleanup without any test coverage.
