### PR TITLE
Support reporting metrics to prometheus

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -43,6 +43,7 @@ under the License.
 		<hamcrest.version>1.3</hamcrest.version>
 		<javax.annotation-api.version>1.3.2</javax.annotation-api.version>
 		<java.guava.version>11.0.2</java.guava.version>
+		<prometheus.version>0.8.1</prometheus.version>
 		<slf4j.version>1.7.15</slf4j.version>
 		<log4j.version>2.12.1</log4j.version>
 		<spotless.version>2.4.2</spotless.version>
@@ -66,6 +67,7 @@ under the License.
 		<module>shuffle-core</module>
 		<module>shuffle-kubernetes</module>
 		<module>shuffle-plugin</module>
+		<module>shuffle-metrics-reporter</module>
 		<module>shuffle-dist</module>
 		<module>shuffle-e2e-tests</module>
 		<module>shuffle-storage</module>

--- a/shuffle-common/src/main/java/com/alibaba/flink/shuffle/common/config/ConfigConstants.java
+++ b/shuffle-common/src/main/java/com/alibaba/flink/shuffle/common/config/ConfigConstants.java
@@ -1,0 +1,37 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.flink.shuffle.common.config;
+
+/** ConfigConstants. */
+public class ConfigConstants {
+    /**
+     * The prefix for per-reporter configs. Has to be combined with a reporter name and the configs
+     * mentioned below.
+     */
+    public static final String METRICS_REPORTER_PREFIX = "remote-shuffle.metrics.reporter.";
+
+    /** The class of the reporter to use. This is used as a suffix in an actual reporter config */
+    public static final String METRICS_REPORTER_CLASS_SUFFIX = "class";
+
+    /**
+     * The class of the reporter factory to use. This is used as a suffix in an actual reporter
+     * config
+     */
+    public static final String METRICS_REPORTER_FACTORY_CLASS_SUFFIX = "factory.class";
+}

--- a/shuffle-common/src/main/java/com/alibaba/flink/shuffle/common/config/DelegatingConfiguration.java
+++ b/shuffle-common/src/main/java/com/alibaba/flink/shuffle/common/config/DelegatingConfiguration.java
@@ -1,0 +1,157 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.flink.shuffle.common.config;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Properties;
+
+/**
+ * A configuration that manages a subset of keys with a common prefix from a given configuration.
+ */
+public final class DelegatingConfiguration extends Configuration {
+
+    private static final long serialVersionUID = 1L;
+
+    private final Configuration backingConfig; // the configuration actually storing the data
+
+    private String prefix; // the prefix key by which keys for this config are marked
+
+    // --------------------------------------------------------------------------------------------
+
+    /** Default constructor for serialization. Creates an empty delegating configuration. */
+    public DelegatingConfiguration() {
+        this.backingConfig = new Configuration();
+        this.prefix = "";
+    }
+
+    /**
+     * Creates a new delegating configuration which stores its key/value pairs in the given
+     * configuration using the specifies key prefix.
+     *
+     * @param backingConfig The configuration holding the actual config data.
+     * @param prefix The prefix prepended to all config keys.
+     */
+    public DelegatingConfiguration(Configuration backingConfig, String prefix) {
+        this.backingConfig = backingConfig;
+        this.prefix = prefix;
+    }
+
+    // --------------------------------------------------------------------------------------------
+
+    @Override
+    public String getString(String key, String defaultValue) {
+        return this.backingConfig.getString(this.prefix + key, defaultValue);
+    }
+
+    @Override
+    public String getString(ConfigOption<String> configOption) {
+        return this.backingConfig.getString(prefixOption(configOption, prefix));
+    }
+
+    @Override
+    public String getString(ConfigOption<String> configOption, String overrideDefault) {
+        return this.backingConfig.getString(prefixOption(configOption, prefix), overrideDefault);
+    }
+
+    @Override
+    public void setString(String key, String value) {
+        this.backingConfig.setString(this.prefix + key, value);
+    }
+
+    @Override
+    public void setString(ConfigOption<String> key, String value) {
+        this.backingConfig.setString(prefix + key.key(), value);
+    }
+
+    @Override
+    public Integer getInteger(ConfigOption<Integer> configOption) {
+        return this.backingConfig.getInteger(prefixOption(configOption, prefix));
+    }
+
+    @Override
+    public Long getLong(ConfigOption<Long> configOption) {
+        return this.backingConfig.getLong(prefixOption(configOption, prefix));
+    }
+
+    @Override
+    public Boolean getBoolean(ConfigOption<Boolean> configOption) {
+        return this.backingConfig.getBoolean(prefixOption(configOption, prefix));
+    }
+
+    @Override
+    public Float getFloat(ConfigOption<Float> configOption) {
+        return this.backingConfig.getFloat(prefixOption(configOption, prefix));
+    }
+
+    @Override
+    public Double getDouble(ConfigOption<Double> configOption) {
+        return this.backingConfig.getDouble(prefixOption(configOption, prefix));
+    }
+
+    @Override
+    public String toString() {
+        return backingConfig.toString();
+    }
+
+    @Override
+    public Map<String, String> toMap() {
+        Map<String, String> map = backingConfig.toMap();
+        Map<String, String> prefixed = new HashMap<>();
+        for (Map.Entry<String, String> entry : map.entrySet()) {
+            if (entry.getKey().startsWith(prefix)) {
+                String keyWithoutPrefix = entry.getKey().substring(prefix.length());
+                prefixed.put(keyWithoutPrefix, entry.getValue());
+            }
+        }
+        return prefixed;
+    }
+
+    @Override
+    public Properties toProperties() {
+        Properties clonedConfiguration = new Properties();
+        clonedConfiguration.putAll(toMap());
+        return clonedConfiguration;
+    }
+
+    // --------------------------------------------------------------------------------------------
+
+    @Override
+    public int hashCode() {
+        return this.prefix.hashCode() ^ this.backingConfig.hashCode();
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (obj instanceof DelegatingConfiguration) {
+            DelegatingConfiguration other = (DelegatingConfiguration) obj;
+            return this.prefix.equals(other.prefix)
+                    && this.backingConfig.equals(other.backingConfig);
+        } else {
+            return false;
+        }
+    }
+
+    // --------------------------------------------------------------------------------------------
+
+    private static <T> ConfigOption<T> prefixOption(ConfigOption<T> option, String prefix) {
+        String key = prefix + option.key();
+        return new ConfigOption<T>(key);
+    }
+}

