### PR TITLE
[FRS-22] Upgrade Log4j2 to 2.17.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -37,14 +37,13 @@ under the License.
 	<properties>
 		<scala.binary.version>2.11</scala.binary.version>
 		<flink.shaded.version>13.0</flink.shaded.version>
-		<log4j.version>2.12.1</log4j.version>
+		<log4j.version>2.17.0</log4j.version>
 		<junit.version>4.13</junit.version>
 		<mockito.version>2.21.0</mockito.version>
 		<hamcrest.version>1.3</hamcrest.version>
 		<javax.annotation-api.version>1.3.2</javax.annotation-api.version>
 		<java.guava.version>11.0.2</java.guava.version>
 		<slf4j.version>1.7.15</slf4j.version>
-		<log4j.version>2.12.1</log4j.version>
 		<spotless.version>2.4.2</spotless.version>
 		<target.java.version>1.8</target.java.version>
 		<maven.compiler.source>${target.java.version}</maven.compiler.source>


### PR DESCRIPTION
<!--

*Thank you very much for contributing to remote-shuffle-service-for-flink. To help the community review your issue or contribution in the best possible way，please take a few minutes to fulfill following items.*

-->

## What is the purpose of the change

This PR solves #22 . Upgrade Log4j2 to 2.15.0 because of the log4j2 vulnerability. https://nvd.nist.gov/vuln/detail/CVE-2021-44228.


## Brief change log

  - *Upgrade Log4j2 to 2.15.0*


## Verifying this change

This change is already covered by existing tests.