--- a/shuffle-core/src/main/java/com/alibaba/flink/shuffle/core/config/MetricOptions.java
+++ b/shuffle-core/src/main/java/com/alibaba/flink/shuffle/core/config/MetricOptions.java
@@ -22,6 +22,29 @@ import com.alibaba.flink.shuffle.common.config.ConfigOption;
 
 /** Config options for metrics. */
 public class MetricOptions {
+    /**
+     * An optional list of reporter names. If configured, only reporters whose name matches any of
+     * the names in the list will be started. Otherwise, all reporters that could be found in the
+     * configuration will be started.
+     *
+     * <p>Example:
+     *
+     * <pre>{@code
+     * metrics.reporters = foo,bar
+     *
+     * metrics.reporter.foo.class = org.apache.flink.metrics.reporter.JMXReporter
+     * metrics.reporter.foo.interval = 10
+     *
+     * metrics.reporter.bar.class = org.apache.flink.metrics.graphite.GraphiteReporter
+     * metrics.reporter.bar.port = 1337
+     * }</pre>
+     */
+    public static final ConfigOption<String> REPORTERS_LIST =
+            new ConfigOption<String>("remote-shuffle.metrics.reporter")
+                    .description(
+                            "An optional list of reporter names. If configured, only reporters whose name matches"
+                                    + " any of the names in the list will be started. Otherwise, all reporters that could be found in"
+                                    + " the configuration will be started.");
 
     /** Whether the http server for reading metrics is enabled. */
     public static final ConfigOption<Boolean> METRICS_HTTP_SERVER_ENABLE =
@@ -60,7 +83,6 @@ public class MetricOptions {
                             "Specify the implementation classes of metrics reporter. Separate by "
                                     + "';' if there are multiple class names. Each class name needs"
                                     + " a package name prefix, e.g. a.b.c.Factory1;a.b.c.Factory2.");
-
     // ------------------------------------------------------------------------
 
     /** Not intended to be instantiated. */

--- a/shuffle-core/src/main/java/com/alibaba/flink/shuffle/core/exception/IllegalConfigurationException.java
+++ b/shuffle-core/src/main/java/com/alibaba/flink/shuffle/core/exception/IllegalConfigurationException.java
@@ -1,0 +1,62 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.flink.shuffle.core.exception;
+
+import com.alibaba.flink.shuffle.common.config.Configuration;
+
+/**
+ * An {@code IllegalConfigurationException} is thrown when the values in a given {@link
+ * Configuration} are not valid. This may refer to the Flink configuration with which the framework
+ * is started, or a Configuration passed internally between components.
+ */
+public class IllegalConfigurationException extends RuntimeException {
+
+    private static final long serialVersionUID = 695506964810499989L;
+
+    /**
+     * Constructs an new IllegalConfigurationException with the given error message.
+     *
+     * @param message The error message for the exception.
+     */
+    public IllegalConfigurationException(String message) {
+        super(message);
+    }
+
+    /**
+     * Constructs an new IllegalConfigurationException with the given error message format and
+     * arguments.
+     *
+     * @param format The error message format for the exception.
+     * @param arguments The arguments for the format.
+     */
+    public IllegalConfigurationException(String format, Object... arguments) {
+        super(String.format(format, arguments));
+    }
+
+    /**
+     * Constructs an new IllegalConfigurationException with the given error message and a given
+     * cause.
+     *
+     * @param message The error message for the exception.
+     * @param cause The exception that caused this exception.
+     */
+    public IllegalConfigurationException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/shuffle-core/src/main/java/com/alibaba/flink/shuffle/core/exception/TraversableOnceException.java
+++ b/shuffle-core/src/main/java/com/alibaba/flink/shuffle/core/exception/TraversableOnceException.java
@@ -1,0 +1,34 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.flink.shuffle.core.exception;
+
+/**
+ * An exception, indicating that an {@link Iterable} can only be traversed once, but has been
+ * attempted to traverse an additional time.
+ */
+public class TraversableOnceException extends RuntimeException {
+
+    private static final long serialVersionUID = 7636881584773577290L;
+
+    /** Creates a new exception with a default message. */
+    public TraversableOnceException() {
+        super(
+                "The Iterable can be iterated over only once. Only the first call to 'iterator()' will succeed.");
+    }
+}

--- a/shuffle-core/src/main/java/com/alibaba/flink/shuffle/core/utils/NetUtils.java
+++ b/shuffle-core/src/main/java/com/alibaba/flink/shuffle/core/utils/NetUtils.java
@@ -1,0 +1,119 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.flink.shuffle.core.utils;
+
+import com.alibaba.flink.shuffle.core.exception.IllegalConfigurationException;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Collections;
+import java.util.Iterator;
+
+/** Utility for various network related tasks (such as finding free ports). */
+public class NetUtils {
+
+    private static final Logger LOG = LoggerFactory.getLogger(NetUtils.class);
+
+    // ------------------------------------------------------------------------
+    //  Port range parsing
+    // ------------------------------------------------------------------------
+
+    /**
+     * Returns an iterator over available ports defined by the range definition.
+     *
+     * @param rangeDefinition String describing a single port, a range of ports or multiple ranges.
+     * @return Set of ports from the range definition
+     * @throws NumberFormatException If an invalid string is passed.
+     */
+    public static Iterator<Integer> getPortRangeFromString(String rangeDefinition)
+            throws NumberFormatException {
+        final String[] ranges = rangeDefinition.trim().split(",");
+
+        UnionIterator<Integer> iterators = new UnionIterator<>();
+
+        for (String rawRange : ranges) {
+            Iterator<Integer> rangeIterator;
+            String range = rawRange.trim();
+            int dashIdx = range.indexOf('-');
+            if (dashIdx == -1) {
+                // only one port in range:
+                final int port = Integer.valueOf(range);
+                if (!isValidHostPort(port)) {
+                    throw new IllegalConfigurationException(
+                            "Invalid port configuration. Port must be between 0"
+                                    + "and 65535, but was "
+                                    + port
+                                    + ".");
+                }
+                rangeIterator = Collections.singleton(Integer.valueOf(range)).iterator();
+            } else {
+                // evaluate range
+                final int start = Integer.valueOf(range.substring(0, dashIdx));
+                if (!isValidHostPort(start)) {
+                    throw new IllegalConfigurationException(
+                            "Invalid port configuration. Port must be between 0"
+                                    + "and 65535, but was "
+                                    + start
+                                    + ".");
+                }
+                final int end = Integer.valueOf(range.substring(dashIdx + 1, range.length()));
+                if (!isValidHostPort(end)) {
+                    throw new IllegalConfigurationException(
+                            "Invalid port configuration. Port must be between 0"
+                                    + "and 65535, but was "
+                                    + end
+                                    + ".");
+                }
+                rangeIterator =
+                        new Iterator<Integer>() {
+                            int i = start;
+
+                            @Override
+                            public boolean hasNext() {
+                                return i <= end;
+                            }
+
+                            @Override
+                            public Integer next() {
+                                return i++;
+                            }
+
+                            @Override
+                            public void remove() {
+                                throw new UnsupportedOperationException("Remove not supported");
+                            }
+                        };
+            }
+            iterators.add(rangeIterator);
+        }
+
+        return iterators;
+    }
+
+    /**
+     * check whether the given port is in right range when getting port from local system.
+     *
+     * @param port the port to check
+     * @return true if the number in the range 0 to 65535
+     */
+    public static boolean isValidHostPort(int port) {
+        return 0 <= port && port <= 65535;
+    }
+}

--- a/shuffle-core/src/main/java/com/alibaba/flink/shuffle/core/utils/UnionIterator.java
+++ b/shuffle-core/src/main/java/com/alibaba/flink/shuffle/core/utils/UnionIterator.java
@@ -1,0 +1,106 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.flink.shuffle.core.utils;
+
+import com.alibaba.flink.shuffle.core.exception.TraversableOnceException;
+
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+import java.util.NoSuchElementException;
+
+/**
+ * An iterator that concatenates a collection of iterators. The UnionIterator is a mutable, reusable
+ * type.
+ *
+ * @param <T> The type returned by the iterator.
+ */
+public class UnionIterator<T> implements Iterator<T>, Iterable<T> {
+
+    private Iterator<T> currentIterator;
+
+    private ArrayList<Iterator<T>> furtherIterators = new ArrayList<>();
+
+    private int nextIterator;
+
+    private boolean iteratorAvailable = true;
+
+    // ------------------------------------------------------------------------
+
+    public void clear() {
+        currentIterator = null;
+        furtherIterators.clear();
+        nextIterator = 0;
+        iteratorAvailable = true;
+    }
+
+    public void addList(List<T> list) {
+        add(list.iterator());
+    }
+
+    public void add(Iterator<T> iterator) {
+        if (currentIterator == null) {
+            currentIterator = iterator;
+        } else {
+            furtherIterators.add(iterator);
+        }
+    }
+
+    // ------------------------------------------------------------------------
+
+    @Override
+    public Iterator<T> iterator() {
+        if (iteratorAvailable) {
+            iteratorAvailable = false;
+            return this;
+        } else {
+            throw new TraversableOnceException();
+        }
+    }
+
+    @Override
+    public boolean hasNext() {
+        while (currentIterator != null) {
+            if (currentIterator.hasNext()) {
+                return true;
+            } else if (nextIterator < furtherIterators.size()) {
+                currentIterator = furtherIterators.get(nextIterator);
+                nextIterator++;
+            } else {
+                currentIterator = null;
+            }
+        }
+
+        return false;
+    }
+
+    @Override
+    public T next() {
+        if (hasNext()) {
+            return currentIterator.next();
+        } else {
+            throw new NoSuchElementException();
+        }
+    }
+
+    @Override
+    public void remove() {
+        throw new UnsupportedOperationException();
+    }
+}

--- a/shuffle-dist/src/main/assemblies/bin.xml
+++ b/shuffle-dist/src/main/assemblies/bin.xml
@@ -70,6 +70,13 @@ under the License.
 			<outputDirectory>lib/</outputDirectory>
 			<fileMode>0644</fileMode>
 		</file>
+
+		<!-- copy metrics reporter jar -->
+		<file>
+			<source>../shuffle-metrics-reporter/shuffle-metrics-reporter-prometheus/target/shuffle-metrics-reporter-prometheus-${project.version}.jar</source>
+			<outputDirectory>lib/</outputDirectory>
+			<fileMode>0644</fileMode>
+		</file>
 	</files>
 
 	<fileSets>

--- a/shuffle-examples/src/main/java/com/alibaba/flink/shuffle/examples/BatchJobDemo.java
+++ b/shuffle-examples/src/main/java/com/alibaba/flink/shuffle/examples/BatchJobDemo.java
@@ -18,6 +18,7 @@
 
 package com.alibaba.flink.shuffle.examples;
 
+import org.apache.flink.api.common.RuntimeExecutionMode;
 import org.apache.flink.runtime.jobgraph.JobType;
 import org.apache.flink.streaming.api.datastream.DataStream;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
@@ -45,9 +46,17 @@ public class BatchJobDemo {
                 .addSink(
                         new SinkFunction<byte[]>() {
                             @Override
-                            public void invoke(byte[] value) {}
+                            public void invoke(byte[] value) {
+                                try {
+                                    System.out.println(new String(value));
+                                    Thread.sleep(1000);
+                                } catch (Exception e) {
+                                    e.printStackTrace();
+                                }
+                            }
                         });
         StreamGraph streamGraph = env.getStreamGraph();
+        env.setRuntimeMode(RuntimeExecutionMode.BATCH);
         streamGraph.setGlobalStreamExchangeMode(GlobalStreamExchangeMode.ALL_EDGES_BLOCKING);
         streamGraph.setJobType(JobType.BATCH);
         env.execute(streamGraph);

--- a/shuffle-metrics-reporter/pom.xml
+++ b/shuffle-metrics-reporter/pom.xml
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+  http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+		 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+		 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<parent>
+		<artifactId>flink-shuffle-parent</artifactId>
+		<groupId>com.alibaba.flink.shuffle</groupId>
+		<version>1.1-SNAPSHOT</version>
+		<relativePath>..</relativePath>
+	</parent>
+	<modelVersion>4.0.0</modelVersion>
+
+	<artifactId>shuffle-metrics-reporter</artifactId>
+	<packaging>pom</packaging>
+
+	<properties>
+		<maven.compiler.source>8</maven.compiler.source>
+		<maven.compiler.target>8</maven.compiler.target>
+	</properties>
+
+	<modules>
+		<module>shuffle-metrics-reporter-prometheus</module>
+	</modules>
+
+	<dependencies>
+		<dependency>
+			<groupId>com.alibaba.flink.shuffle</groupId>
+			<artifactId>shuffle-metrics</artifactId>
+			<version>${project.version}</version>
+		</dependency>
+	</dependencies>
+</project>

--- a/shuffle-metrics-reporter/shuffle-metrics-reporter-prometheus/pom.xml
+++ b/shuffle-metrics-reporter/shuffle-metrics-reporter-prometheus/pom.xml
@@ -1,0 +1,90 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+  http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+		 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+		 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<parent>
+		<artifactId>shuffle-metrics-reporter</artifactId>
+		<groupId>com.alibaba.flink.shuffle</groupId>
+		<version>1.1-SNAPSHOT</version>
+	</parent>
+	<modelVersion>4.0.0</modelVersion>
+
+	<artifactId>shuffle-metrics-reporter-prometheus</artifactId>
+
+	<properties>
+		<maven.compiler.source>8</maven.compiler.source>
+		<maven.compiler.target>8</maven.compiler.target>
+	</properties>
+
+	<dependencies>
+		<dependency>
+			<groupId>io.prometheus</groupId>
+			<artifactId>simpleclient</artifactId>
+			<version>${prometheus.version}</version>
+		</dependency>
+
+		<dependency>
+			<groupId>io.prometheus</groupId>
+			<artifactId>simpleclient_httpserver</artifactId>
+			<version>${prometheus.version}</version>
+		</dependency>
+
+		<dependency>
+			<groupId>io.prometheus</groupId>
+			<artifactId>simpleclient_pushgateway</artifactId>
+			<version>${prometheus.version}</version>
+		</dependency>
+
+        <dependency>
+            <groupId>org.apache.httpcomponents</groupId>
+            <artifactId>httpcore</artifactId>
+            <version>4.1.2</version>
+            <scope>test</scope>
+        </dependency>
+
+    </dependencies>
+
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-shade-plugin</artifactId>
+				<configuration>
+					<createDependencyReducedPom>false</createDependencyReducedPom>
+				</configuration>
+				<executions>
+					<execution>
+						<id>shade-flink</id>
+						<phase>package</phase>
+						<goals>
+							<goal>shade</goal>
+						</goals>
+						<configuration>
+							<artifactSet>
+								<includes>
+									<include>io.prometheus:*</include>
+								</includes>
+							</artifactSet>
+						</configuration>
+					</execution>
+				</executions>
+			</plugin>
+		</plugins>
+	</build>
+</project>

--- a/shuffle-metrics-reporter/shuffle-metrics-reporter-prometheus/src/main/java/com/alibaba/flink/shuffle/metrics/reporter/AbstractPrometheusReporter.java
+++ b/shuffle-metrics-reporter/shuffle-metrics-reporter-prometheus/src/main/java/com/alibaba/flink/shuffle/metrics/reporter/AbstractPrometheusReporter.java
@@ -1,0 +1,346 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.flink.shuffle.metrics.reporter;
+
+import com.alibaba.metrics.ClusterHistogram;
+import com.alibaba.metrics.Compass;
+import com.alibaba.metrics.Counter;
+import com.alibaba.metrics.FastCompass;
+import com.alibaba.metrics.Gauge;
+import com.alibaba.metrics.Histogram;
+import com.alibaba.metrics.IMetricManager;
+import com.alibaba.metrics.Meter;
+import com.alibaba.metrics.Metric;
+import com.alibaba.metrics.MetricFilter;
+import com.alibaba.metrics.MetricName;
+import com.alibaba.metrics.MetricRegistry;
+import com.alibaba.metrics.Snapshot;
+import com.alibaba.metrics.Timer;
+import com.alibaba.metrics.common.config.MetricsCollectPeriodConfig;
+import com.alibaba.metrics.reporter.MetricManagerReporter;
+import io.prometheus.client.Collector;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.AbstractMap;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.regex.Pattern;
+
+/** base prometheus reporter for prometheus metrics. */
+public class AbstractPrometheusReporter extends MetricManagerReporter {
+    protected final Logger log = LoggerFactory.getLogger(getClass());
+    private static final Pattern UNALLOWED_CHAR_PATTERN = Pattern.compile("[^a-zA-Z0-9:_]");
+    private IMetricManager metricManager;
+
+    private final Map<String, AbstractMap.SimpleImmutableEntry<Collector, Integer>>
+            collectorsWithCountByMetricName = new ConcurrentHashMap<>();
+
+    public AbstractPrometheusReporter(
+            IMetricManager metricManager,
+            String name,
+            MetricFilter filter,
+            MetricsCollectPeriodConfig metricsReportPeriodConfig,
+            TimeUnit rateUnit,
+            TimeUnit durationUnit) {
+        super(metricManager, name, filter, metricsReportPeriodConfig, rateUnit, durationUnit);
+        this.metricManager = metricManager;
+    }
+
+    @Override
+    public void report(
+            Map<MetricName, Gauge> gauges,
+            Map<MetricName, Counter> counters,
+            Map<MetricName, Histogram> histograms,
+            Map<MetricName, Meter> meters,
+            Map<MetricName, Timer> timers,
+            Map<MetricName, Compass> compasses,
+            Map<MetricName, FastCompass> fastCompasses,
+            Map<MetricName, ClusterHistogram> clusterHistogrames) {
+
+        Map<String, Set<MetricName>> metricNamesByGroup = metricManager.listMetricNamesByGroup();
+
+        Arrays.asList(
+                        gauges,
+                        counters,
+                        histograms,
+                        meters,
+                        timers,
+                        compasses,
+                        fastCompasses,
+                        clusterHistogrames)
+                .forEach(
+                        metricNameMap -> {
+                            for (Map.Entry<MetricName, ? extends Metric> g :
+                                    metricNameMap.entrySet()) {
+
+                                String group = getGroupByMetricName(metricNamesByGroup, g.getKey());
+                                String metricName =
+                                        filterCharacters(
+                                                MetricRegistry.name(group, g.getKey().getKey())
+                                                        .getKey());
+
+                                final String helpString = metricName + " (scope: " + g + ")";
+
+                                List<String> dimensionKeys = new LinkedList<>();
+                                List<String> dimensionValues = new LinkedList<>();
+
+                                for (final Map.Entry<String, String> dimension :
+                                        g.getKey().getTags().entrySet()) {
+                                    final String key = dimension.getKey();
+                                    dimensionKeys.add(filterCharacters(key));
+                                    dimensionValues.add(filterCharacters(dimension.getValue()));
+                                }
+                                final Collector collector;
+                                int count = 0;
+                                if (collectorsWithCountByMetricName.containsKey(metricName)) {
+                                    final AbstractMap.SimpleImmutableEntry<Collector, Integer>
+                                            collectorWithCount =
+                                                    collectorsWithCountByMetricName.get(metricName);
+                                    collector = collectorWithCount.getKey();
+                                } else {
+                                    collector =
+                                            createCollector(
+                                                    g.getValue(),
+                                                    dimensionKeys,
+                                                    dimensionValues,
+                                                    metricName,
+                                                    helpString);
+                                    try {
+                                        collector.register();
+                                    } catch (Exception e) {
+                                        log.warn(
+                                                "There was a problem registering metric {}.",
+                                                metricName,
+                                                e);
+                                    }
+                                }
+                                addMetricToCollector(g.getValue(), dimensionValues, collector);
+                                collectorsWithCountByMetricName.put(
+                                        metricName,
+                                        new AbstractMap.SimpleImmutableEntry<>(
+                                                collector, count + 1));
+                            }
+                        });
+    }
+
+    private Collector createCollector(
+            Metric metric,
+            List<String> dimensionKeys,
+            List<String> dimensionValues,
+            String scopedMetricName,
+            String helpString) {
+        Collector collector;
+        if (metric instanceof Gauge || metric instanceof Counter || metric instanceof Meter) {
+            collector =
+                    io.prometheus.client.Gauge.build()
+                            .name(scopedMetricName)
+                            .help(helpString)
+                            .labelNames(toArray(dimensionKeys))
+                            .create();
+        } else if (metric instanceof Histogram) {
+            collector =
+                    new HistogramSummaryProxy(
+                            (Histogram) metric,
+                            scopedMetricName,
+                            helpString,
+                            dimensionKeys,
+                            dimensionValues);
+        } else {
+            log.warn(
+                    "Cannot create collector for unknown metric type: {}. This indicates that the metric type is not supported by this reporter.",
+                    metric.getClass().getName());
+            collector = null;
+        }
+        return collector;
+    }
+
+    static class HistogramSummaryProxy extends Collector {
+        static final List<Double> QUANTILES = Arrays.asList(.5, .75, .95, .98, .99, .999);
+
+        private final String metricName;
+        private final String helpString;
+        private final List<String> labelNamesWithQuantile;
+
+        private final Map<List<String>, Histogram> histogramsByLabelValues = new HashMap<>();
+
+        HistogramSummaryProxy(
+                final Histogram histogram,
+                final String metricName,
+                final String helpString,
+                final List<String> labelNames,
+                final List<String> labelValues) {
+            this.metricName = metricName;
+            this.helpString = helpString;
+            this.labelNamesWithQuantile = addToList(labelNames, "quantile");
+            histogramsByLabelValues.put(labelValues, histogram);
+        }
+
+        @Override
+        public List<MetricFamilySamples> collect() {
+            // We cannot use SummaryMetricFamily because it is impossible to get a sum of all values
+            // (at least for Dropwizard histograms,
+            // whose snapshot's values array only holds a sample of recent values).
+
+            List<MetricFamilySamples.Sample> samples = new LinkedList<>();
+            for (Map.Entry<List<String>, Histogram> labelValuesToHistogram :
+                    histogramsByLabelValues.entrySet()) {
+                addSamples(
+                        labelValuesToHistogram.getKey(),
+                        labelValuesToHistogram.getValue(),
+                        samples);
+            }
+            return Collections.singletonList(
+                    new MetricFamilySamples(metricName, Type.SUMMARY, helpString, samples));
+        }
+
+        void addChild(final Histogram histogram, final List<String> labelValues) {
+            histogramsByLabelValues.put(labelValues, histogram);
+        }
+
+        void remove(final List<String> labelValues) {
+            histogramsByLabelValues.remove(labelValues);
+        }
+
+        private void addSamples(
+                final List<String> labelValues,
+                final Histogram histogram,
+                final List<MetricFamilySamples.Sample> samples) {
+            samples.add(
+                    new MetricFamilySamples.Sample(
+                            metricName + "_count",
+                            labelNamesWithQuantile.subList(0, labelNamesWithQuantile.size() - 1),
+                            labelValues,
+                            histogram.getCount()));
+            final Snapshot statistics = histogram.getSnapshot();
+
+            for (final Double quantile : QUANTILES) {
+                samples.add(
+                        new MetricFamilySamples.Sample(
+                                metricName,
+                                labelNamesWithQuantile,
+                                addToList(labelValues, quantile.toString()),
+                                statistics.getValue(quantile)));
+            }
+        }
+    }
+
+    private static List<String> addToList(List<String> list, String element) {
+        final List<String> result = new ArrayList<>(list);
+        result.add(element);
+        return result;
+    }
+
+    private static String[] toArray(List<String> list) {
+        return list.toArray(new String[list.size()]);
+    }
+
+    private void addMetricToCollector(
+            Metric metric, List<String> dimensionValues, Collector collector) {
+        if (metric instanceof Gauge) {
+            ((io.prometheus.client.Gauge) collector)
+                    .setChild(gaugeFrom((Gauge) metric), toArray(dimensionValues));
+        } else if (metric instanceof Counter) {
+            ((io.prometheus.client.Gauge) collector)
+                    .setChild(gaugeFrom((Counter) metric), toArray(dimensionValues));
+        } else if (metric instanceof Meter) {
+            ((io.prometheus.client.Gauge) collector)
+                    .setChild(gaugeFrom((Meter) metric), toArray(dimensionValues));
+        } else if (metric instanceof Histogram) {
+            ((HistogramSummaryProxy) collector).addChild((Histogram) metric, dimensionValues);
+        } else {
+            log.warn(
+                    "Cannot add unknown metric type: {}. This indicates that the metric type is not supported by this reporter.",
+                    metric.getClass().getName());
+        }
+    }
+
+    io.prometheus.client.Gauge.Child gaugeFrom(Gauge gauge) {
+        return new io.prometheus.client.Gauge.Child() {
+            @Override
+            public double get() {
+                final Object value = gauge.getValue();
+                if (value == null) {
+                    log.debug("Gauge {} is null-valued, defaulting to 0.", gauge);
+                    return 0;
+                }
+                if (value instanceof Double) {
+                    return (double) value;
+                }
+                if (value instanceof Number) {
+                    return ((Number) value).doubleValue();
+                }
+                if (value instanceof Boolean) {
+                    return ((Boolean) value) ? 1 : 0;
+                }
+                log.debug(
+                        "Invalid type for Gauge {}: {}, only number types and booleans are supported by this reporter.",
+                        gauge,
+                        value.getClass().getName());
+                return 0;
+            }
+        };
+    }
+
+    private static io.prometheus.client.Gauge.Child gaugeFrom(Counter counter) {
+        return new io.prometheus.client.Gauge.Child() {
+            @Override
+            public double get() {
+                return (double) counter.getCount();
+            }
+        };
+    }
+
+    private static io.prometheus.client.Gauge.Child gaugeFrom(Meter meter) {
+        return new io.prometheus.client.Gauge.Child() {
+            @Override
+            public double get() {
+                return meter.getCount();
+            }
+        };
+    }
+
+    private static String filterCharacters(String input) {
+        // https://prometheus.io/docs/instrumenting/writing_exporters/
+        // Only [a-zA-Z0-9:_] are valid in metric names, any other characters should be sanitized to
+        // an underscore.
+        return UNALLOWED_CHAR_PATTERN.matcher(input).replaceAll("_");
+    }
+
+    private String getGroupByMetricName(
+            Map<String, Set<MetricName>> metricNamesByGroup, MetricName name) {
+        AtomicReference<String> groupName = new AtomicReference<>("");
+        metricNamesByGroup.forEach(
+                (group, names) -> {
+                    if (names.contains(name)) {
+                        groupName.set(group);
+                    }
+                });
+        return groupName.get();
+    }
+}

--- a/shuffle-metrics-reporter/shuffle-metrics-reporter-prometheus/src/main/java/com/alibaba/flink/shuffle/metrics/reporter/PrometheusPushGatewayReporter.java
+++ b/shuffle-metrics-reporter/shuffle-metrics-reporter-prometheus/src/main/java/com/alibaba/flink/shuffle/metrics/reporter/PrometheusPushGatewayReporter.java
@@ -1,0 +1,189 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.flink.shuffle.metrics.reporter;
+
+import com.alibaba.metrics.IMetricManager;
+import com.alibaba.metrics.Metric;
+import com.alibaba.metrics.MetricFilter;
+import com.alibaba.metrics.common.config.MetricsCollectPeriodConfig;
+import com.alibaba.metrics.reporter.MetricManagerReporter;
+import io.prometheus.client.CollectorRegistry;
+import io.prometheus.client.exporter.PushGateway;
+import org.glassfish.jersey.internal.guava.Preconditions;
+
+import java.io.IOException;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * {@link MetricManagerReporter} that exports {@link Metric Metrics} via Prometheus {@link
+ * PushGateway}.
+ */
+public class PrometheusPushGatewayReporter extends AbstractPrometheusReporter {
+    private final PushGateway pushGateway;
+    private final String jobName;
+    private final Map<String, String> groupingKey;
+    private final boolean deleteOnShutdown;
+    private static final String INIT_FLAG = "com.alibaba.metrics.file_reporter.init_flag";
+    private static final String REPORTER_NAME = "prometheus-pushGateway-reporter";
+
+    private PrometheusPushGatewayReporter(
+            String host,
+            int port,
+            String jobName,
+            Map<String, String> groupingKey,
+            final boolean deleteOnShutdown,
+            IMetricManager metricManager,
+            MetricFilter filter,
+            MetricsCollectPeriodConfig metricsReportPeriodConfig,
+            TimeUnit rateUnit,
+            TimeUnit durationUnit) {
+        super(
+                metricManager,
+                REPORTER_NAME,
+                filter,
+                metricsReportPeriodConfig,
+                rateUnit,
+                durationUnit);
+        this.pushGateway = new PushGateway(host + ':' + port);
+        this.jobName = Preconditions.checkNotNull(jobName);
+        this.groupingKey = Preconditions.checkNotNull(groupingKey);
+        this.deleteOnShutdown = deleteOnShutdown;
+    }
+
+    @Override
+    public void start(long period, TimeUnit unit) {
+        String initFlag = System.getProperty(INIT_FLAG);
+
+        if ("false".equals(initFlag)) {
+            log.info("PrometheusPushGatewayReporter disabled...");
+            return;
+        }
+
+        if (initFlag == null) {
+            System.setProperty(INIT_FLAG, "true");
+            super.start(period, unit);
+        } else {
+            log.info("PrometheusPushGatewayReporter has been started...");
+        }
+    }
+
+    @Override
+    public void report() {
+        try {
+            super.report();
+            pushGateway.push(CollectorRegistry.defaultRegistry, jobName, groupingKey);
+        } catch (Exception e) {
+            log.warn(
+                    "Failed to push metrics to PushGateway with jobName {}, groupingKey {}.",
+                    jobName,
+                    groupingKey,
+                    e);
+        }
+    }
+
+    @Override
+    public void close() {
+        if (deleteOnShutdown && pushGateway != null) {
+            try {
+                pushGateway.delete(jobName, groupingKey);
+            } catch (IOException e) {
+                log.warn(
+                        "Failed to delete metrics from PushGateway with jobName {}, groupingKey {}.",
+                        jobName,
+                        groupingKey,
+                        e);
+            }
+        }
+        super.close();
+    }
+
+    /** A builder for PrometheusPushGatewayReporter instances. */
+    public static class Builder {
+        private String host;
+        private int port;
+        private String jobName;
+        private Map<String, String> groupingKey;
+        private boolean deleteOnShutdown;
+        private MetricFilter filter;
+        private IMetricManager metricManager;
+        private MetricsCollectPeriodConfig metricsReportPeriodConfig;
+        private TimeUnit rateUnit;
+        private TimeUnit durationUnit;
+
+        // 提交到服务器的时间戳的单位，只支持毫秒和秒，默认是秒
+        private TimeUnit timestampPrecision = TimeUnit.SECONDS;
+
+        Builder(IMetricManager metricManager) {
+            this.metricManager = metricManager;
+            this.rateUnit = TimeUnit.SECONDS;
+            this.durationUnit = TimeUnit.MILLISECONDS;
+            this.filter = MetricFilter.ALL;
+        }
+
+        public PrometheusPushGatewayReporter.Builder host(String host) {
+            this.host = host;
+            return this;
+        }
+
+        public PrometheusPushGatewayReporter.Builder port(int port) {
+            this.port = port;
+            return this;
+        }
+
+        public PrometheusPushGatewayReporter.Builder jobName(String jobName) {
+            this.jobName = jobName;
+            return this;
+        }
+
+        public PrometheusPushGatewayReporter.Builder groupingKey(Map<String, String> groupingKey) {
+            this.groupingKey = groupingKey;
+            return this;
+        }
+
+        public PrometheusPushGatewayReporter.Builder deleteOnShutdown(boolean deleteOnShutdown) {
+            this.deleteOnShutdown = deleteOnShutdown;
+            return this;
+        }
+
+        /**
+         * @param metricsReportPeriodConfig
+         * @return
+         */
+        public PrometheusPushGatewayReporter.Builder metricsReportPeriodConfig(
+                MetricsCollectPeriodConfig metricsReportPeriodConfig) {
+            this.metricsReportPeriodConfig = metricsReportPeriodConfig;
+            return this;
+        }
+
+        public PrometheusPushGatewayReporter build() {
+            return new PrometheusPushGatewayReporter(
+                    host,
+                    port,
+                    jobName,
+                    groupingKey,
+                    deleteOnShutdown,
+                    metricManager,
+                    filter,
+                    metricsReportPeriodConfig,
+                    rateUnit,
+                    durationUnit);
+        }
+    }
+}

--- a/shuffle-metrics-reporter/shuffle-metrics-reporter-prometheus/src/main/java/com/alibaba/flink/shuffle/metrics/reporter/PrometheusPushGatewayReporterFactory.java
+++ b/shuffle-metrics-reporter/shuffle-metrics-reporter-prometheus/src/main/java/com/alibaba/flink/shuffle/metrics/reporter/PrometheusPushGatewayReporterFactory.java
@@ -1,0 +1,125 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.flink.shuffle.metrics.reporter;
+
+import com.alibaba.flink.shuffle.common.config.Configuration;
+import com.alibaba.flink.shuffle.common.utils.CommonUtils;
+import com.alibaba.flink.shuffle.common.utils.StringUtils;
+
+import com.alibaba.metrics.common.config.MetricsCollectPeriodConfig;
+import com.alibaba.metrics.reporter.MetricManagerReporter;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.time.Duration;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Properties;
+import java.util.concurrent.TimeUnit;
+
+import static com.alibaba.flink.shuffle.metrics.reporter.PrometheusPushGatewayReporterOptions.DELETE_ON_SHUTDOWN;
+import static com.alibaba.flink.shuffle.metrics.reporter.PrometheusPushGatewayReporterOptions.GROUPING_KEY;
+import static com.alibaba.flink.shuffle.metrics.reporter.PrometheusPushGatewayReporterOptions.HOST;
+import static com.alibaba.flink.shuffle.metrics.reporter.PrometheusPushGatewayReporterOptions.INTERVAL;
+import static com.alibaba.flink.shuffle.metrics.reporter.PrometheusPushGatewayReporterOptions.JOB_NAME;
+import static com.alibaba.flink.shuffle.metrics.reporter.PrometheusPushGatewayReporterOptions.PORT;
+import static com.alibaba.flink.shuffle.metrics.reporter.PrometheusPushGatewayReporterOptions.RANDOM_JOB_NAME_SUFFIX;
+import static com.alibaba.metrics.MetricManager.getIMetricManager;
+
+/** {@link MetricReporterFactory} for {@link PrometheusPushGatewayReporter}. */
+public class PrometheusPushGatewayReporterFactory implements MetricReporterFactory {
+    private static final Logger LOG =
+            LoggerFactory.getLogger(PrometheusPushGatewayReporterFactory.class);
+
+    @Override
+    public MetricManagerReporter createMetricReporter(Properties conf) {
+        Configuration configuration = new Configuration(conf);
+        String host = configuration.getString(HOST.key(), HOST.defaultValue());
+        int port = configuration.getInteger(PORT.key(), PORT.defaultValue());
+        String configuredJobName = configuration.getString(JOB_NAME.key(), JOB_NAME.defaultValue());
+        boolean randomSuffix =
+                configuration.getBoolean(
+                        RANDOM_JOB_NAME_SUFFIX.key(), RANDOM_JOB_NAME_SUFFIX.defaultValue());
+        boolean deleteOnShutdown =
+                configuration.getBoolean(
+                        DELETE_ON_SHUTDOWN.key(), DELETE_ON_SHUTDOWN.defaultValue());
+        Map<String, String> groupingKey =
+                parseGroupingKey(
+                        configuration.getString(GROUPING_KEY.key(), GROUPING_KEY.defaultValue()));
+
+        Duration interval =
+                configuration.getDuration(
+                        INTERVAL, Duration.ofMinutes(MetricsCollectPeriodConfig.DEFAULT_INTERVAL));
+        if (host == null || host.isEmpty() || port < 1) {
+            throw new IllegalArgumentException(
+                    "Invalid host/port configuration. Host: " + host + " Port: " + port);
+        }
+
+        String jobName = configuredJobName;
+        if (randomSuffix) {
+            jobName = configuredJobName + CommonUtils.randomHexString(16);
+        }
+
+        PrometheusPushGatewayReporter.Builder builder =
+                new PrometheusPushGatewayReporter.Builder(getIMetricManager());
+        builder.port(port);
+        builder.host(host);
+        builder.jobName(jobName);
+        builder.deleteOnShutdown(deleteOnShutdown);
+        builder.groupingKey(groupingKey);
+        builder.metricsReportPeriodConfig(
+                new MetricsCollectPeriodConfig((int) interval.getSeconds()));
+
+        // start reporter
+        MetricManagerReporter reporter = builder.build();
+        reporter.start(interval.getSeconds(), TimeUnit.SECONDS);
+        return reporter;
+    }
+
+    static Map<String, String> parseGroupingKey(final String groupingKeyConfig) {
+        if (!groupingKeyConfig.isEmpty()) {
+            Map<String, String> groupingKey = new HashMap<>();
+            String[] kvs = groupingKeyConfig.split(";");
+            for (String kv : kvs) {
+                int idx = kv.indexOf("=");
+                if (idx < 0) {
+                    LOG.warn("Invalid prometheusPushGateway groupingKey:{}, will be ignored", kv);
+                    continue;
+                }
+
+                String labelKey = kv.substring(0, idx);
+                String labelValue = kv.substring(idx + 1);
+                if (StringUtils.isNullOrWhitespaceOnly(labelKey)
+                        || StringUtils.isNullOrWhitespaceOnly(labelValue)) {
+                    LOG.warn(
+                            "Invalid groupingKey {labelKey:{}, labelValue:{}} must not be empty",
+                            labelKey,
+                            labelValue);
+                    continue;
+                }
+                groupingKey.put(labelKey, labelValue);
+            }
+
+            return groupingKey;
+        }
+
+        return Collections.emptyMap();
+    }
+}

--- a/shuffle-metrics-reporter/shuffle-metrics-reporter-prometheus/src/main/java/com/alibaba/flink/shuffle/metrics/reporter/PrometheusPushGatewayReporterOptions.java
+++ b/shuffle-metrics-reporter/shuffle-metrics-reporter-prometheus/src/main/java/com/alibaba/flink/shuffle/metrics/reporter/PrometheusPushGatewayReporterOptions.java
@@ -1,0 +1,74 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.flink.shuffle.metrics.reporter;
+
+import com.alibaba.flink.shuffle.common.config.ConfigOption;
+
+import java.time.Duration;
+
+/** Config options for the {@link PrometheusPushGatewayReporter}. */
+public class PrometheusPushGatewayReporterOptions {
+    public static final ConfigOption<String> HOST =
+            new ConfigOption<String>("host")
+                    .defaultValue(null)
+                    .description("Whether the http server for requesting metrics is enabled.");
+
+    public static final ConfigOption<Integer> PORT =
+            new ConfigOption<Integer>("port")
+                    .defaultValue(-1)
+                    .description("The PushGateway server port.");
+
+    public static final ConfigOption<String> JOB_NAME =
+            new ConfigOption<String>("jobName")
+                    .defaultValue("flink-remote-shuffle")
+                    .description("The job name under which metrics will be pushed");
+
+    public static final ConfigOption<Boolean> RANDOM_JOB_NAME_SUFFIX =
+            new ConfigOption<Boolean>("randomJobNameSuffix")
+                    .defaultValue(true)
+                    .description(
+                            "Specifies whether a random suffix should be appended to the job name.");
+
+    public static final ConfigOption<Boolean> DELETE_ON_SHUTDOWN =
+            new ConfigOption<Boolean>("deleteOnShutdown")
+                    .defaultValue(true)
+                    .description(
+                            "Specifies whether to delete metrics from the PushGateway on shutdown."
+                                    + " Flink will try its best to delete the metrics but this is not guaranteed. See %s for more details.");
+
+    public static final ConfigOption<Boolean> FILTER_LABEL_VALUE_CHARACTER =
+            new ConfigOption<Boolean>("filterLabelValueCharacters")
+                    .defaultValue(true)
+                    .description(
+                            "Specifies whether to filter label value characters."
+                                    + " If enabled, all characters not matching [a-zA-Z0-9:_] will be removed,"
+                                    + " otherwise no characters will be removed.");
+
+    public static final ConfigOption<String> GROUPING_KEY =
+            new ConfigOption<String>("groupingKey")
+                    .defaultValue("")
+                    .description(
+                            "Specifies the grouping key which is the group and global labels of all metrics.");
+
+    public static final ConfigOption<Duration> INTERVAL =
+            new ConfigOption<Duration>("interval")
+                    .defaultValue(Duration.ofMinutes(1))
+                    .description(
+                            "The interval between reports. This is used as a suffix in an actual reporter config.");
+}

--- a/shuffle-metrics-reporter/shuffle-metrics-reporter-prometheus/src/main/java/com/alibaba/flink/shuffle/metrics/reporter/PrometheusReporter.java
+++ b/shuffle-metrics-reporter/shuffle-metrics-reporter-prometheus/src/main/java/com/alibaba/flink/shuffle/metrics/reporter/PrometheusReporter.java
@@ -1,0 +1,144 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.flink.shuffle.metrics.reporter;
+
+import com.alibaba.metrics.IMetricManager;
+import com.alibaba.metrics.Metric;
+import com.alibaba.metrics.MetricFilter;
+import com.alibaba.metrics.common.config.MetricsCollectPeriodConfig;
+import com.alibaba.metrics.reporter.MetricManagerReporter;
+import io.prometheus.client.exporter.HTTPServer;
+import org.glassfish.jersey.internal.guava.Preconditions;
+
+import java.io.IOException;
+import java.util.Iterator;
+import java.util.concurrent.TimeUnit;
+
+/** {@link MetricManagerReporter} that exports {@link Metric Metrics} via Prometheus. */
+public class PrometheusReporter extends AbstractPrometheusReporter {
+    private HTTPServer httpServer;
+    private int port;
+    private static final String INIT_FLAG = "com.alibaba.metrics.file_reporter.init_flag";
+    private static final String REPORTER_NAME = "prometheus-reporter";
+
+    int getPort() {
+        Preconditions.checkState(httpServer != null, "Server has not been initialized.");
+        return port;
+    }
+
+    protected PrometheusReporter(
+            Iterator<Integer> ports,
+            IMetricManager metricManager,
+            MetricFilter filter,
+            MetricsCollectPeriodConfig metricsReportPeriodConfig,
+            TimeUnit rateUnit,
+            TimeUnit durationUnit) {
+        super(
+                metricManager,
+                REPORTER_NAME,
+                filter,
+                metricsReportPeriodConfig,
+                rateUnit,
+                durationUnit);
+        while (ports.hasNext()) {
+            port = ports.next();
+            try {
+                // internally accesses CollectorRegistry.defaultRegistry
+                httpServer = new HTTPServer(port);
+                log.info("Started PrometheusReporter HTTP server on port {}.", port);
+                break;
+            } catch (IOException ioe) { // assume port conflict
+                log.debug("Could not start PrometheusReporter HTTP server on port {}.", port, ioe);
+            }
+        }
+
+        if (httpServer == null) {
+            throw new RuntimeException(
+                    "Could not start PrometheusReporter HTTP server on any configured port. Ports: "
+                            + ports);
+        }
+    }
+
+    @Override
+    public void start(long period, TimeUnit unit) {
+        String initFlag = System.getProperty(INIT_FLAG);
+
+        if ("false".equals(initFlag)) {
+            log.info("PrometheusReporter disabled...");
+            return;
+        }
+
+        if (initFlag == null) {
+            System.setProperty(INIT_FLAG, "true");
+            super.start(period, unit);
+        } else {
+            log.info("PrometheusReporter has been started...");
+        }
+    }
+
+    @Override
+    public void close() {
+        if (httpServer != null) {
+            httpServer.stop();
+        }
+        super.close();
+    }
+
+    /** A builder for PrometheusReporter instances. */
+    public static class Builder {
+        private Iterator<Integer> ports;
+        private MetricFilter filter;
+        private IMetricManager metricManager;
+        private MetricsCollectPeriodConfig metricsReportPeriodConfig;
+        private TimeUnit rateUnit;
+        private TimeUnit durationUnit;
+
+        Builder(IMetricManager metricManager) {
+            this.metricManager = metricManager;
+            this.rateUnit = TimeUnit.SECONDS;
+            this.durationUnit = TimeUnit.MILLISECONDS;
+            this.filter = MetricFilter.ALL;
+        }
+
+        public PrometheusReporter.Builder ports(Iterator<Integer> ports) {
+            this.ports = ports;
+            return this;
+        }
+
+        /**
+         * @param metricsReportPeriodConfig
+         * @return
+         */
+        public PrometheusReporter.Builder metricsReportPeriodConfig(
+                MetricsCollectPeriodConfig metricsReportPeriodConfig) {
+            this.metricsReportPeriodConfig = metricsReportPeriodConfig;
+            return this;
+        }
+
+        public PrometheusReporter build() {
+            return new PrometheusReporter(
+                    ports,
+                    metricManager,
+                    filter,
+                    metricsReportPeriodConfig,
+                    rateUnit,
+                    durationUnit);
+        }
+    }
+}

--- a/shuffle-metrics-reporter/shuffle-metrics-reporter-prometheus/src/main/java/com/alibaba/flink/shuffle/metrics/reporter/PrometheusReporterFactory.java
+++ b/shuffle-metrics-reporter/shuffle-metrics-reporter-prometheus/src/main/java/com/alibaba/flink/shuffle/metrics/reporter/PrometheusReporterFactory.java
@@ -1,0 +1,58 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.flink.shuffle.metrics.reporter;
+
+import com.alibaba.flink.shuffle.common.config.Configuration;
+import com.alibaba.flink.shuffle.core.utils.NetUtils;
+
+import com.alibaba.metrics.common.config.MetricsCollectPeriodConfig;
+import com.alibaba.metrics.reporter.MetricManagerReporter;
+
+import java.time.Duration;
+import java.util.Iterator;
+import java.util.Properties;
+import java.util.concurrent.TimeUnit;
+
+import static com.alibaba.flink.shuffle.metrics.reporter.PrometheusPushGatewayReporterOptions.INTERVAL;
+import static com.alibaba.metrics.MetricManager.getIMetricManager;
+
+/** {@link MetricReporterFactory} for {@link PrometheusReporter}. */
+public class PrometheusReporterFactory implements MetricReporterFactory {
+    private static final String ARG_PORT = "port";
+    private static final String DEFAULT_PORT = "9249";
+
+    @Override
+    public MetricManagerReporter createMetricReporter(Properties conf) {
+        Configuration configuration = new Configuration(conf);
+        String portsConfig = configuration.getString(ARG_PORT, DEFAULT_PORT);
+        Iterator<Integer> ports = NetUtils.getPortRangeFromString(portsConfig);
+        Duration interval =
+                configuration.getDuration(
+                        INTERVAL, Duration.ofMinutes(MetricsCollectPeriodConfig.DEFAULT_INTERVAL));
+        PrometheusReporter.Builder builder = new PrometheusReporter.Builder(getIMetricManager());
+        builder.ports(ports);
+        builder.metricsReportPeriodConfig(
+                new MetricsCollectPeriodConfig((int) interval.getSeconds()));
+
+        // start reporter
+        MetricManagerReporter reporter = builder.build();
+        reporter.start(interval.getSeconds(), TimeUnit.SECONDS);
+        return reporter;
+    }
+}

--- a/shuffle-metrics-reporter/shuffle-metrics-reporter-prometheus/src/main/resources/META-INF/NOTICE
+++ b/shuffle-metrics-reporter/shuffle-metrics-reporter-prometheus/src/main/resources/META-INF/NOTICE
@@ -1,0 +1,12 @@
+flink-metrics-prometheus
+Copyright 2014-2021 The Apache Software Foundation
+
+This product includes software developed at
+The Apache Software Foundation (http://www.apache.org/).
+
+This project bundles the following dependencies under the Apache Software License 2.0. (http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+- io.prometheus:simpleclient:0.8.1
+- io.prometheus:simpleclient_common:0.8.1
+- io.prometheus:simpleclient_httpserver:0.8.1
+- io.prometheus:simpleclient_pushgateway:0.8.1

--- a/shuffle-metrics-reporter/shuffle-metrics-reporter-prometheus/src/main/resources/META-INF/services/com.alibaba.flink.shuffle.metrics.reporter.MetricReporterFactory
+++ b/shuffle-metrics-reporter/shuffle-metrics-reporter-prometheus/src/main/resources/META-INF/services/com.alibaba.flink.shuffle.metrics.reporter.MetricReporterFactory
@@ -1,0 +1,17 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+com.alibaba.flink.shuffle.metrics.reporter.PrometheusReporterFactory
+com.alibaba.flink.shuffle.metrics.reporter.PrometheusPushGatewayReporterFactory

--- a/shuffle-metrics-reporter/shuffle-metrics-reporter-prometheus/src/test/java/com/alibaba/flink/shuffle/metrics/reporter/PrometheusPushGatewayReporterTest.java
+++ b/shuffle-metrics-reporter/shuffle-metrics-reporter-prometheus/src/test/java/com/alibaba/flink/shuffle/metrics/reporter/PrometheusPushGatewayReporterTest.java
@@ -1,0 +1,50 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.flink.shuffle.metrics.reporter;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.Map;
+
+/** Test for {@link PrometheusPushGatewayReporter}. */
+public class PrometheusPushGatewayReporterTest extends TestLogger {
+
+    @Test
+    public void testParseGroupingKey() {
+        Map<String, String> groupingKey =
+                PrometheusPushGatewayReporterFactory.parseGroupingKey("k1=v1;k2=v2");
+        Assert.assertNotNull(groupingKey);
+        Assert.assertEquals("v1", groupingKey.get("k1"));
+        Assert.assertEquals("v2", groupingKey.get("k2"));
+    }
+
+    @Test
+    public void testParseIncompleteGroupingKey() {
+        Map<String, String> groupingKey =
+                PrometheusPushGatewayReporterFactory.parseGroupingKey("k1=");
+        Assert.assertTrue(groupingKey.isEmpty());
+
+        groupingKey = PrometheusPushGatewayReporterFactory.parseGroupingKey("=v1");
+        Assert.assertTrue(groupingKey.isEmpty());
+
+        groupingKey = PrometheusPushGatewayReporterFactory.parseGroupingKey("k1");
+        Assert.assertTrue(groupingKey.isEmpty());
+    }
+}

--- a/shuffle-metrics-reporter/shuffle-metrics-reporter-prometheus/src/test/java/com/alibaba/flink/shuffle/metrics/reporter/PrometheusReporterTest.java
+++ b/shuffle-metrics-reporter/shuffle-metrics-reporter-prometheus/src/test/java/com/alibaba/flink/shuffle/metrics/reporter/PrometheusReporterTest.java
@@ -1,0 +1,95 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.flink.shuffle.metrics.reporter;
+
+import com.alibaba.flink.shuffle.common.config.Configuration;
+import com.alibaba.flink.shuffle.metrics.entry.MetricUtils;
+
+import com.alibaba.metrics.ClusterHistogram;
+import com.alibaba.metrics.Compass;
+import com.alibaba.metrics.Counter;
+import com.alibaba.metrics.FastCompass;
+import com.alibaba.metrics.Gauge;
+import com.alibaba.metrics.Histogram;
+import com.alibaba.metrics.IMetricManager;
+import com.alibaba.metrics.Meter;
+import com.alibaba.metrics.Metric;
+import com.alibaba.metrics.MetricFilter;
+import com.alibaba.metrics.MetricName;
+import com.alibaba.metrics.Timer;
+import com.alibaba.metrics.reporter.MetricManagerReporter;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+import java.util.Map;
+import java.util.Properties;
+
+import static com.alibaba.metrics.MetricManager.getIMetricManager;
+
+/** Basic test for {@link PrometheusReporter}. */
+public class PrometheusReporterTest extends TestLogger {
+    private static final PrometheusReporterFactory prometheusReporterFactory =
+            new PrometheusReporterFactory();
+
+    @Rule public ExpectedException thrown = ExpectedException.none();
+    private IMetricManager metricManager;
+
+    private MetricManagerReporter reporter;
+
+    @Before
+    public void setupReporter() {
+        Properties properties = new Properties();
+        Configuration conf = new Configuration(properties);
+        metricManager = getIMetricManager();
+        reporter = prometheusReporterFactory.createMetricReporter(conf.toProperties());
+    }
+
+    @After
+    public void shutdownRegistry() throws Exception {
+        if (reporter != null) {
+            reporter.close();
+        }
+    }
+
+    /**
+     * {@link io.prometheus.client.Counter} may not decrease, so report {@link Counter} as {@link
+     * io.prometheus.client.Gauge}.
+     *
+     * @throws Exception Might be thrown on HTTP problems.
+     */
+    @Test
+    public void counterIsReportedAsPrometheusGauge() throws Exception {
+        Counter testCounter = MetricUtils.getCounter("test", "testCounter");
+        testCounter.inc(7);
+        Map<Class<? extends Metric>, Map<MetricName, ? extends Metric>> categoryMetrics =
+                metricManager.getAllCategoryMetrics(MetricFilter.ALL);
+        reporter.report(
+                (Map<MetricName, Gauge>) categoryMetrics.get(Gauge.class),
+                (Map<MetricName, Counter>) categoryMetrics.get(Counter.class),
+                (Map<MetricName, Histogram>) categoryMetrics.get(Histogram.class),
+                (Map<MetricName, Meter>) categoryMetrics.get(Meter.class),
+                (Map<MetricName, Timer>) categoryMetrics.get(Timer.class),
+                (Map<MetricName, Compass>) categoryMetrics.get(Compass.class),
+                (Map<MetricName, FastCompass>) categoryMetrics.get(FastCompass.class),
+                (Map<MetricName, ClusterHistogram>) categoryMetrics.get(ClusterHistogram.class));
+    }
+}

--- a/shuffle-metrics-reporter/shuffle-metrics-reporter-prometheus/src/test/java/com/alibaba/flink/shuffle/metrics/reporter/TestLogger.java
+++ b/shuffle-metrics-reporter/shuffle-metrics-reporter-prometheus/src/test/java/com/alibaba/flink/shuffle/metrics/reporter/TestLogger.java
@@ -1,0 +1,92 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.flink.shuffle.metrics.reporter;
+
+import org.junit.Rule;
+import org.junit.rules.TestRule;
+import org.junit.rules.TestWatcher;
+import org.junit.runner.Description;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.PrintWriter;
+import java.io.StringWriter;
+
+/**
+ * Adds automatic test name logging. Every test which wants to log which test is currently executed
+ * and why it failed, simply has to extend this class.
+ */
+public class TestLogger {
+    protected final Logger log = LoggerFactory.getLogger(getClass());
+
+    static {
+        TestSignalHandler.register();
+    }
+
+    @Rule
+    public TestRule watchman =
+            new TestWatcher() {
+
+                @Override
+                public void starting(Description description) {
+                    log.info(
+                            "\n================================================================================"
+                                    + "\nTest {} is running."
+                                    + "\n--------------------------------------------------------------------------------",
+                            description);
+                }
+
+                @Override
+                public void succeeded(Description description) {
+                    log.info(
+                            "\n--------------------------------------------------------------------------------"
+                                    + "\nTest {} successfully run."
+                                    + "\n================================================================================",
+                            description);
+                }
+
+                @Override
+                public void failed(Throwable e, Description description) {
+                    log.error(
+                            "\n--------------------------------------------------------------------------------"
+                                    + "\nTest {} failed with:\n{}"
+                                    + "\n================================================================================",
+                            description,
+                            exceptionToString(e));
+                }
+            };
+
+    @Rule public final TestRule nameProvider = new TestNameProvider();
+
+    private static String exceptionToString(Throwable t) {
+        if (t == null) {
+            return "(null)";
+        }
+
+        try {
+            StringWriter stm = new StringWriter();
+            PrintWriter wrt = new PrintWriter(stm);
+            t.printStackTrace(wrt);
+            wrt.close();
+            return stm.toString();
+        } catch (Throwable ignored) {
+            return t.getClass().getName() + " (error while printing stack trace)";
+        }
+    }
+}

--- a/shuffle-metrics-reporter/shuffle-metrics-reporter-prometheus/src/test/java/com/alibaba/flink/shuffle/metrics/reporter/TestNameProvider.java
+++ b/shuffle-metrics-reporter/shuffle-metrics-reporter-prometheus/src/test/java/com/alibaba/flink/shuffle/metrics/reporter/TestNameProvider.java
@@ -1,0 +1,52 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.flink.shuffle.metrics.reporter;
+
+import org.junit.rules.TestRule;
+import org.junit.runner.Description;
+import org.junit.runners.model.Statement;
+
+import javax.annotation.Nullable;
+
+/**
+ * A rule that provides the current test name per thread. Currently, the test name is available for
+ * all tests that extend {@link TestLogger}.
+ */
+public class TestNameProvider implements TestRule {
+    private static ThreadLocal<String> testName = new ThreadLocal<>();
+
+    @Nullable
+    public static String getCurrentTestName() {
+        return testName.get();
+    }
+
+    @Override
+    public Statement apply(Statement base, Description description) {
+        return new Statement() {
+            @Override
+            public void evaluate() throws Throwable {
+                testName.set(description.getDisplayName());
+                try {
+                    base.evaluate();
+                } finally {
+                    testName.set(null);
+                }
+            }
+        };
+    }
+}

--- a/shuffle-metrics-reporter/shuffle-metrics-reporter-prometheus/src/test/java/com/alibaba/flink/shuffle/metrics/reporter/TestSignalHandler.java
+++ b/shuffle-metrics-reporter/shuffle-metrics-reporter-prometheus/src/test/java/com/alibaba/flink/shuffle/metrics/reporter/TestSignalHandler.java
@@ -1,0 +1,83 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.flink.shuffle.metrics.reporter;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import sun.misc.Signal;
+
+/**
+ * This signal handler / signal logger is based on Apache Hadoop's
+ * org.apache.hadoop.util.SignalLogger.
+ *
+ * <p>This is a reduced version of {@link org.apache.flink.runtime.util.SignalHandler}.
+ */
+public class TestSignalHandler {
+
+    private static final Logger LOG = LoggerFactory.getLogger(TestSignalHandler.class);
+
+    private static boolean registered = false;
+
+    /** Our signal handler. */
+    private static class Handler implements sun.misc.SignalHandler {
+
+        private final sun.misc.SignalHandler prevHandler;
+
+        Handler(String name) {
+            prevHandler = Signal.handle(new Signal(name), this);
+        }
+
+        /**
+         * Handle an incoming signal.
+         *
+         * @param signal The incoming signal
+         */
+        @Override
+        public void handle(Signal signal) {
+            LOG.warn(
+                    "RECEIVED SIGNAL {}: SIG{}. Shutting down as requested.",
+                    signal.getNumber(),
+                    signal.getName());
+            prevHandler.handle(signal);
+        }
+    }
+
+    /** Register some signal handlers. */
+    public static void register() {
+        synchronized (TestSignalHandler.class) {
+            if (registered) {
+                return;
+            }
+            registered = true;
+
+            final String[] signals =
+                    System.getProperty("os.name").startsWith("Windows")
+                            ? new String[] {"TERM", "INT"}
+                            : new String[] {"TERM", "HUP", "INT"};
+
+            for (String signalName : signals) {
+                try {
+                    new Handler(signalName);
+                } catch (Exception e) {
+                    LOG.info("Error while registering signal handler", e);
+                }
+            }
+        }
+    }
+}

--- a/shuffle-metrics-reporter/shuffle-metrics-reporter-prometheus/src/test/resources/log4j2-test.properties
+++ b/shuffle-metrics-reporter/shuffle-metrics-reporter-prometheus/src/test/resources/log4j2-test.properties
@@ -1,0 +1,28 @@
+################################################################################
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+# limitations under the License.
+################################################################################
+
+# Set root logger level to OFF to not flood build logs
+# set manually to INFO for debugging purposes
+rootLogger.level = OFF
+rootLogger.appenderRef.test.ref = TestLogger
+
+appender.testlogger.name = TestLogger
+appender.testlogger.type = CONSOLE
+appender.testlogger.target = SYSTEM_ERR
+appender.testlogger.layout.type = PatternLayout
+appender.testlogger.layout.pattern = %-4r [%t] %-5p %c %x - %m%n

--- a/shuffle-metrics/src/main/java/com/alibaba/flink/shuffle/metrics/reporter/ReporterSetup.java
+++ b/shuffle-metrics/src/main/java/com/alibaba/flink/shuffle/metrics/reporter/ReporterSetup.java
@@ -18,35 +18,79 @@
 
 package com.alibaba.flink.shuffle.metrics.reporter;
 
+import com.alibaba.flink.shuffle.common.config.ConfigConstants;
 import com.alibaba.flink.shuffle.common.config.Configuration;
+import com.alibaba.flink.shuffle.common.config.DelegatingConfiguration;
+import com.alibaba.flink.shuffle.core.config.MetricOptions;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Set;
+import java.util.TreeSet;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 import java.util.stream.Collectors;
-import java.util.stream.Stream;
-
-import static com.alibaba.flink.shuffle.core.config.MetricOptions.METRICS_REPORTER_CLASSES;
 
 /** Encapsulates everything needed for the instantiation and configuration of a metric reporter. */
 public final class ReporterSetup {
     private static final Logger LOG = LoggerFactory.getLogger(ReporterSetup.class);
-
+    // regex pattern to split the defined reporters
+    private static final Pattern reporterListPattern = Pattern.compile("\\s*,\\s*");
     private static final String CONFIGURATION_ARGS_DELIMITER = ";";
 
+    // regex pattern to extract the name from reporter configuration keys, e.g. "rep" from
+    // "remote-shuffle.metrics.reporter.rep.class"
+    private static final Pattern reporterClassPattern =
+            Pattern.compile(
+                    Pattern.quote(ConfigConstants.METRICS_REPORTER_PREFIX)
+                            +
+                            // [\S&&[^.]] = intersection of non-whitespace and non-period character
+                            // classes
+                            "([\\S&&[^.]]*)\\."
+                            + '('
+                            + Pattern.quote(ConfigConstants.METRICS_REPORTER_CLASS_SUFFIX)
+                            + '|'
+                            + Pattern.quote(ConfigConstants.METRICS_REPORTER_FACTORY_CLASS_SUFFIX)
+                            + ')');
+
     public static void fromConfiguration(final Configuration conf) {
-        String reportersString = conf.getString(METRICS_REPORTER_CLASSES);
-        if (reportersString == null) {
+        String includedReportersString = conf.getString(MetricOptions.REPORTERS_LIST, "");
+        Set<String> namedReporters =
+                findEnabledReportersInConfiguration(conf, includedReportersString);
+
+        if (namedReporters.isEmpty()) {
             LOG.info("Metric reporter factories are not configured");
             return;
         }
 
-        Set<String> reporterFactories =
-                Stream.of(reportersString.split(CONFIGURATION_ARGS_DELIMITER))
-                        .collect(Collectors.toSet());
-        reporterFactories.forEach(
-                factoryClass -> setupReporterViaReflection(factoryClass.trim(), conf));
+        final Map<String, Configuration> reporterFactories =
+                loadAvailableReporterFactories(namedReporters, conf);
+
+        reporterFactories.forEach(ReporterSetup::setupReporterViaReflection);
+    }
+
+    /**
+     * @param namedReporters
+     * @param conf
+     * @return
+     */
+    private static Map<String, Configuration> loadAvailableReporterFactories(
+            Set<String> namedReporters, Configuration conf) {
+        Map<String, Configuration> availableReporterFactories = new HashMap<>();
+        for (String namedReporter : namedReporters) {
+            DelegatingConfiguration delegatingConfiguration =
+                    new DelegatingConfiguration(
+                            conf, ConfigConstants.METRICS_REPORTER_PREFIX + namedReporter + '.');
+
+            final String reporterClassName =
+                    delegatingConfiguration.getString(
+                            ConfigConstants.METRICS_REPORTER_FACTORY_CLASS_SUFFIX, null);
+            availableReporterFactories.put(reporterClassName, delegatingConfiguration);
+        }
+        return availableReporterFactories;
     }
 
     private static void setupReporterViaReflection(
@@ -66,5 +110,44 @@ public final class ReporterSetup {
                 (MetricReporterFactory) factoryClazz.newInstance();
         metricReporterFactory.createMetricReporter(conf.toProperties());
         LOG.info("Setup metric reporter " + reporterFactory + " successfully");
+    }
+
+    private static Set<String> findEnabledReportersInConfiguration(
+            Configuration configuration, String includedReportersString) {
+        Set<String> includedReporters =
+                reporterListPattern
+                        .splitAsStream(includedReportersString)
+                        .filter(r -> !r.isEmpty()) // splitting an empty string results in
+                        // an empty string on jdk9+
+                        .collect(Collectors.toSet());
+
+        // use a TreeSet to make the reporter order deterministic, which is useful for testing
+        Set<String> namedOrderedReporters = new TreeSet<>(String::compareTo);
+
+        // scan entire configuration for keys starting with METRICS_REPORTER_PREFIX and determine
+        // the set of enabled reporters
+        for (String key : configuration.toMap().keySet()) {
+            if (key.startsWith(ConfigConstants.METRICS_REPORTER_PREFIX)) {
+                Matcher matcher = reporterClassPattern.matcher(key);
+                if (matcher.matches()) {
+                    String reporterName = matcher.group(1);
+                    if (includedReporters.isEmpty() || includedReporters.contains(reporterName)) {
+                        if (namedOrderedReporters.contains(reporterName)) {
+                            LOG.warn(
+                                    "Duplicate class configuration detected for reporter {}.",
+                                    reporterName);
+                        } else {
+                            namedOrderedReporters.add(reporterName);
+                        }
+                    } else {
+                        LOG.info(
+                                "Excluding reporter {}, not configured in reporter list ({}).",
+                                reporterName,
+                                includedReportersString);
+                    }
+                }
+            }
+        }
+        return namedOrderedReporters;
     }
 }

--- a/shuffle-metrics/src/test/java/com/alibaba/flink/shuffle/metrics/reporter/ReporterSetupTest.java
+++ b/shuffle-metrics/src/test/java/com/alibaba/flink/shuffle/metrics/reporter/ReporterSetupTest.java
@@ -18,15 +18,14 @@
 
 package com.alibaba.flink.shuffle.metrics.reporter;
 
+import com.alibaba.flink.shuffle.common.config.ConfigConstants;
 import com.alibaba.flink.shuffle.common.config.Configuration;
 
 import org.junit.Test;
 
 import java.util.Properties;
 
-import static com.alibaba.flink.shuffle.core.config.MetricOptions.METRICS_REPORTER_CLASSES;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
 /** Tests for {@link ReporterSetup}. */
@@ -35,8 +34,12 @@ public class ReporterSetupTest {
     public void testInitReporterFromConfiguration() {
         FakedMetricReporterFactory.resetMethodCallCount();
         Properties properties = new Properties();
+        String name = "fake";
         properties.setProperty(
-                METRICS_REPORTER_CLASSES.key(),
+                ConfigConstants.METRICS_REPORTER_PREFIX
+                        + name
+                        + '.'
+                        + ConfigConstants.METRICS_REPORTER_FACTORY_CLASS_SUFFIX,
                 "com.alibaba.flink.shuffle.metrics.reporter.FakedMetricReporterFactory");
         Configuration conf = new Configuration(properties);
 
@@ -49,10 +52,20 @@ public class ReporterSetupTest {
     public void testMultipleSameReporters() {
         FakedMetricReporterFactory.resetMethodCallCount();
         Properties properties = new Properties();
+        String name1 = "fake1";
+        String name2 = "fake2";
         properties.setProperty(
-                METRICS_REPORTER_CLASSES.key(),
-                "com.alibaba.flink.shuffle.metrics.reporter.FakedMetricReporterFactory;"
-                        + "com.alibaba.flink.shuffle.metrics.reporter.FakedMetricReporterFactory");
+                ConfigConstants.METRICS_REPORTER_PREFIX
+                        + name1
+                        + '.'
+                        + ConfigConstants.METRICS_REPORTER_FACTORY_CLASS_SUFFIX,
+                "com.alibaba.flink.shuffle.metrics.reporter.FakedMetricReporterFactory");
+        properties.setProperty(
+                ConfigConstants.METRICS_REPORTER_PREFIX
+                        + name2
+                        + '.'
+                        + ConfigConstants.METRICS_REPORTER_FACTORY_CLASS_SUFFIX,
+                "com.alibaba.flink.shuffle.metrics.reporter.FakedMetricReporterFactory");
         Configuration conf = new Configuration(properties);
 
         assertEquals(0, FakedMetricReporterFactory.getMethodCallCount());
@@ -64,10 +77,21 @@ public class ReporterSetupTest {
     public void testMultipleDifferentReporters() {
         FakedMetricReporterFactory.resetMethodCallCount();
         Properties properties = new Properties();
+        String name1 = "fake1";
+        String name2 = "anotherFaked";
         properties.setProperty(
-                METRICS_REPORTER_CLASSES.key(),
-                "com.alibaba.flink.shuffle.metrics.reporter.FakedMetricReporterFactory;"
-                        + "com.alibaba.flink.shuffle.metrics.reporter.AnotherFakedReporterFactory");
+                ConfigConstants.METRICS_REPORTER_PREFIX
+                        + name1
+                        + '.'
+                        + ConfigConstants.METRICS_REPORTER_FACTORY_CLASS_SUFFIX,
+                "com.alibaba.flink.shuffle.metrics.reporter.FakedMetricReporterFactory");
+        properties.setProperty(
+                ConfigConstants.METRICS_REPORTER_PREFIX
+                        + name2
+                        + '.'
+                        + ConfigConstants.METRICS_REPORTER_FACTORY_CLASS_SUFFIX,
+                "com.alibaba.flink.shuffle.metrics.reporter.AnotherFakedReporterFactory");
+
         Configuration conf = new Configuration(properties);
 
         assertEquals(0, FakedMetricReporterFactory.getMethodCallCount());
@@ -86,14 +110,19 @@ public class ReporterSetupTest {
         assertTrue(
                 FakedMetricReporterFactory.getConf() == null
                         || FakedMetricReporterFactory.getConf().getString("my.k1") == null);
-        final String reporterKey = METRICS_REPORTER_CLASSES.key();
-        final String reporterVal =
-                "com.alibaba.flink.shuffle.metrics.reporter.FakedMetricReporterFactory";
-
         Properties properties = new Properties();
-        properties.setProperty("my.k1", "v1");
-        properties.setProperty("my.k2", "v2");
-        properties.setProperty(reporterKey, reporterVal);
+        String name = "fake";
+        properties.setProperty(
+                ConfigConstants.METRICS_REPORTER_PREFIX
+                        + name
+                        + '.'
+                        + ConfigConstants.METRICS_REPORTER_FACTORY_CLASS_SUFFIX,
+                "com.alibaba.flink.shuffle.metrics.reporter.FakedMetricReporterFactory");
+
+        properties.setProperty(
+                ConfigConstants.METRICS_REPORTER_PREFIX + name + '.' + "my.k1", "v1");
+        properties.setProperty(
+                ConfigConstants.METRICS_REPORTER_PREFIX + name + '.' + "my.k2", "v2");
         Configuration conf = new Configuration(properties);
         ReporterSetup.fromConfiguration(conf);
 
@@ -101,7 +130,5 @@ public class ReporterSetupTest {
         Configuration config = FakedMetricReporterFactory.getConf();
         assertTrue(config.getString("my.k1").equals("v1"));
         assertTrue(config.getString("my.k2").equals("v2"));
-        assertFalse(config.getString("my.k1").equals("v2"));
-        assertTrue(config.getString(reporterKey).equals(reporterVal));
     }
 }


### PR DESCRIPTION
## What is the purpose of the change
Support reporting metrics to prometheus.(use PrometheusReporter or use PrometheusPushGatewayReporter)

## Instructions for use
Put the following configuration into the global configuration.
- remote-shuffle.metrics.reporter.promgateway.factory.class: com.alibaba.flink.shuffle.metrics.reporter.PrometheusPushGatewayReporterFactory
- remote-shuffle.metrics.reporter.promgateway.host: xxxxxx
- remote-shuffle.metrics.reporter.promgateway.port: 9091
- remote-shuffle.metrics.reporter.promgateway.jobName: flink-remote-shuffle
- remote-shuffle.metrics.reporter.promgateway.randomJobNameSuffix: true
- remote-shuffle.metrics.reporter.promgateway.deleteOnShutdown: false
- remote-shuffle.metrics.reporter.promgateway.interval: 60 SECONDS


