### PR TITLE
[FRS-24] Improve worker load balance

### DIFF
--- a/shuffle-common/src/main/java/com/alibaba/flink/shuffle/common/utils/ExceptionUtils.java
+++ b/shuffle-common/src/main/java/com/alibaba/flink/shuffle/common/utils/ExceptionUtils.java
@@ -23,6 +23,7 @@ import javax.annotation.Nullable;
 import java.io.PrintWriter;
 import java.io.StringWriter;
 import java.util.Optional;
+import java.util.function.Predicate;
 
 /** Utility for manipulating exceptions. */
 public class ExceptionUtils {
@@ -124,6 +125,33 @@ public class ExceptionUtils {
                 cause = cause.getCause();
             }
         }
+        return Optional.empty();
+    }
+
+    /**
+     * Checks whether a throwable chain contains an exception matching a predicate and returns it.
+     *
+     * <p>This method is copied from Apache Flink (org.apache.flink.util.ExceptionUtils).
+     *
+     * @param throwable the throwable chain to check.
+     * @param predicate the predicate of the exception to search for in the chain.
+     * @return Optional throwable of the requested type if available, otherwise empty.
+     */
+    public static Optional<Throwable> findThrowable(
+            Throwable throwable, Predicate<Throwable> predicate) {
+        if (throwable == null || predicate == null) {
+            return Optional.empty();
+        }
+
+        Throwable t = throwable;
+        while (t != null) {
+            if (predicate.test(t)) {
+                return Optional.of(t);
+            } else {
+                t = t.getCause();
+            }
+        }
+
         return Optional.empty();
     }
 

--- a/shuffle-coordinator/src/main/java/com/alibaba/flink/shuffle/coordinator/manager/ShuffleManager.java
+++ b/shuffle-coordinator/src/main/java/com/alibaba/flink/shuffle/coordinator/manager/ShuffleManager.java
@@ -824,6 +824,11 @@ public class ShuffleManager extends RemoteShuffleFencedRpcEndpoint<UUID>
                         instanceID,
                         shuffleWorkerRegistrationInstance.getShuffleWorkerRegisterId(),
                         payload.getDataPartitionStatuses());
+                assignmentTracker.reportWorkerStorageSpaces(
+                        instanceID,
+                        shuffleWorkers.get(instanceID).getShuffleWorkerRegisterId(),
+                        payload.getNumHddUsableBytes(),
+                        payload.getNumSsdUsableBytes());
             } else {
                 LOG.warn(
                         "The shuffle worker with id {} is not registered before but receive the heartbeat.",

--- a/shuffle-coordinator/src/main/java/com/alibaba/flink/shuffle/coordinator/manager/WorkerToManagerHeartbeatPayload.java
+++ b/shuffle-coordinator/src/main/java/com/alibaba/flink/shuffle/coordinator/manager/WorkerToManagerHeartbeatPayload.java
@@ -28,11 +28,28 @@ public class WorkerToManagerHeartbeatPayload implements Serializable {
 
     private final List<DataPartitionStatus> dataPartitionStatuses;
 
-    public WorkerToManagerHeartbeatPayload(List<DataPartitionStatus> dataPartitionStatuses) {
+    private final long numHddUsableBytes;
+
+    private final long numSsdUsableBytes;
+
+    public WorkerToManagerHeartbeatPayload(
+            List<DataPartitionStatus> dataPartitionStatuses,
+            long numHddUsableBytes,
+            long numSsdUsableBytes) {
         this.dataPartitionStatuses = dataPartitionStatuses;
+        this.numHddUsableBytes = numHddUsableBytes;
+        this.numSsdUsableBytes = numSsdUsableBytes;
     }
 
     public List<DataPartitionStatus> getDataPartitionStatuses() {
         return dataPartitionStatuses;
+    }
+
+    public long getNumHddUsableBytes() {
+        return numHddUsableBytes;
+    }
+
+    public long getNumSsdUsableBytes() {
+        return numSsdUsableBytes;
     }
 }

--- a/shuffle-coordinator/src/main/java/com/alibaba/flink/shuffle/coordinator/manager/assignmenttracker/AssignmentTracker.java
+++ b/shuffle-coordinator/src/main/java/com/alibaba/flink/shuffle/coordinator/manager/assignmenttracker/AssignmentTracker.java
@@ -174,4 +174,10 @@ public interface AssignmentTracker {
      * @return The data partition distribution.
      */
     Map<DataPartitionCoordinate, InstanceID> getDataPartitionDistribution(JobID jobID);
+
+    void reportWorkerStorageSpaces(
+            InstanceID instanceID,
+            RegistrationID shuffleWorkerRegisterId,
+            long numHddUsableBytes,
+            long numSsdUsableBytes);
 }

--- a/shuffle-coordinator/src/main/java/com/alibaba/flink/shuffle/coordinator/manager/assignmenttracker/BasePartitionPlacementStrategy.java
+++ b/shuffle-coordinator/src/main/java/com/alibaba/flink/shuffle/coordinator/manager/assignmenttracker/BasePartitionPlacementStrategy.java
@@ -1,0 +1,32 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.flink.shuffle.coordinator.manager.assignmenttracker;
+
+/** An abstract class to implement the common methods of {@link PartitionPlacementStrategy}. */
+public abstract class BasePartitionPlacementStrategy implements PartitionPlacementStrategy {
+    protected final long reservedSpaceBytes;
+
+    BasePartitionPlacementStrategy(long reservedSpaceBytes) {
+        this.reservedSpaceBytes = reservedSpaceBytes;
+    }
+
+    boolean isUsableSpaceEnoughOrNotInit(long usableSpaceBytes) {
+        return usableSpaceBytes >= reservedSpaceBytes || usableSpaceBytes < 0;
+    }
+}

--- a/shuffle-coordinator/src/main/java/com/alibaba/flink/shuffle/coordinator/manager/assignmenttracker/MinNumberPlacementStrategy.java
+++ b/shuffle-coordinator/src/main/java/com/alibaba/flink/shuffle/coordinator/manager/assignmenttracker/MinNumberPlacementStrategy.java
@@ -1,0 +1,64 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.flink.shuffle.coordinator.manager.assignmenttracker;
+
+import com.alibaba.flink.shuffle.core.ids.RegistrationID;
+
+import java.util.Map;
+
+import static com.alibaba.flink.shuffle.coordinator.manager.assignmenttracker.PlacementUtils.singleElementWorkerArray;
+import static com.alibaba.flink.shuffle.coordinator.manager.assignmenttracker.PlacementUtils.throwNoAvailableWorkerException;
+
+/**
+ * This strategy will select the next worker with two conditions. The first is that the number of
+ * data partitions stored by the worker is the smallest. The second is that the available storage
+ * space of the worker is greater than the minimum configurable value.
+ */
+class MinNumberPlacementStrategy extends BasePartitionPlacementStrategy {
+
+    MinNumberPlacementStrategy(long reservedSpaceBytes) {
+        super(reservedSpaceBytes);
+    }
+
+    @Override
+    public WorkerStatus[] selectNextWorker(
+            Map<RegistrationID, WorkerStatus> workers,
+            PartitionPlacementContext partitionPlacementContext)
+            throws ShuffleResourceAllocationException {
+        WorkerStatus selectedWorker = null;
+        for (WorkerStatus workerStatus : workers.values()) {
+            long usableSpaceBytes =
+                    PlacementUtils.getUsableSpaceBytes(
+                            partitionPlacementContext.getDataPartitionFactoryName(), workerStatus);
+            if (isUsableSpaceEnoughOrNotInit(usableSpaceBytes)) {
+                if (selectedWorker == null
+                        || workerStatus.getDataPartitions().size()
+                                < selectedWorker.getDataPartitions().size()) {
+                    selectedWorker = workerStatus;
+                }
+            }
+        }
+
+        if (selectedWorker == null) {
+            throwNoAvailableWorkerException(workers.size());
+        }
+
+        return singleElementWorkerArray(selectedWorker);
+    }
+}

--- a/shuffle-coordinator/src/main/java/com/alibaba/flink/shuffle/coordinator/manager/assignmenttracker/PartitionPlacementContext.java
+++ b/shuffle-coordinator/src/main/java/com/alibaba/flink/shuffle/coordinator/manager/assignmenttracker/PartitionPlacementContext.java
@@ -1,0 +1,36 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.flink.shuffle.coordinator.manager.assignmenttracker;
+
+/**
+ * A context class which is used when choose the next worker to store a new data partition. This is
+ * a runtime context, while the other variables are placed in the fields of each different strategy.
+ */
+public class PartitionPlacementContext {
+
+    private final String dataPartitionFactoryName;
+
+    PartitionPlacementContext(String dataPartitionFactoryName) {
+        this.dataPartitionFactoryName = dataPartitionFactoryName;
+    }
+
+    String getDataPartitionFactoryName() {
+        return dataPartitionFactoryName;
+    }
+}

--- a/shuffle-coordinator/src/main/java/com/alibaba/flink/shuffle/coordinator/manager/assignmenttracker/PartitionPlacementStrategy.java
+++ b/shuffle-coordinator/src/main/java/com/alibaba/flink/shuffle/coordinator/manager/assignmenttracker/PartitionPlacementStrategy.java
@@ -1,0 +1,31 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.flink.shuffle.coordinator.manager.assignmenttracker;
+
+import com.alibaba.flink.shuffle.core.ids.RegistrationID;
+
+import java.util.Map;
+
+/** Worker selection strategy for storing the next data partition. */
+interface PartitionPlacementStrategy {
+    WorkerStatus[] selectNextWorker(
+            Map<RegistrationID, WorkerStatus> workers,
+            PartitionPlacementContext partitionPlacementContext)
+            throws ShuffleResourceAllocationException;
+}

--- a/shuffle-coordinator/src/main/java/com/alibaba/flink/shuffle/coordinator/manager/assignmenttracker/PartitionPlacementStrategyLoader.java
+++ b/shuffle-coordinator/src/main/java/com/alibaba/flink/shuffle/coordinator/manager/assignmenttracker/PartitionPlacementStrategyLoader.java
@@ -1,0 +1,73 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.flink.shuffle.coordinator.manager.assignmenttracker;
+
+import com.alibaba.flink.shuffle.common.config.Configuration;
+import com.alibaba.flink.shuffle.core.config.ManagerOptions;
+import com.alibaba.flink.shuffle.core.config.StorageOptions;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import static com.alibaba.flink.shuffle.common.utils.CommonUtils.checkNotNull;
+
+/** A utility class to load partition placement strategy factories from the configuration. */
+public final class PartitionPlacementStrategyLoader {
+
+    private static final Logger LOG =
+            LoggerFactory.getLogger(PartitionPlacementStrategyLoader.class);
+
+    /** Config name for the {@link MinNumberPlacementStrategy}. */
+    public static final String MIN_NUM_PLACEMENT_STRATEGY_NAME = "min-num";
+
+    /** Config name for the {@link RandomPlacementStrategy}. */
+    public static final String RANDOM_PLACEMENT_STRATEGY_NAME = "random";
+
+    /** Config name for the {@link RoundRobinPlacementStrategy}. */
+    public static final String ROUND_ROBIN_PLACEMENT_STRATEGY_NAME = "round-robin";
+
+    private PartitionPlacementStrategyLoader() {}
+
+    /**
+     * Loads a {@link PartitionPlacementStrategy} from the given configuration.
+     *
+     * @param configuration which specifies the placement strategy factory to load
+     * @return data partition placement strategy factory loaded
+     */
+    public static PartitionPlacementStrategy loadPlacementStrategyFactory(
+            final Configuration configuration) {
+        checkNotNull(configuration);
+        long reservedSpaceBytes =
+                configuration.getMemorySize(StorageOptions.STORAGE_RESERVED_SPACE_BYTES).getBytes();
+        String strategyParam = configuration.getString(ManagerOptions.PARTITION_PLACEMENT_STRATEGY);
+        LOG.info("Using the data partition placement strategy: " + strategyParam);
+
+        switch (strategyParam.toLowerCase()) {
+            case MIN_NUM_PLACEMENT_STRATEGY_NAME:
+                return new MinNumberPlacementStrategy(reservedSpaceBytes);
+            case RANDOM_PLACEMENT_STRATEGY_NAME:
+                return new RandomPlacementStrategy(reservedSpaceBytes);
+            case ROUND_ROBIN_PLACEMENT_STRATEGY_NAME:
+                return new RoundRobinPlacementStrategy(reservedSpaceBytes);
+            default:
+                throw new IllegalArgumentException(
+                        "Unknown partition placement strategy: " + strategyParam);
+        }
+    }
+}

--- a/shuffle-coordinator/src/main/java/com/alibaba/flink/shuffle/coordinator/manager/assignmenttracker/PlacementUtils.java
+++ b/shuffle-coordinator/src/main/java/com/alibaba/flink/shuffle/coordinator/manager/assignmenttracker/PlacementUtils.java
@@ -1,0 +1,80 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.flink.shuffle.coordinator.manager.assignmenttracker;
+
+import com.alibaba.flink.shuffle.storage.partition.HDDOnlyLocalFileMapPartitionFactory;
+import com.alibaba.flink.shuffle.storage.partition.LocalFileMapPartitionFactory;
+import com.alibaba.flink.shuffle.storage.partition.SSDOnlyLocalFileMapPartitionFactory;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import static com.alibaba.flink.shuffle.common.utils.CommonUtils.checkState;
+import static com.alibaba.flink.shuffle.core.config.StorageOptions.STORAGE_RESERVED_SPACE_BYTES;
+
+/** Utility methods to manipulate {@link PartitionPlacementStrategy}s. */
+public class PlacementUtils {
+
+    private static final Logger LOG = LoggerFactory.getLogger(PlacementUtils.class);
+
+    static long getUsableSpaceBytes(String partitionFactoryName, WorkerStatus workerStatus) {
+        checkState(partitionFactoryName != null, "Empty data partition factory name");
+
+        long hddUsableBytes = workerStatus.getNumHddUsableSpaceBytes();
+        long ssdUsableBytes = workerStatus.getNumSsdUsableSpaceBytes();
+        long usableSpaceBytes = -1;
+
+        if (partitionFactoryName.equals(LocalFileMapPartitionFactory.class.getName())) {
+            usableSpaceBytes = Math.max(hddUsableBytes, ssdUsableBytes);
+        } else if (partitionFactoryName.equals(
+                HDDOnlyLocalFileMapPartitionFactory.class.getName())) {
+            usableSpaceBytes = hddUsableBytes;
+        } else if (partitionFactoryName.equals(
+                SSDOnlyLocalFileMapPartitionFactory.class.getName())) {
+            usableSpaceBytes = ssdUsableBytes;
+        }
+        if (usableSpaceBytes < 0) {
+            LOG.warn(
+                    "The available storage space of the worker may not be reported yet. "
+                            + "The minimum available space limit is ignored.");
+        }
+        return usableSpaceBytes;
+    }
+
+    static void throwNoAvailableWorkerException(int numWorkers)
+            throws ShuffleResourceAllocationException {
+        if (numWorkers > 0) {
+            throw new ShuffleResourceAllocationException(
+                    "No available workers. This may not indicate that there is no normal worker node,"
+                            + " because maybe all workers have been filtered out."
+                            + " You can decrease the value of the configuration "
+                            + STORAGE_RESERVED_SPACE_BYTES.key()
+                            + " ("
+                            + STORAGE_RESERVED_SPACE_BYTES.defaultValue().toHumanReadableString()
+                            + " by default) to allow workers with smaller storage space to be used"
+                            + " for writing data.");
+        } else {
+            throw new ShuffleResourceAllocationException("No available workers");
+        }
+    }
+
+    static WorkerStatus[] singleElementWorkerArray(WorkerStatus workerStatus) {
+        return new WorkerStatus[] {workerStatus};
+    }
+}

--- a/shuffle-coordinator/src/main/java/com/alibaba/flink/shuffle/coordinator/manager/assignmenttracker/RandomPlacementStrategy.java
+++ b/shuffle-coordinator/src/main/java/com/alibaba/flink/shuffle/coordinator/manager/assignmenttracker/RandomPlacementStrategy.java
@@ -1,0 +1,100 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.flink.shuffle.coordinator.manager.assignmenttracker;
+
+import com.alibaba.flink.shuffle.core.ids.RegistrationID;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Random;
+
+import static com.alibaba.flink.shuffle.coordinator.manager.assignmenttracker.PlacementUtils.singleElementWorkerArray;
+import static com.alibaba.flink.shuffle.coordinator.manager.assignmenttracker.PlacementUtils.throwNoAvailableWorkerException;
+
+/**
+ * This strategy selects the next worker in random order. The available storage space of the worker
+ * should be greater than the minimum configurable value.
+ */
+class RandomPlacementStrategy extends BasePartitionPlacementStrategy {
+    private static final Random RANDOM_ORDER = new Random();
+
+    RandomPlacementStrategy(long reservedSpaceBytes) {
+        super(reservedSpaceBytes);
+    }
+
+    @Override
+    public WorkerStatus[] selectNextWorker(
+            Map<RegistrationID, WorkerStatus> workers,
+            PartitionPlacementContext partitionPlacementContext)
+            throws ShuffleResourceAllocationException {
+
+        WorkerStatus selectedWorker = selectNextRandomWorker(workers, partitionPlacementContext);
+        return singleElementWorkerArray(selectedWorker);
+    }
+
+    private WorkerStatus selectNextRandomWorker(
+            Map<RegistrationID, WorkerStatus> workers,
+            PartitionPlacementContext partitionPlacementContext)
+            throws ShuffleResourceAllocationException {
+        WorkerStatus selectedWorker = randomlySelectOneWorker(workers, partitionPlacementContext);
+
+        if (selectedWorker == null) {
+            throwNoAvailableWorkerException(workers.size());
+        }
+
+        return selectedWorker;
+    }
+
+    private WorkerStatus randomlySelectOneWorker(
+            Map<RegistrationID, WorkerStatus> workers,
+            PartitionPlacementContext partitionPlacementContext) {
+        if (workers.isEmpty()) {
+            return null;
+        }
+
+        WorkerStatus selectedWorker = null;
+        List<RegistrationID> workerIDs = new ArrayList<>(workers.keySet());
+        for (int startIndex = 0; startIndex < workerIDs.size(); startIndex++) {
+            int selectedIndex = RANDOM_ORDER.nextInt(workerIDs.size() - startIndex) + startIndex;
+            RegistrationID registrationID = workerIDs.get(selectedIndex);
+            WorkerStatus currentWorker = workers.get(registrationID);
+            long usableSpaceBytes =
+                    PlacementUtils.getUsableSpaceBytes(
+                            partitionPlacementContext.getDataPartitionFactoryName(), currentWorker);
+            if (isUsableSpaceEnoughOrNotInit(usableSpaceBytes)) {
+                selectedWorker = currentWorker;
+                break;
+            }
+            swapRegistrationID(workerIDs, startIndex, selectedIndex);
+        }
+        return selectedWorker;
+    }
+
+    private static void swapRegistrationID(
+            List<RegistrationID> workerIDs, int startIndex, int selectedIndex) {
+        if (startIndex == selectedIndex) {
+            return;
+        }
+        RegistrationID currentRegistrationID = workerIDs.get(selectedIndex);
+        RegistrationID startRegistrationID = workerIDs.get(startIndex);
+        workerIDs.set(startIndex, currentRegistrationID);
+        workerIDs.set(selectedIndex, startRegistrationID);
+    }
+}

--- a/shuffle-coordinator/src/main/java/com/alibaba/flink/shuffle/coordinator/manager/assignmenttracker/RoundRobinPlacementStrategy.java
+++ b/shuffle-coordinator/src/main/java/com/alibaba/flink/shuffle/coordinator/manager/assignmenttracker/RoundRobinPlacementStrategy.java
@@ -1,0 +1,108 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.flink.shuffle.coordinator.manager.assignmenttracker;
+
+import com.alibaba.flink.shuffle.core.ids.RegistrationID;
+
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+
+import static com.alibaba.flink.shuffle.coordinator.manager.assignmenttracker.PlacementUtils.singleElementWorkerArray;
+import static com.alibaba.flink.shuffle.coordinator.manager.assignmenttracker.PlacementUtils.throwNoAvailableWorkerException;
+
+/**
+ * This strategy selects the next worker in round robin order. The available storage space of the
+ * worker should be greater than the minimum configurable value.
+ */
+class RoundRobinPlacementStrategy extends BasePartitionPlacementStrategy {
+    private final Map<RegistrationID, Long> selectWorkerCount;
+
+    private long selectCounter;
+
+    RoundRobinPlacementStrategy(long reservedSpaceBytes) {
+        super(reservedSpaceBytes);
+        this.selectWorkerCount = new HashMap<>();
+        this.selectCounter = 0;
+    }
+
+    @Override
+    public WorkerStatus[] selectNextWorker(
+            Map<RegistrationID, WorkerStatus> workers,
+            PartitionPlacementContext partitionPlacementContext)
+            throws ShuffleResourceAllocationException {
+        WorkerStatus selectedWorker = roundRobinSelectWorker(workers, partitionPlacementContext);
+
+        if (selectedWorker == null) {
+            throwNoAvailableWorkerException(workers.size());
+        }
+
+        return singleElementWorkerArray(selectedWorker);
+    }
+
+    private WorkerStatus roundRobinSelectWorker(
+            Map<RegistrationID, WorkerStatus> workers,
+            PartitionPlacementContext partitionPlacementContext) {
+        WorkerStatus selectedWorker = null;
+
+        RegistrationID chosenWorkerID = null;
+        long numSelectCount = Long.MAX_VALUE;
+        for (Map.Entry<RegistrationID, WorkerStatus> workerEntry : workers.entrySet()) {
+            RegistrationID registrationID = workerEntry.getKey();
+            WorkerStatus currentWorker = workerEntry.getValue();
+            if (!selectWorkerCount.containsKey(registrationID)) {
+                selectWorkerCount.put(registrationID, 0L);
+            }
+
+            long usableSpaceBytes =
+                    PlacementUtils.getUsableSpaceBytes(
+                            partitionPlacementContext.getDataPartitionFactoryName(),
+                            workers.get(registrationID));
+
+            if (selectWorkerCount.get(registrationID) < numSelectCount
+                    && isUsableSpaceEnoughOrNotInit(usableSpaceBytes)) {
+                chosenWorkerID = registrationID;
+                numSelectCount = selectWorkerCount.get(registrationID);
+                selectedWorker = currentWorker;
+                if (selectWorkerCount.get(registrationID) == 0) {
+                    break;
+                }
+            }
+        }
+
+        if (selectedWorker != null) {
+            selectCounter++;
+            selectWorkerCount.put(chosenWorkerID, selectCounter);
+        }
+
+        removeNonExistWorker(workers);
+        return selectedWorker;
+    }
+
+    private void removeNonExistWorker(Map<RegistrationID, WorkerStatus> workers) {
+        Set<RegistrationID> toRemoveWorkerIDs = new HashSet<>();
+        for (RegistrationID registrationID : selectWorkerCount.keySet()) {
+            if (!workers.containsKey(registrationID)) {
+                toRemoveWorkerIDs.add(registrationID);
+            }
+        }
+        toRemoveWorkerIDs.forEach(selectWorkerCount::remove);
+    }
+}

--- a/shuffle-coordinator/src/main/java/com/alibaba/flink/shuffle/coordinator/manager/assignmenttracker/WorkerStatus.java
+++ b/shuffle-coordinator/src/main/java/com/alibaba/flink/shuffle/coordinator/manager/assignmenttracker/WorkerStatus.java
@@ -45,6 +45,10 @@ class WorkerStatus {
 
     private final int dataPort;
 
+    private long numHddUsableSpaceBytes;
+
+    private long numSsdUsableSpaceBytes;
+
     private final Map<DataPartitionCoordinate, DataPartitionStatus> dataPartitions =
             new HashMap<>();
 
@@ -62,12 +66,28 @@ class WorkerStatus {
         this.dataPort = dataPort;
     }
 
+    void setNumHddUsableSpaceBytes(long numHddUsableSpaceBytes) {
+        this.numHddUsableSpaceBytes = numHddUsableSpaceBytes;
+    }
+
+    void setNumSsdUsableSpaceBytes(long numSsdUsableSpaceBytes) {
+        this.numSsdUsableSpaceBytes = numSsdUsableSpaceBytes;
+    }
+
     public InstanceID getWorkerID() {
         return workerID;
     }
 
     public RegistrationID getRegistrationID() {
         return registrationID;
+    }
+
+    public long getNumHddUsableSpaceBytes() {
+        return numHddUsableSpaceBytes;
+    }
+
+    public long getNumSsdUsableSpaceBytes() {
+        return numSsdUsableSpaceBytes;
     }
 
     public ShuffleWorkerDescriptor createShuffleWorkerDescriptor() {
@@ -113,6 +133,10 @@ class WorkerStatus {
                 + '\''
                 + ", dataPort="
                 + dataPort
+                + ", numHddUsableSpaceBytes="
+                + numHddUsableSpaceBytes
+                + ", numSsdUsableSpaceBytes="
+                + numSsdUsableSpaceBytes
                 + '}';
     }
 }

--- a/shuffle-coordinator/src/main/java/com/alibaba/flink/shuffle/coordinator/manager/entrypoint/ShuffleManagerEntrypoint.java
+++ b/shuffle-coordinator/src/main/java/com/alibaba/flink/shuffle/coordinator/manager/entrypoint/ShuffleManagerEntrypoint.java
@@ -130,7 +130,7 @@ public class ShuffleManagerEntrypoint implements AutoCloseableAsync, FatalErrorH
                         ioExecutor,
                         jobHeartbeatServices,
                         workerHeartbeatServices,
-                        new AssignmentTrackerImpl());
+                        new AssignmentTrackerImpl(configuration));
     }
 
     public Configuration getConfiguration() {

--- a/shuffle-coordinator/src/main/java/com/alibaba/flink/shuffle/coordinator/utils/WorkerCheckerUtils.java
+++ b/shuffle-coordinator/src/main/java/com/alibaba/flink/shuffle/coordinator/utils/WorkerCheckerUtils.java
@@ -1,0 +1,44 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.flink.shuffle.coordinator.utils;
+
+import com.alibaba.flink.shuffle.coordinator.worker.checker.ShuffleWorkerChecker;
+
+/** Utility methods to manipulate {@link ShuffleWorkerChecker}s. */
+public class WorkerCheckerUtils {
+    private static final long Kb = 1024;
+    private static final long Mb = Kb * 1024;
+    private static final long Gb = Mb * 1024;
+    private static final long Tb = Gb * 1024;
+    private static final long Pb = Tb * 1024;
+    private static final long Eb = Pb * 1024;
+
+    protected static final String[] BYTES_UNITS = new String[] {"", "K", "M", "G", "T", "P", "E"};
+
+    protected static final long[] BYTES_STEPS = new long[] {0, Kb, Mb, Gb, Tb, Pb, Eb};
+
+    public static String bytesToHumanReadable(long bytes) {
+        for (int i = BYTES_UNITS.length - 1; i > 0; i--) {
+            if (bytes > BYTES_STEPS[i]) {
+                return String.format("%3.2f %s", (double) bytes / BYTES_STEPS[i], BYTES_UNITS[i]);
+            }
+        }
+        return Long.toString(bytes);
+    }
+}

--- a/shuffle-coordinator/src/main/java/com/alibaba/flink/shuffle/coordinator/worker/ShuffleWorkerRunner.java
+++ b/shuffle-coordinator/src/main/java/com/alibaba/flink/shuffle/coordinator/worker/ShuffleWorkerRunner.java
@@ -36,6 +36,8 @@ import com.alibaba.flink.shuffle.coordinator.metrics.MetricsRestHandler;
 import com.alibaba.flink.shuffle.coordinator.utils.ClusterEntrypointUtils;
 import com.alibaba.flink.shuffle.coordinator.utils.EnvironmentInformation;
 import com.alibaba.flink.shuffle.coordinator.utils.LeaderRetrievalUtils;
+import com.alibaba.flink.shuffle.coordinator.worker.checker.ShuffleWorkerChecker;
+import com.alibaba.flink.shuffle.coordinator.worker.checker.ShuffleWorkerCheckerImpl;
 import com.alibaba.flink.shuffle.coordinator.worker.metastore.LocalShuffleMetaStore;
 import com.alibaba.flink.shuffle.core.config.StorageOptions;
 import com.alibaba.flink.shuffle.core.config.WorkerOptions;
@@ -272,6 +274,9 @@ public class ShuffleWorkerRunner implements FatalErrorHandler, AutoCloseable {
                 recoveredCount,
                 failedCount);
 
+        ShuffleWorkerChecker shuffleWorkerChecker =
+                new ShuffleWorkerCheckerImpl(configuration, dataStore);
+
         NettyConfig nettyConfig = new NettyConfig(configuration);
         NettyServer nettyServer = new NettyServer(dataStore, nettyConfig);
         nettyServer.start();
@@ -289,6 +294,7 @@ public class ShuffleWorkerRunner implements FatalErrorHandler, AutoCloseable {
                 shuffleWorkerLocation,
                 fileSystemShuffleMetaStore,
                 dataStore,
+                shuffleWorkerChecker,
                 nettyServer);
     }
 

--- a/shuffle-coordinator/src/main/java/com/alibaba/flink/shuffle/coordinator/worker/checker/ShuffleWorkerChecker.java
+++ b/shuffle-coordinator/src/main/java/com/alibaba/flink/shuffle/coordinator/worker/checker/ShuffleWorkerChecker.java
@@ -1,0 +1,35 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.flink.shuffle.coordinator.worker.checker;
+
+/**
+ * A interface to achieve the state of the shuffle worker, including storage state, the information
+ * of data partition files, etc.
+ */
+public interface ShuffleWorkerChecker {
+
+    /** The max storage usable bytes of all HDD storage disks. */
+    long getNumHddMaxUsableBytes();
+
+    /** The max storage usable bytes of all SSD storage disks. */
+    long getNumSsdMaxUsableBytes();
+
+    /** Close the shuffle worker checker. */
+    void close();
+}

--- a/shuffle-coordinator/src/main/java/com/alibaba/flink/shuffle/coordinator/worker/checker/ShuffleWorkerCheckerImpl.java
+++ b/shuffle-coordinator/src/main/java/com/alibaba/flink/shuffle/coordinator/worker/checker/ShuffleWorkerCheckerImpl.java
@@ -1,0 +1,167 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.flink.shuffle.coordinator.worker.checker;
+
+import com.alibaba.flink.shuffle.common.config.Configuration;
+import com.alibaba.flink.shuffle.coordinator.utils.WorkerCheckerUtils;
+import com.alibaba.flink.shuffle.coordinator.worker.ShuffleWorker;
+import com.alibaba.flink.shuffle.core.executor.ExecutorThreadFactory;
+import com.alibaba.flink.shuffle.core.storage.PartitionedDataStore;
+import com.alibaba.flink.shuffle.core.storage.StorageMeta;
+import com.alibaba.flink.shuffle.storage.StorageMetrics;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.nio.file.Paths;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicLong;
+
+import static com.alibaba.flink.shuffle.common.utils.CommonUtils.checkArgument;
+import static com.alibaba.flink.shuffle.common.utils.CommonUtils.checkNotNull;
+import static com.alibaba.flink.shuffle.core.config.StorageOptions.STORAGE_CHECK_UPDATE_PERIOD;
+
+/**
+ * The implementation class of {@link ShuffleWorkerChecker} is used to obtain the status of the
+ * {@link ShuffleWorker}, including storage status, data partition file information, etc.
+ */
+public class ShuffleWorkerCheckerImpl implements ShuffleWorkerChecker {
+
+    private static final Logger LOG = LoggerFactory.getLogger(ShuffleWorkerCheckerImpl.class);
+
+    private final ScheduledExecutorService storageCheckerService;
+
+    private final PartitionedDataStore dataStore;
+
+    /** The max storage usable bytes of all HDD storage disks. */
+    private final AtomicLong numHddMaxUsableBytes;
+
+    /** The max storage usable bytes of all SSD storage disks. */
+    private final AtomicLong numSsdMaxUsableBytes;
+
+    /**
+     * The total bytes of all data partition in the data store, including total bytes of data files
+     * and index files.
+     */
+    private long numTotalPartitionFileBytes;
+
+    public long getNumTotalPartitionFileBytes() {
+        return numTotalPartitionFileBytes;
+    }
+
+    @Override
+    public long getNumHddMaxUsableBytes() {
+        return numHddMaxUsableBytes.get();
+    }
+
+    @Override
+    public long getNumSsdMaxUsableBytes() {
+        return numSsdMaxUsableBytes.get();
+    }
+
+    @Override
+    public void close() {
+        if (storageCheckerService != null) {
+            storageCheckerService.shutdownNow();
+        }
+    }
+
+    public ShuffleWorkerCheckerImpl(Configuration configuration, PartitionedDataStore dataStore) {
+        this.dataStore = checkNotNull(dataStore);
+        this.numHddMaxUsableBytes = new AtomicLong(-1);
+        this.numSsdMaxUsableBytes = new AtomicLong(-1);
+        this.storageCheckerService =
+                Executors.newSingleThreadScheduledExecutor(
+                        new ExecutorThreadFactory("RSS-ShuffleWorker-Storage-Checker"));
+        startStorageCheckerThread(configuration);
+    }
+
+    private void startStorageCheckerThread(Configuration configuration) {
+        try {
+            long storageCheckerPeriod =
+                    configuration.getDuration(STORAGE_CHECK_UPDATE_PERIOD).toMillis();
+            checkArgument(
+                    storageCheckerPeriod > 0L, "The storage check interval must be larger than 0.");
+
+            StorageCheckRunnable storageCheckRunnable = new StorageCheckRunnable();
+            storageCheckRunnable.run();
+
+            StorageMetrics.registerGaugeForNumHddMaxUsableBytes(this::getNumHddMaxUsableBytes);
+            StorageMetrics.registerGaugeForNumSsdMaxUsableBytes(this::getNumSsdMaxUsableBytes);
+            StorageMetrics.registerGaugeForNumTotalPartitionFileBytes(
+                    this::getNumTotalPartitionFileBytes);
+
+            storageCheckerService.scheduleAtFixedRate(
+                    storageCheckRunnable, 0, storageCheckerPeriod, TimeUnit.MILLISECONDS);
+        } catch (Throwable t) {
+            throw new RuntimeException("Failed to start storage check thread", t);
+        }
+    }
+
+    private class StorageCheckRunnable implements Runnable {
+        @Override
+        public void run() {
+            try {
+                updateStorageUsableSpaces();
+            } catch (Throwable t) {
+                LOG.error("Failed to update the usable spaces,", t);
+            }
+        }
+
+        private void updateStorageUsableSpaces() {
+            long start = System.nanoTime();
+            updatePartitionFactoriesMetas();
+            numTotalPartitionFileBytes = dataStore.numDataPartitionTotalBytes();
+            LOG.info(
+                    "Update data store info in {} ms, max usable space, HDD: {}({}), SSD:{}({}), "
+                            + "total partition file bytes: {}({}).",
+                    String.format("%.2f", (float) ((System.nanoTime() - start) / 1000000)),
+                    WorkerCheckerUtils.bytesToHumanReadable(numHddMaxUsableBytes.get()),
+                    numHddMaxUsableBytes,
+                    WorkerCheckerUtils.bytesToHumanReadable(numSsdMaxUsableBytes.get()),
+                    numSsdMaxUsableBytes,
+                    WorkerCheckerUtils.bytesToHumanReadable(numTotalPartitionFileBytes),
+                    numTotalPartitionFileBytes);
+        }
+
+        private void updatePartitionFactoriesMetas() {
+            long maxHddUsableBytes = 0;
+            for (StorageMeta hddStorageMeta : dataStore.getHddStorageMetas()) {
+                long usableSpace = updateSingleStorageMeta(hddStorageMeta);
+                maxHddUsableBytes = Math.max(maxHddUsableBytes, usableSpace);
+            }
+            numHddMaxUsableBytes.set(maxHddUsableBytes);
+
+            long maxSsdUsableBytes = 0;
+            for (StorageMeta ssdStorageMeta : dataStore.getSsdStorageMetas()) {
+                long usableSpace = updateSingleStorageMeta(ssdStorageMeta);
+                maxSsdUsableBytes = Math.max(maxSsdUsableBytes, usableSpace);
+            }
+            numSsdMaxUsableBytes.set(maxSsdUsableBytes);
+        }
+
+        private long updateSingleStorageMeta(StorageMeta storageMeta) {
+            long usableSpace = Paths.get(storageMeta.getStoragePath()).toFile().getUsableSpace();
+            storageMeta.setNumUsableSpaceBytes(usableSpace);
+            return usableSpace;
+        }
+    }
+}

--- a/shuffle-coordinator/src/main/java/com/alibaba/flink/shuffle/minicluster/ShuffleMiniCluster.java
+++ b/shuffle-coordinator/src/main/java/com/alibaba/flink/shuffle/minicluster/ShuffleMiniCluster.java
@@ -23,6 +23,7 @@ import com.alibaba.flink.shuffle.client.ShuffleManagerClientConfiguration;
 import com.alibaba.flink.shuffle.client.ShuffleManagerClientImpl;
 import com.alibaba.flink.shuffle.client.ShuffleWorkerStatusListener;
 import com.alibaba.flink.shuffle.common.config.Configuration;
+import com.alibaba.flink.shuffle.common.config.MemorySize;
 import com.alibaba.flink.shuffle.common.functions.AutoCloseableAsync;
 import com.alibaba.flink.shuffle.common.handler.FatalErrorHandler;
 import com.alibaba.flink.shuffle.common.utils.FutureUtils;
@@ -36,6 +37,7 @@ import com.alibaba.flink.shuffle.coordinator.manager.assignmenttracker.Assignmen
 import com.alibaba.flink.shuffle.coordinator.worker.ShuffleWorker;
 import com.alibaba.flink.shuffle.coordinator.worker.ShuffleWorkerRunner;
 import com.alibaba.flink.shuffle.core.config.MemoryOptions;
+import com.alibaba.flink.shuffle.core.config.StorageOptions;
 import com.alibaba.flink.shuffle.core.config.TransferOptions;
 import com.alibaba.flink.shuffle.core.executor.ExecutorThreadFactory;
 import com.alibaba.flink.shuffle.core.ids.InstanceID;
@@ -202,6 +204,9 @@ public class ShuffleMiniCluster implements AutoCloseableAsync {
                         HeartbeatServicesUtils.createManagerWorkerHeartbeatServices(configuration);
                 jobHeartbeatServices =
                         HeartbeatServicesUtils.createManagerJobHeartbeatServices(configuration);
+
+                configuration.setMemorySize(
+                        StorageOptions.STORAGE_RESERVED_SPACE_BYTES, MemorySize.ZERO);
 
                 AkkaRpcServiceUtils.loadRpcSystem(configuration);
                 startShuffleManager();
@@ -384,7 +389,7 @@ public class ShuffleMiniCluster implements AutoCloseableAsync {
                         ioExecutor,
                         jobHeartbeatServices,
                         workerHeartbeatServices,
-                        new AssignmentTrackerImpl());
+                        new AssignmentTrackerImpl(miniClusterConfiguration.getConfiguration()));
 
         shuffleManager.start();
     }

--- a/shuffle-coordinator/src/main/java/com/alibaba/flink/shuffle/minicluster/ShuffleMiniClusterConfiguration.java
+++ b/shuffle-coordinator/src/main/java/com/alibaba/flink/shuffle/minicluster/ShuffleMiniClusterConfiguration.java
@@ -20,6 +20,7 @@ package com.alibaba.flink.shuffle.minicluster;
 
 import com.alibaba.flink.shuffle.common.config.Configuration;
 import com.alibaba.flink.shuffle.core.config.ManagerOptions;
+import com.alibaba.flink.shuffle.core.config.StorageOptions;
 import com.alibaba.flink.shuffle.core.config.WorkerOptions;
 
 import javax.annotation.Nullable;
@@ -89,6 +90,10 @@ public class ShuffleMiniClusterConfiguration {
         return commonBindAddress != null
                 ? commonBindAddress
                 : configuration.getString(WorkerOptions.BIND_HOST, "localhost");
+    }
+
+    public long getReservedSpaceBytes() {
+        return configuration.getMemorySize(StorageOptions.STORAGE_RESERVED_SPACE_BYTES).getBytes();
     }
 
     public Configuration getConfiguration() {

--- a/shuffle-coordinator/src/test/java/com/alibaba/flink/shuffle/coordinator/manager/ShuffleManagerHATest.java
+++ b/shuffle-coordinator/src/test/java/com/alibaba/flink/shuffle/coordinator/manager/ShuffleManagerHATest.java
@@ -208,6 +208,13 @@ public class ShuffleManagerHATest {
         }
 
         @Override
+        public void reportWorkerStorageSpaces(
+                InstanceID instanceID,
+                RegistrationID shuffleWorkerRegisterId,
+                long numHddUsableBytes,
+                long numSsdUsableBytes) {}
+
+        @Override
         public Map<DataPartitionCoordinate, InstanceID> getDataPartitionDistribution(JobID jobID) {
             return null;
         }

--- a/shuffle-coordinator/src/test/java/com/alibaba/flink/shuffle/coordinator/manager/ShuffleManagerTest.java
+++ b/shuffle-coordinator/src/test/java/com/alibaba/flink/shuffle/coordinator/manager/ShuffleManagerTest.java
@@ -18,6 +18,8 @@
 
 package com.alibaba.flink.shuffle.coordinator.manager;
 
+import com.alibaba.flink.shuffle.common.config.Configuration;
+import com.alibaba.flink.shuffle.common.config.MemorySize;
 import com.alibaba.flink.shuffle.common.utils.ExceptionUtils;
 import com.alibaba.flink.shuffle.coordinator.heartbeat.HeartbeatManagerImpl;
 import com.alibaba.flink.shuffle.coordinator.heartbeat.HeartbeatServices;
@@ -31,6 +33,7 @@ import com.alibaba.flink.shuffle.coordinator.utils.TestingFatalErrorHandler;
 import com.alibaba.flink.shuffle.coordinator.utils.TestingUtils;
 import com.alibaba.flink.shuffle.coordinator.worker.ShuffleWorkerGateway;
 import com.alibaba.flink.shuffle.coordinator.worker.ShuffleWorkerMetrics;
+import com.alibaba.flink.shuffle.core.config.StorageOptions;
 import com.alibaba.flink.shuffle.core.ids.DataPartitionID;
 import com.alibaba.flink.shuffle.core.ids.DataSetID;
 import com.alibaba.flink.shuffle.core.ids.InstanceID;
@@ -549,7 +552,7 @@ public class ShuffleManagerTest extends TestLogger {
         shuffleManager.heartbeatFromWorker(
                 worker.getWorkerID(),
                 new WorkerToManagerHeartbeatPayload(
-                        Arrays.asList(dataPartitionStatus, releasingDataPartitionStatus)));
+                        Arrays.asList(dataPartitionStatus, releasingDataPartitionStatus), 0, 0));
 
         assertTrue(
                 shuffleManager
@@ -579,7 +582,9 @@ public class ShuffleManagerTest extends TestLogger {
             throws InterruptedException, ExecutionException, TimeoutException {
         testingFatalErrorHandler = new TestingFatalErrorHandler();
         InstanceID shuffleManagerInstanceID = new InstanceID();
-        testAssignmentTracker = new AssignmentTrackerImpl();
+        Configuration configuration = new Configuration();
+        configuration.setMemorySize(StorageOptions.STORAGE_RESERVED_SPACE_BYTES, MemorySize.ZERO);
+        testAssignmentTracker = new AssignmentTrackerImpl(configuration);
 
         leaderElectionService = new TestingLeaderElectionService();
         final TestingHighAvailabilityServices highAvailabilityServices =

--- a/shuffle-coordinator/src/test/java/com/alibaba/flink/shuffle/coordinator/manager/assignmenttracker/MinNumberPlacementStrategyTest.java
+++ b/shuffle-coordinator/src/test/java/com/alibaba/flink/shuffle/coordinator/manager/assignmenttracker/MinNumberPlacementStrategyTest.java
@@ -1,0 +1,106 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.flink.shuffle.coordinator.manager.assignmenttracker;
+
+import com.alibaba.flink.shuffle.common.config.Configuration;
+import com.alibaba.flink.shuffle.common.config.MemorySize;
+import com.alibaba.flink.shuffle.coordinator.manager.ShuffleResource;
+import com.alibaba.flink.shuffle.coordinator.utils.EmptyShuffleWorkerGateway;
+import com.alibaba.flink.shuffle.core.config.ManagerOptions;
+import com.alibaba.flink.shuffle.core.config.StorageOptions;
+import com.alibaba.flink.shuffle.core.ids.InstanceID;
+import com.alibaba.flink.shuffle.core.ids.JobID;
+import com.alibaba.flink.shuffle.core.ids.MapPartitionID;
+import com.alibaba.flink.shuffle.core.ids.RegistrationID;
+
+import org.junit.Test;
+
+import static com.alibaba.flink.shuffle.coordinator.manager.assignmenttracker.PlacementStrategyTestUtils.PARTITION_FACTORY_CLASS;
+import static com.alibaba.flink.shuffle.coordinator.manager.assignmenttracker.PlacementStrategyTestUtils.expectedNoAvailableWorkersException;
+import static com.alibaba.flink.shuffle.coordinator.manager.assignmenttracker.PlacementStrategyTestUtils.selectWorkerWithEnoughSpace;
+import static com.alibaba.flink.shuffle.coordinator.utils.RandomIDUtils.randomDataSetId;
+import static com.alibaba.flink.shuffle.coordinator.utils.RandomIDUtils.randomJobId;
+import static com.alibaba.flink.shuffle.coordinator.utils.RandomIDUtils.randomMapPartitionId;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+/** Tests for {@link MinNumberPlacementStrategy}. */
+public class MinNumberPlacementStrategyTest {
+
+    @Test
+    public void testSelectRightWorker() throws ShuffleResourceAllocationException {
+        JobID jobId = randomJobId();
+
+        Configuration configuration = new Configuration();
+        configuration.setString(
+                ManagerOptions.PARTITION_PLACEMENT_STRATEGY,
+                PartitionPlacementStrategyLoader.MIN_NUM_PLACEMENT_STRATEGY_NAME);
+        configuration.setMemorySize(StorageOptions.STORAGE_RESERVED_SPACE_BYTES, MemorySize.ZERO);
+        AssignmentTracker assignmentTracker = new AssignmentTrackerImpl(configuration);
+        assignmentTracker.registerJob(jobId);
+
+        // Registers two workers
+        RegistrationID worker1 = new RegistrationID();
+        RegistrationID worker2 = new RegistrationID();
+
+        assignmentTracker.registerWorker(
+                new InstanceID("worker1"),
+                worker1,
+                new EmptyShuffleWorkerGateway(),
+                "worker1",
+                1024);
+        assignmentTracker.registerWorker(
+                new InstanceID("worker2"),
+                worker2,
+                new EmptyShuffleWorkerGateway(),
+                "worker2",
+                1026);
+
+        MapPartitionID dataPartitionId1 = randomMapPartitionId();
+        MapPartitionID dataPartitionId2 = randomMapPartitionId();
+
+        ShuffleResource shuffleResource1 =
+                assignmentTracker.requestShuffleResource(
+                        jobId, randomDataSetId(), dataPartitionId1, 2, PARTITION_FACTORY_CLASS);
+        String workerAddress1 = shuffleResource1.getMapPartitionLocation().getWorkerAddress();
+        ShuffleResource shuffleResource2 =
+                assignmentTracker.requestShuffleResource(
+                        jobId, randomDataSetId(), dataPartitionId2, 2, PARTITION_FACTORY_CLASS);
+        String workerAddress2 = shuffleResource2.getMapPartitionLocation().getWorkerAddress();
+
+        assertTrue(workerAddress1.equals("worker1") || workerAddress1.equals("worker2"));
+        if (workerAddress1.equals("worker1")) {
+            assertEquals("worker2", workerAddress2);
+        } else {
+            assertEquals("worker1", workerAddress2);
+        }
+    }
+
+    @Test
+    public void testSelectWorkerWithEnoughSpace() throws ShuffleResourceAllocationException {
+        selectWorkerWithEnoughSpace(
+                PartitionPlacementStrategyLoader.MIN_NUM_PLACEMENT_STRATEGY_NAME);
+    }
+
+    @Test(expected = ShuffleResourceAllocationException.class)
+    public void testNoAvailableWorkersException() throws ShuffleResourceAllocationException {
+        expectedNoAvailableWorkersException(
+                PartitionPlacementStrategyLoader.MIN_NUM_PLACEMENT_STRATEGY_NAME);
+    }
+}

--- a/shuffle-coordinator/src/test/java/com/alibaba/flink/shuffle/coordinator/manager/assignmenttracker/PlacementStrategyTestUtils.java
+++ b/shuffle-coordinator/src/test/java/com/alibaba/flink/shuffle/coordinator/manager/assignmenttracker/PlacementStrategyTestUtils.java
@@ -1,0 +1,161 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.flink.shuffle.coordinator.manager.assignmenttracker;
+
+import com.alibaba.flink.shuffle.common.config.Configuration;
+import com.alibaba.flink.shuffle.common.config.MemorySize;
+import com.alibaba.flink.shuffle.common.utils.ExceptionUtils;
+import com.alibaba.flink.shuffle.coordinator.manager.DataPartitionCoordinate;
+import com.alibaba.flink.shuffle.coordinator.manager.ShuffleResource;
+import com.alibaba.flink.shuffle.coordinator.utils.EmptyShuffleWorkerGateway;
+import com.alibaba.flink.shuffle.core.config.ManagerOptions;
+import com.alibaba.flink.shuffle.core.config.StorageOptions;
+import com.alibaba.flink.shuffle.core.ids.InstanceID;
+import com.alibaba.flink.shuffle.core.ids.JobID;
+import com.alibaba.flink.shuffle.core.ids.MapPartitionID;
+import com.alibaba.flink.shuffle.core.ids.RegistrationID;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+import static com.alibaba.flink.shuffle.coordinator.utils.RandomIDUtils.randomDataSetId;
+import static com.alibaba.flink.shuffle.coordinator.utils.RandomIDUtils.randomJobId;
+import static com.alibaba.flink.shuffle.coordinator.utils.RandomIDUtils.randomMapPartitionId;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+/** This class contains auxiliary methods for unit tests of {@link PartitionPlacementStrategy}. */
+public class PlacementStrategyTestUtils {
+
+    static final String PARTITION_FACTORY_CLASS =
+            "com.alibaba.flink.shuffle.storage.partition.LocalFileMapPartitionFactory";
+
+    static AssignmentTrackerImpl createAssignmentTrackerImpl(String placementStrategyName) {
+        Configuration configuration = new Configuration();
+        configuration.setString(ManagerOptions.PARTITION_PLACEMENT_STRATEGY, placementStrategyName);
+        configuration.setMemorySize(StorageOptions.STORAGE_RESERVED_SPACE_BYTES, MemorySize.ZERO);
+        return new AssignmentTrackerImpl(configuration);
+    }
+
+    static void registerWorkerToTracker(
+            AssignmentTrackerImpl assignmentTracker,
+            InstanceID workerInstanceID,
+            String workerAddr,
+            int dataPort) {
+        assignmentTracker.registerWorker(
+                workerInstanceID,
+                new RegistrationID(),
+                new EmptyShuffleWorkerGateway(),
+                workerAddr,
+                dataPort);
+    }
+
+    static void selectWorkerWithEnoughSpace(String placementStrategyName)
+            throws ShuffleResourceAllocationException {
+        JobID jobId = randomJobId();
+        Configuration configuration = new Configuration();
+        configuration.setString(ManagerOptions.PARTITION_PLACEMENT_STRATEGY, placementStrategyName);
+        configuration.setMemorySize(
+                StorageOptions.STORAGE_RESERVED_SPACE_BYTES, MemorySize.parse("1k"));
+        AssignmentTrackerImpl assignmentTracker = new AssignmentTrackerImpl(configuration);
+        assignmentTracker.registerJob(jobId);
+
+        InstanceID workerInstance1 = new InstanceID("worker1");
+        InstanceID workerInstance2 = new InstanceID("worker2");
+        RegistrationID registrationID1 = new RegistrationID();
+        RegistrationID registrationID2 = new RegistrationID();
+        assignmentTracker.registerWorker(
+                workerInstance1, registrationID1, new EmptyShuffleWorkerGateway(), "worker1", 1024);
+        assignmentTracker.registerWorker(
+                workerInstance2, registrationID2, new EmptyShuffleWorkerGateway(), "worker2", 1025);
+
+        assertNotNull(assignmentTracker.getWorkers().get(registrationID1));
+        assertNotNull(assignmentTracker.getWorkers().get(registrationID2));
+        assignmentTracker.getWorkers().get(registrationID1).setNumHddUsableSpaceBytes(1024);
+        assignmentTracker.getWorkers().get(registrationID2).setNumHddUsableSpaceBytes(1023);
+
+        List<ShuffleResource> shuffleResources = new ArrayList<>();
+
+        for (int i = 0; i < 100; i++) {
+            MapPartitionID dataPartitionId = randomMapPartitionId();
+            ShuffleResource shuffleResource =
+                    assignmentTracker.requestShuffleResource(
+                            jobId, randomDataSetId(), dataPartitionId, 2, PARTITION_FACTORY_CLASS);
+            shuffleResources.add(shuffleResource);
+        }
+
+        assertEquals(100, shuffleResources.size());
+        Map<DataPartitionCoordinate, InstanceID> distribution =
+                assignmentTracker.getDataPartitionDistribution(jobId);
+
+        int numWorker1 = 0;
+        int numWorker2 = 0;
+        for (InstanceID instanceID : distribution.values()) {
+            if (instanceID.equals(workerInstance1)) {
+                numWorker1++;
+            } else if (instanceID.equals(workerInstance2)) {
+                numWorker2++;
+            }
+        }
+        assertTrue(numWorker1 == 100 && numWorker2 == 0);
+    }
+
+    static void expectedNoAvailableWorkersException(String placementStrategyName)
+            throws ShuffleResourceAllocationException {
+        JobID jobId = randomJobId();
+        Configuration configuration = new Configuration();
+        configuration.setString(ManagerOptions.PARTITION_PLACEMENT_STRATEGY, placementStrategyName);
+        configuration.setMemorySize(
+                StorageOptions.STORAGE_RESERVED_SPACE_BYTES, MemorySize.parse("1k"));
+        AssignmentTrackerImpl assignmentTracker = new AssignmentTrackerImpl(configuration);
+        assignmentTracker.registerJob(jobId);
+
+        InstanceID workerInstance1 = new InstanceID("worker1");
+        InstanceID workerInstance2 = new InstanceID("worker2");
+        RegistrationID registrationID1 = new RegistrationID();
+        RegistrationID registrationID2 = new RegistrationID();
+        assignmentTracker.registerWorker(
+                workerInstance1, registrationID1, new EmptyShuffleWorkerGateway(), "worker1", 1024);
+        assignmentTracker.registerWorker(
+                workerInstance2, registrationID2, new EmptyShuffleWorkerGateway(), "worker2", 1025);
+
+        assertNotNull(assignmentTracker.getWorkers().get(registrationID1));
+        assertNotNull(assignmentTracker.getWorkers().get(registrationID2));
+        assignmentTracker.getWorkers().get(registrationID1).setNumHddUsableSpaceBytes(1023);
+        assignmentTracker.getWorkers().get(registrationID2).setNumHddUsableSpaceBytes(1023);
+
+        try {
+            assignmentTracker.requestShuffleResource(
+                    jobId, randomDataSetId(), randomMapPartitionId(), 2, PARTITION_FACTORY_CLASS);
+        } catch (ShuffleResourceAllocationException e) {
+            assertTrue(
+                    ExceptionUtils.findThrowable(
+                                    e,
+                                    exception ->
+                                            exception
+                                                    .getMessage()
+                                                    .contains(
+                                                            "maybe all workers have been filtered out"))
+                            .isPresent());
+            throw e;
+        }
+    }
+}

--- a/shuffle-coordinator/src/test/java/com/alibaba/flink/shuffle/coordinator/manager/assignmenttracker/RandomPlacementStrategyTest.java
+++ b/shuffle-coordinator/src/test/java/com/alibaba/flink/shuffle/coordinator/manager/assignmenttracker/RandomPlacementStrategyTest.java
@@ -1,0 +1,114 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.flink.shuffle.coordinator.manager.assignmenttracker;
+
+import com.alibaba.flink.shuffle.coordinator.manager.DataPartitionCoordinate;
+import com.alibaba.flink.shuffle.coordinator.manager.ShuffleResource;
+import com.alibaba.flink.shuffle.core.ids.InstanceID;
+import com.alibaba.flink.shuffle.core.ids.JobID;
+import com.alibaba.flink.shuffle.core.ids.MapPartitionID;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import static com.alibaba.flink.shuffle.coordinator.manager.assignmenttracker.PlacementStrategyTestUtils.PARTITION_FACTORY_CLASS;
+import static com.alibaba.flink.shuffle.coordinator.manager.assignmenttracker.PlacementStrategyTestUtils.createAssignmentTrackerImpl;
+import static com.alibaba.flink.shuffle.coordinator.manager.assignmenttracker.PlacementStrategyTestUtils.expectedNoAvailableWorkersException;
+import static com.alibaba.flink.shuffle.coordinator.manager.assignmenttracker.PlacementStrategyTestUtils.registerWorkerToTracker;
+import static com.alibaba.flink.shuffle.coordinator.manager.assignmenttracker.PlacementStrategyTestUtils.selectWorkerWithEnoughSpace;
+import static com.alibaba.flink.shuffle.coordinator.utils.RandomIDUtils.randomDataSetId;
+import static com.alibaba.flink.shuffle.coordinator.utils.RandomIDUtils.randomJobId;
+import static com.alibaba.flink.shuffle.coordinator.utils.RandomIDUtils.randomMapPartitionId;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+/** Tests for {@link RandomPlacementStrategy}. */
+public class RandomPlacementStrategyTest {
+    private JobID jobId;
+
+    private InstanceID workerInstance1;
+
+    private InstanceID workerInstance2;
+
+    private AssignmentTrackerImpl assignmentTracker;
+
+    @Before
+    public void start() {
+        jobId = randomJobId();
+        assignmentTracker =
+                createAssignmentTrackerImpl(
+                        PartitionPlacementStrategyLoader.RANDOM_PLACEMENT_STRATEGY_NAME);
+        assignmentTracker.registerJob(jobId);
+
+        workerInstance1 = new InstanceID("worker1");
+        workerInstance2 = new InstanceID("worker2");
+
+        registerWorkerToTracker(assignmentTracker, workerInstance1, "worker1", 1024);
+        registerWorkerToTracker(assignmentTracker, workerInstance2, "worker2", 1025);
+    }
+
+    @Test
+    public void testSelectRightWorker() throws ShuffleResourceAllocationException {
+        List<ShuffleResource> shuffleResources = new ArrayList<>();
+        Set<String> workerNames = new HashSet<>();
+
+        for (int i = 0; i < 100; i++) {
+            MapPartitionID dataPartitionId = randomMapPartitionId();
+            ShuffleResource shuffleResource =
+                    assignmentTracker.requestShuffleResource(
+                            jobId, randomDataSetId(), dataPartitionId, 2, PARTITION_FACTORY_CLASS);
+            shuffleResources.add(shuffleResource);
+            workerNames.add(shuffleResource.getMapPartitionLocation().getWorkerAddress());
+        }
+        assertEquals(100, shuffleResources.size());
+        assertTrue(workerNames.contains("worker1") && workerNames.contains("worker2"));
+        Map<DataPartitionCoordinate, InstanceID> distribution =
+                assignmentTracker.getDataPartitionDistribution(jobId);
+
+        int numWorker1 = 0;
+        int numWorker2 = 0;
+        for (InstanceID instanceID : distribution.values()) {
+            if (instanceID.equals(workerInstance1)) {
+                numWorker1++;
+            } else if (instanceID.equals(workerInstance2)) {
+                numWorker2++;
+            }
+        }
+        assertEquals(100, numWorker1 + numWorker2);
+        assertTrue(numWorker1 > 1 && numWorker2 > 1);
+    }
+
+    @Test
+    public void testSelectWorkerWithEnoughSpace() throws ShuffleResourceAllocationException {
+        selectWorkerWithEnoughSpace(
+                PartitionPlacementStrategyLoader.RANDOM_PLACEMENT_STRATEGY_NAME);
+    }
+
+    @Test(expected = ShuffleResourceAllocationException.class)
+    public void testNoAvailableWorkersException() throws ShuffleResourceAllocationException {
+        expectedNoAvailableWorkersException(
+                PartitionPlacementStrategyLoader.RANDOM_PLACEMENT_STRATEGY_NAME);
+    }
+}

--- a/shuffle-coordinator/src/test/java/com/alibaba/flink/shuffle/coordinator/manager/assignmenttracker/RoundRobinPlacementStrategyTest.java
+++ b/shuffle-coordinator/src/test/java/com/alibaba/flink/shuffle/coordinator/manager/assignmenttracker/RoundRobinPlacementStrategyTest.java
@@ -1,0 +1,124 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.flink.shuffle.coordinator.manager.assignmenttracker;
+
+import com.alibaba.flink.shuffle.coordinator.manager.DataPartitionCoordinate;
+import com.alibaba.flink.shuffle.coordinator.manager.ShuffleResource;
+import com.alibaba.flink.shuffle.core.ids.InstanceID;
+import com.alibaba.flink.shuffle.core.ids.JobID;
+import com.alibaba.flink.shuffle.core.ids.MapPartitionID;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import static com.alibaba.flink.shuffle.coordinator.manager.assignmenttracker.PlacementStrategyTestUtils.PARTITION_FACTORY_CLASS;
+import static com.alibaba.flink.shuffle.coordinator.manager.assignmenttracker.PlacementStrategyTestUtils.createAssignmentTrackerImpl;
+import static com.alibaba.flink.shuffle.coordinator.manager.assignmenttracker.PlacementStrategyTestUtils.expectedNoAvailableWorkersException;
+import static com.alibaba.flink.shuffle.coordinator.manager.assignmenttracker.PlacementStrategyTestUtils.registerWorkerToTracker;
+import static com.alibaba.flink.shuffle.coordinator.manager.assignmenttracker.PlacementStrategyTestUtils.selectWorkerWithEnoughSpace;
+import static com.alibaba.flink.shuffle.coordinator.utils.RandomIDUtils.randomDataSetId;
+import static com.alibaba.flink.shuffle.coordinator.utils.RandomIDUtils.randomJobId;
+import static com.alibaba.flink.shuffle.coordinator.utils.RandomIDUtils.randomMapPartitionId;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertTrue;
+
+/** Tests for {@link RoundRobinPlacementStrategy}. */
+public class RoundRobinPlacementStrategyTest {
+    private JobID jobId;
+
+    private InstanceID workerInstance1;
+
+    private InstanceID workerInstance2;
+
+    private AssignmentTrackerImpl assignmentTracker;
+
+    @Before
+    public void start() {
+        jobId = randomJobId();
+        assignmentTracker =
+                createAssignmentTrackerImpl(
+                        PartitionPlacementStrategyLoader.ROUND_ROBIN_PLACEMENT_STRATEGY_NAME);
+        assignmentTracker.registerJob(jobId);
+
+        workerInstance1 = new InstanceID("worker1");
+        workerInstance2 = new InstanceID("worker2");
+
+        registerWorkerToTracker(assignmentTracker, workerInstance1, "worker1", 1024);
+        registerWorkerToTracker(assignmentTracker, workerInstance2, "worker2", 1025);
+    }
+
+    @Test
+    public void testSelectRightWorker() throws ShuffleResourceAllocationException {
+        List<ShuffleResource> shuffleResources = new ArrayList<>();
+        Set<String> workerNames = new HashSet<>();
+
+        String lastWorkerName = null;
+        for (int i = 0; i < 100; i++) {
+            MapPartitionID dataPartitionId = randomMapPartitionId();
+            ShuffleResource shuffleResource =
+                    assignmentTracker.requestShuffleResource(
+                            jobId, randomDataSetId(), dataPartitionId, 2, PARTITION_FACTORY_CLASS);
+            shuffleResources.add(shuffleResource);
+            String currentWorkerAddress =
+                    shuffleResource.getMapPartitionLocation().getWorkerAddress();
+            workerNames.add(currentWorkerAddress);
+            if (lastWorkerName == null) {
+                lastWorkerName = currentWorkerAddress;
+            } else {
+                assertNotEquals(lastWorkerName, currentWorkerAddress);
+                lastWorkerName = currentWorkerAddress;
+            }
+        }
+        assertEquals(100, shuffleResources.size());
+        assertTrue(workerNames.contains("worker1") && workerNames.contains("worker2"));
+        Map<DataPartitionCoordinate, InstanceID> distribution =
+                assignmentTracker.getDataPartitionDistribution(jobId);
+
+        int numWorker1 = 0;
+        int numWorker2 = 0;
+        for (InstanceID instanceID : distribution.values()) {
+            if (instanceID.equals(workerInstance1)) {
+                numWorker1++;
+            } else if (instanceID.equals(workerInstance2)) {
+                numWorker2++;
+            }
+        }
+        assertEquals(50, numWorker1);
+        assertEquals(50, numWorker2);
+    }
+
+    @Test
+    public void testSelectWorkerWithEnoughSpace() throws ShuffleResourceAllocationException {
+        selectWorkerWithEnoughSpace(
+                PartitionPlacementStrategyLoader.ROUND_ROBIN_PLACEMENT_STRATEGY_NAME);
+    }
+
+    @Test(expected = ShuffleResourceAllocationException.class)
+    public void testNoAvailableWorkersException() throws ShuffleResourceAllocationException {
+        expectedNoAvailableWorkersException(
+                PartitionPlacementStrategyLoader.ROUND_ROBIN_PLACEMENT_STRATEGY_NAME);
+    }
+}

--- a/shuffle-coordinator/src/test/java/com/alibaba/flink/shuffle/coordinator/utils/EmptyPartitionedDataStore.java
+++ b/shuffle-coordinator/src/test/java/com/alibaba/flink/shuffle/coordinator/utils/EmptyPartitionedDataStore.java
@@ -34,6 +34,8 @@ import com.alibaba.flink.shuffle.core.storage.WritingViewContext;
 
 import javax.annotation.Nullable;
 
+import java.util.Set;
+
 /** An empty partitioned data store used for tests. */
 public class EmptyPartitionedDataStore implements PartitionedDataStore {
 
@@ -69,6 +71,11 @@ public class EmptyPartitionedDataStore implements PartitionedDataStore {
     public void releaseDataByJobID(JobID jobID, @Nullable Throwable throwable) {}
 
     @Override
+    public long numDataPartitionTotalBytes() {
+        return 0;
+    }
+
+    @Override
     public void shutDown(boolean releaseData) {}
 
     @Override
@@ -93,6 +100,16 @@ public class EmptyPartitionedDataStore implements PartitionedDataStore {
 
     @Override
     public SingleThreadExecutorPool getExecutorPool(StorageMeta storageMeta) {
+        return null;
+    }
+
+    @Override
+    public Set<StorageMeta> getHddStorageMetas() {
+        return null;
+    }
+
+    @Override
+    public Set<StorageMeta> getSsdStorageMetas() {
         return null;
     }
 }

--- a/shuffle-coordinator/src/test/java/com/alibaba/flink/shuffle/coordinator/utils/WorkerCheckerUtilsTest.java
+++ b/shuffle-coordinator/src/test/java/com/alibaba/flink/shuffle/coordinator/utils/WorkerCheckerUtilsTest.java
@@ -1,0 +1,67 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.flink.shuffle.coordinator.utils;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+/** Tests for {@link WorkerCheckerUtils}. */
+public class WorkerCheckerUtilsTest {
+    @Test
+    public void testBytesToHumanReadable() {
+        assertEquals(
+                "5.29 E",
+                WorkerCheckerUtils.bytesToHumanReadable(
+                        (long) (1024L * 1024 * 1024 * 1024 * 1024 * 1024 * 5.28532)));
+        assertEquals(
+                "8.23 P",
+                WorkerCheckerUtils.bytesToHumanReadable(
+                        (long) (1024L * 1024 * 1024 * 1024 * 1024 * 8.234)));
+        assertEquals(
+                "1.35 T",
+                WorkerCheckerUtils.bytesToHumanReadable(
+                        (long) (1024L * 1024 * 1024 * 1024 * 1.346)));
+        assertEquals(
+                "243.40 G",
+                WorkerCheckerUtils.bytesToHumanReadable((long) (1024L * 1024 * 1024 * 243.40123)));
+        assertEquals(
+                "1023.99 M", WorkerCheckerUtils.bytesToHumanReadable(1024 * 1024 * 1024 - 10486));
+        assertEquals(
+                "1024.00 M", WorkerCheckerUtils.bytesToHumanReadable(1024 * 1024 * 1024 - 1000));
+        assertEquals("1.00 G", WorkerCheckerUtils.bytesToHumanReadable(1024 * 1024 * 1024 + 1));
+        assertEquals("1.83 K", WorkerCheckerUtils.bytesToHumanReadable(1874));
+        assertEquals("1024", WorkerCheckerUtils.bytesToHumanReadable(1024));
+        assertEquals("1.00 K", WorkerCheckerUtils.bytesToHumanReadable(1025));
+        assertEquals("234", WorkerCheckerUtils.bytesToHumanReadable(234));
+        assertEquals("0", WorkerCheckerUtils.bytesToHumanReadable(0));
+        assertEquals("-1", WorkerCheckerUtils.bytesToHumanReadable(-1));
+    }
+
+    @Test
+    public void testBytesSteps() {
+        assertEquals(WorkerCheckerUtils.BYTES_STEPS.length, WorkerCheckerUtils.BYTES_UNITS.length);
+        assertEquals(7, WorkerCheckerUtils.BYTES_STEPS.length);
+        long originalBytes = 1024;
+        for (int i = 1; i < WorkerCheckerUtils.BYTES_STEPS.length; i++) {
+            assertEquals(originalBytes, WorkerCheckerUtils.BYTES_STEPS[i]);
+            originalBytes *= 1024;
+        }
+    }
+}

--- a/shuffle-coordinator/src/test/java/com/alibaba/flink/shuffle/coordinator/worker/ShuffleWorkerTest.java
+++ b/shuffle-coordinator/src/test/java/com/alibaba/flink/shuffle/coordinator/worker/ShuffleWorkerTest.java
@@ -34,6 +34,8 @@ import com.alibaba.flink.shuffle.coordinator.utils.RandomIDUtils;
 import com.alibaba.flink.shuffle.coordinator.utils.RecordingHeartbeatServices;
 import com.alibaba.flink.shuffle.coordinator.utils.TestingFatalErrorHandler;
 import com.alibaba.flink.shuffle.coordinator.utils.TestingShuffleManagerGateway;
+import com.alibaba.flink.shuffle.coordinator.worker.checker.ShuffleWorkerChecker;
+import com.alibaba.flink.shuffle.coordinator.worker.checker.ShuffleWorkerCheckerImpl;
 import com.alibaba.flink.shuffle.coordinator.worker.metastore.LocalShuffleMetaStore;
 import com.alibaba.flink.shuffle.coordinator.worker.metastore.LocalShuffleMetaStoreTest;
 import com.alibaba.flink.shuffle.core.config.TransferOptions;
@@ -96,6 +98,8 @@ public class ShuffleWorkerTest {
 
     private PartitionedDataStore dataStore;
 
+    private ShuffleWorkerChecker shuffleWorkerChecker;
+
     private NettyServer nettyServer;
 
     @Before
@@ -113,6 +117,8 @@ public class ShuffleWorkerTest {
         testingFatalErrorHandler = new TestingFatalErrorHandler();
 
         dataStore = new EmptyPartitionedDataStore();
+
+        shuffleWorkerChecker = new ShuffleWorkerCheckerImpl(configuration, dataStore);
 
         // choose random worker port
         Random random = new Random(System.currentTimeMillis());
@@ -189,6 +195,7 @@ public class ShuffleWorkerTest {
                             }
                         },
                         dataStore,
+                        shuffleWorkerChecker,
                         nettyServer)) {
             shuffleWorker.start();
             shuffleManagerLeaderRetrieveService.notifyListener(
@@ -239,6 +246,7 @@ public class ShuffleWorkerTest {
                         shuffleWorkerLocation,
                         new EmptyMetaStore(),
                         dataStore,
+                        shuffleWorkerChecker,
                         nettyServer)) {
             shuffleWorker.start();
             shuffleManagerLeaderRetrieveService.notifyListener(
@@ -340,6 +348,7 @@ public class ShuffleWorkerTest {
                             }
                         },
                         dataStore,
+                        shuffleWorkerChecker,
                         nettyServer)) {
             shuffleWorker.start();
             shuffleManagerLeaderRetrieveService.notifyListener(
@@ -380,6 +389,7 @@ public class ShuffleWorkerTest {
                         shuffleWorkerLocation,
                         new EmptyMetaStore(),
                         dataStore,
+                        shuffleWorkerChecker,
                         nettyServer)) {
             shuffleWorker.start();
 
@@ -426,6 +436,7 @@ public class ShuffleWorkerTest {
                         shuffleWorkerLocation,
                         new EmptyMetaStore(),
                         dataStore,
+                        shuffleWorkerChecker,
                         nettyServer)) {
             shuffleWorker.start();
             shuffleManagerLeaderRetrieveService.notifyListener(
@@ -484,6 +495,7 @@ public class ShuffleWorkerTest {
                         shuffleWorkerLocation,
                         metaStore,
                         dataStore,
+                        shuffleWorkerChecker,
                         nettyServer)) {
             shuffleWorker.start();
             shuffleManagerLeaderRetrieveService.notifyListener(

--- a/shuffle-coordinator/src/test/java/com/alibaba/flink/shuffle/coordinator/worker/checker/ShuffleWorkerCheckerImplTest.java
+++ b/shuffle-coordinator/src/test/java/com/alibaba/flink/shuffle/coordinator/worker/checker/ShuffleWorkerCheckerImplTest.java
@@ -1,0 +1,146 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.flink.shuffle.coordinator.worker.checker;
+
+import com.alibaba.flink.shuffle.common.config.Configuration;
+import com.alibaba.flink.shuffle.common.utils.ExceptionUtils;
+import com.alibaba.flink.shuffle.coordinator.utils.EmptyPartitionedDataStore;
+import com.alibaba.flink.shuffle.core.config.MemoryOptions;
+import com.alibaba.flink.shuffle.core.config.StorageOptions;
+import com.alibaba.flink.shuffle.core.listener.PartitionStateListener;
+import com.alibaba.flink.shuffle.core.storage.DataPartitionMeta;
+import com.alibaba.flink.shuffle.core.storage.StorageType;
+import com.alibaba.flink.shuffle.storage.datastore.PartitionedDataStoreImpl;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import java.util.Properties;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+/** Tests for {@link ShuffleWorkerCheckerImpl}. */
+public class ShuffleWorkerCheckerImplTest {
+
+    @Rule public final TemporaryFolder temporaryFolder = new TemporaryFolder();
+
+    private PartitionedDataStoreImpl dataStore;
+
+    @Before
+    public void before() {
+        dataStore =
+                createPartitionedDataStore(
+                        temporaryFolder.getRoot().getAbsolutePath(),
+                        new NoOpPartitionStateListener());
+    }
+
+    @After
+    public void clear() {
+        dataStore.shutDown(true);
+        temporaryFolder.delete();
+    }
+
+    @Test
+    public void testInitWorkerCheckerWithEmptyStore() {
+        ShuffleWorkerCheckerImpl workerChecker =
+                new ShuffleWorkerCheckerImpl(new Configuration(), new EmptyPartitionedDataStore());
+        assertEquals(-1, workerChecker.getNumHddMaxUsableBytes());
+        assertEquals(-1, workerChecker.getNumSsdMaxUsableBytes());
+        assertEquals(0, workerChecker.getNumTotalPartitionFileBytes());
+    }
+
+    @Test
+    public void testInitWorkerCheckerWithHddStore() {
+        ShuffleWorkerCheckerImpl workerChecker =
+                new ShuffleWorkerCheckerImpl(new Configuration(), dataStore);
+        assertTrue(workerChecker.getNumHddMaxUsableBytes() > 0);
+        assertEquals(0, workerChecker.getNumSsdMaxUsableBytes());
+        assertEquals(0, workerChecker.getNumTotalPartitionFileBytes());
+    }
+
+    @Test
+    public void testInitWorkerCheckerWithSsdStore() {
+        PartitionedDataStoreImpl dataStore =
+                createPartitionedDataStore(
+                        temporaryFolder.getRoot().getAbsolutePath(),
+                        new NoOpPartitionStateListener(),
+                        StorageType.SSD);
+        ShuffleWorkerCheckerImpl workerChecker =
+                new ShuffleWorkerCheckerImpl(new Configuration(), dataStore);
+        assertEquals(0, workerChecker.getNumHddMaxUsableBytes());
+        assertTrue(workerChecker.getNumSsdMaxUsableBytes() > 0);
+        assertEquals(0, workerChecker.getNumTotalPartitionFileBytes());
+    }
+
+    @Test
+    public void testWrongUpdateIntervalArgument() {
+        Configuration configuration = new Configuration();
+        configuration.setString("remote-shuffle.storage.check-update-period", "0");
+        try {
+            new ShuffleWorkerCheckerImpl(configuration, dataStore);
+        } catch (Throwable t) {
+            assertTrue(
+                    ExceptionUtils.findThrowable(
+                                    t,
+                                    throwable ->
+                                            throwable
+                                                    .getMessage()
+                                                    .contains("The storage check interval"))
+                            .isPresent());
+        }
+    }
+
+    private static class NoOpPartitionStateListener implements PartitionStateListener {
+        @Override
+        public void onPartitionCreated(DataPartitionMeta partitionMeta) {}
+
+        @Override
+        public void onPartitionRemoved(DataPartitionMeta partitionMeta) {}
+    }
+
+    private static PartitionedDataStoreImpl createPartitionedDataStore(
+            String storageDir, PartitionStateListener partitionStateListener) {
+        return createPartitionedDataStore(storageDir, partitionStateListener, StorageType.HDD);
+    }
+
+    private static PartitionedDataStoreImpl createPartitionedDataStore(
+            String storageDir,
+            PartitionStateListener partitionStateListener,
+            StorageType storageType) {
+        Properties properties = new Properties();
+        properties.setProperty(
+                MemoryOptions.MEMORY_SIZE_FOR_DATA_READING.key(),
+                MemoryOptions.MIN_VALID_MEMORY_SIZE.getBytes() + "b");
+        properties.setProperty(
+                MemoryOptions.MEMORY_SIZE_FOR_DATA_WRITING.key(),
+                MemoryOptions.MIN_VALID_MEMORY_SIZE.getBytes() + "b");
+        if (storageType.equals(StorageType.HDD)) {
+            properties.setProperty(StorageOptions.STORAGE_LOCAL_DATA_DIRS.key(), storageDir);
+        } else {
+            properties.setProperty(
+                    StorageOptions.STORAGE_LOCAL_DATA_DIRS.key(), "[SSD]" + storageDir);
+        }
+        Configuration configuration = new Configuration(properties);
+        return new PartitionedDataStoreImpl(configuration, partitionStateListener);
+    }
+}

--- a/shuffle-core/src/main/java/com/alibaba/flink/shuffle/core/config/ManagerOptions.java
+++ b/shuffle-core/src/main/java/com/alibaba/flink/shuffle/core/config/ManagerOptions.java
@@ -96,6 +96,16 @@ public class ManagerOptions {
                     .defaultValue("")
                     .description("Java options to start the JVM of the shuffle manager with.");
 
+    public static final ConfigOption<String> PARTITION_PLACEMENT_STRATEGY =
+            new ConfigOption<String>("remote-shuffle.manager.partition-placement-strategy")
+                    .defaultValue("random")
+                    .description(
+                            "Worker selection strategy for storing the next data partition. Different selection"
+                                    + " strategies can be specified through this option."
+                                    + " 'min-num': select the next worker with minimum number of data partitions."
+                                    + " 'random': select the next worker in random order. "
+                                    + " 'round-robin': select the next worker in round-robin order.");
+
     // ------------------------------------------------------------------------
 
     /** Not intended to be instantiated. */

--- a/shuffle-core/src/main/java/com/alibaba/flink/shuffle/core/config/StorageOptions.java
+++ b/shuffle-core/src/main/java/com/alibaba/flink/shuffle/core/config/StorageOptions.java
@@ -22,11 +22,15 @@ import com.alibaba.flink.shuffle.common.config.ConfigOption;
 import com.alibaba.flink.shuffle.common.config.MemorySize;
 import com.alibaba.flink.shuffle.core.storage.StorageType;
 
+import java.time.Duration;
+
 /** Config options for storage. */
 public class StorageOptions {
 
     /** Minimum size of memory to be used for data partition writing and reading. */
     public static final MemorySize MIN_WRITING_READING_MEMORY_SIZE = MemorySize.parse("16m");
+
+    private static final MemorySize STORAGE_RESERVED_SPACE_BYTES_DEFAULT = MemorySize.parse("5g");
 
     /** Whether to enable data checksum for data integrity verification or not. */
     public static final ConfigOption<Boolean> STORAGE_ENABLE_DATA_CHECKSUM =
@@ -152,6 +156,22 @@ public class StorageOptions {
                                             + "smaller than %s, the minimum %s will be used.",
                                     MIN_WRITING_READING_MEMORY_SIZE.toHumanReadableString(),
                                     MIN_WRITING_READING_MEMORY_SIZE.toHumanReadableString()));
+
+    public static final ConfigOption<Duration> STORAGE_CHECK_UPDATE_PERIOD =
+            new ConfigOption<Duration>("remote-shuffle.storage.check-update-period")
+                    .defaultValue(Duration.ofSeconds(10))
+                    .description(
+                            "The update interval of the worker check thread. The"
+                                    + " thread will periodically get the status at this time interval.");
+
+    public static final ConfigOption<MemorySize> STORAGE_RESERVED_SPACE_BYTES =
+            new ConfigOption<MemorySize>("remote-shuffle.storage.min-reserved-space-bytes")
+                    .defaultValue(STORAGE_RESERVED_SPACE_BYTES_DEFAULT)
+                    .description(
+                            "Minimum reserved space size for shuffle workers. This option"
+                                    + " is used to filter out the worker with small remaining storage space"
+                                    + " to ensure that the storage space will not be exhausted during use."
+                                    + " However, setting the value too large will waste storage resources.");
 
     // ------------------------------------------------------------------------
 

--- a/shuffle-core/src/main/java/com/alibaba/flink/shuffle/core/storage/DataPartition.java
+++ b/shuffle-core/src/main/java/com/alibaba/flink/shuffle/core/storage/DataPartition.java
@@ -96,6 +96,12 @@ public interface DataPartition {
     boolean isConsumable();
 
     /**
+     * Returns the total length of this data partition in bytes, including data files and index
+     * files.
+     */
+    long totalBytes();
+
+    /**
      * Type definition of {@link DataPartition}. All {@link DataPartition}s must be either of type
      * {@link #MAP_PARTITION} or type {@link #REDUCE_PARTITION}.
      */

--- a/shuffle-core/src/main/java/com/alibaba/flink/shuffle/core/storage/DataPartitionFactory.java
+++ b/shuffle-core/src/main/java/com/alibaba/flink/shuffle/core/storage/DataPartitionFactory.java
@@ -24,6 +24,7 @@ import com.alibaba.flink.shuffle.core.ids.DataSetID;
 import com.alibaba.flink.shuffle.core.ids.JobID;
 
 import java.io.DataInput;
+import java.util.List;
 
 /**
  * Factory to create new {@link DataPartition}s. Different type of {@link DataPartition}s need
@@ -73,6 +74,12 @@ public interface DataPartitionFactory {
 
     /** Returns the data partition type this partition factory is going to create. */
     DataPartition.DataPartitionType getDataPartitionType();
+
+    /** Returns the HDD storage metas of this partition factory. */
+    List<StorageMeta> getHddStorageMetas();
+
+    /** Returns the SSD storage metas of this partition factory. */
+    List<StorageMeta> getSsdStorageMetas();
 
     static DataPartition.DataPartitionType getDataPartitionType(String dataPartitionFactoryName)
             throws ClassNotFoundException, InstantiationException, IllegalAccessException {

--- a/shuffle-core/src/main/java/com/alibaba/flink/shuffle/core/storage/PartitionedDataStore.java
+++ b/shuffle-core/src/main/java/com/alibaba/flink/shuffle/core/storage/PartitionedDataStore.java
@@ -28,6 +28,8 @@ import com.alibaba.flink.shuffle.core.memory.BufferDispatcher;
 
 import javax.annotation.Nullable;
 
+import java.util.Set;
+
 /**
  * {@link PartitionedDataStore} is the storage of {@link DataPartition}s. Different types of {@link
  * DataPartition}s can be added to and removed from this data store.
@@ -98,6 +100,12 @@ public interface PartitionedDataStore {
     void releaseDataByJobID(JobID jobID, @Nullable Throwable throwable);
 
     /**
+     * Returns the total bytes of all data partition in the data store, including total bytes of
+     * data files and index files.
+     */
+    long numDataPartitionTotalBytes();
+
+    /**
      * Shuts down this data store and releases the resources.
      *
      * @param releaseData Whether to also release all data or not.
@@ -127,4 +135,10 @@ public interface PartitionedDataStore {
      * {@link DataPartition} processing.
      */
     SingleThreadExecutorPool getExecutorPool(StorageMeta storageMeta);
+
+    /** Returns all HDD {@link StorageMeta}s of this data store. */
+    Set<StorageMeta> getHddStorageMetas();
+
+    /** Returns all SSD {@link StorageMeta}s of this data store. */
+    Set<StorageMeta> getSsdStorageMetas();
 }

--- a/shuffle-core/src/main/java/com/alibaba/flink/shuffle/core/storage/StorageMeta.java
+++ b/shuffle-core/src/main/java/com/alibaba/flink/shuffle/core/storage/StorageMeta.java
@@ -35,12 +35,15 @@ public class StorageMeta implements Serializable {
 
     private final StorageType storageType;
 
+    private volatile long numUsableSpaceBytes;
+
     public StorageMeta(String storagePath, StorageType storageType) {
         CommonUtils.checkArgument(storagePath != null, "Must be not null.");
         CommonUtils.checkArgument(storageType != null, "Must be not null.");
 
         this.storagePath = storagePath;
         this.storageType = storageType;
+        this.numUsableSpaceBytes = 0;
     }
 
     public String getStoragePath() {
@@ -49,6 +52,14 @@ public class StorageMeta implements Serializable {
 
     public StorageType getStorageType() {
         return storageType;
+    }
+
+    public long getNumUsableSpaceBytes() {
+        return numUsableSpaceBytes;
+    }
+
+    public void setNumUsableSpaceBytes(long numUsableSpaceBytes) {
+        this.numUsableSpaceBytes = numUsableSpaceBytes;
     }
 
     public void writeTo(DataOutput dataOutput) throws IOException {

--- a/shuffle-core/src/test/java/com/alibaba/flink/shuffle/core/storage/NoOpDataPartition.java
+++ b/shuffle-core/src/test/java/com/alibaba/flink/shuffle/core/storage/NoOpDataPartition.java
@@ -84,4 +84,9 @@ public class NoOpDataPartition implements DataPartition {
     public boolean isConsumable() {
         return false;
     }
+
+    @Override
+    public long totalBytes() {
+        return 0;
+    }
 }

--- a/shuffle-e2e-tests/src/test/java/com/alibaba/flink/shuffle/e2e/shufflecluster/LocalShuffleCluster.java
+++ b/shuffle-e2e-tests/src/test/java/com/alibaba/flink/shuffle/e2e/shufflecluster/LocalShuffleCluster.java
@@ -33,6 +33,7 @@ import com.alibaba.flink.shuffle.coordinator.heartbeat.HeartbeatServicesUtils;
 import com.alibaba.flink.shuffle.coordinator.highavailability.HaServiceUtils;
 import com.alibaba.flink.shuffle.coordinator.highavailability.HaServices;
 import com.alibaba.flink.shuffle.coordinator.manager.DataPartitionCoordinate;
+import com.alibaba.flink.shuffle.coordinator.manager.assignmenttracker.PartitionPlacementStrategyLoader;
 import com.alibaba.flink.shuffle.coordinator.utils.RandomIDUtils;
 import com.alibaba.flink.shuffle.coordinator.worker.ShuffleWorkerMetricKeys;
 import com.alibaba.flink.shuffle.coordinator.worker.ShuffleWorkerMetrics;
@@ -40,6 +41,7 @@ import com.alibaba.flink.shuffle.core.config.HeartbeatOptions;
 import com.alibaba.flink.shuffle.core.config.HighAvailabilityOptions;
 import com.alibaba.flink.shuffle.core.config.ManagerOptions;
 import com.alibaba.flink.shuffle.core.config.MemoryOptions;
+import com.alibaba.flink.shuffle.core.config.StorageOptions;
 import com.alibaba.flink.shuffle.core.config.WorkerOptions;
 import com.alibaba.flink.shuffle.core.ids.InstanceID;
 import com.alibaba.flink.shuffle.e2e.TestJvmProcess;
@@ -121,6 +123,10 @@ public class LocalShuffleCluster {
                 MemoryOptions.MEMORY_SIZE_FOR_DATA_READING, MemoryOptions.MIN_VALID_MEMORY_SIZE);
         config.setMemorySize(
                 MemoryOptions.MEMORY_SIZE_FOR_DATA_WRITING, MemoryOptions.MIN_VALID_MEMORY_SIZE);
+        config.setString(
+                ManagerOptions.PARTITION_PLACEMENT_STRATEGY,
+                PartitionPlacementStrategyLoader.MIN_NUM_PLACEMENT_STRATEGY_NAME);
+        config.setMemorySize(StorageOptions.STORAGE_RESERVED_SPACE_BYTES, MemorySize.ZERO);
     }
 
     public void start() throws Exception {

--- a/shuffle-storage/src/main/java/com/alibaba/flink/shuffle/storage/StorageMetrics.java
+++ b/shuffle-storage/src/main/java/com/alibaba/flink/shuffle/storage/StorageMetrics.java
@@ -39,6 +39,13 @@ public class StorageMetrics {
     public static final String NUM_AVAILABLE_READING_BUFFERS =
             STORAGE + ".num_available_reading_buffers";
 
+    public static final String NUM_HDD_MAX_USABLE_BYTES = STORAGE + ".num_hdd_max_usable_bytes";
+
+    public static final String NUM_SSD_MAX_USABLE_BYTES = STORAGE + ".num_ssd_max_usable_bytes";
+
+    public static final String NUM_TOTAL_PARTITION_FILE_BYTES =
+            STORAGE + ".num_total_partition_file_bytes";
+
     // Number of data partitions stored.
     public static final String NUM_DATA_PARTITIONS = STORAGE + ".num_data_partitions";
 
@@ -73,6 +80,58 @@ public class StorageMetrics {
                     @Override
                     public Integer getValue() {
                         return availableNum.get();
+                    }
+
+                    @Override
+                    public long lastUpdateTime() {
+                        return System.currentTimeMillis();
+                    }
+                });
+    }
+
+    public static void registerGaugeForNumHddMaxUsableBytes(Supplier<Long> numHddMaxUsableBytes) {
+        MetricUtils.registerMetric(
+                STORAGE,
+                NUM_HDD_MAX_USABLE_BYTES,
+                new Gauge<Long>() {
+                    @Override
+                    public Long getValue() {
+                        return numHddMaxUsableBytes.get();
+                    }
+
+                    @Override
+                    public long lastUpdateTime() {
+                        return System.currentTimeMillis();
+                    }
+                });
+    }
+
+    public static void registerGaugeForNumSsdMaxUsableBytes(Supplier<Long> numSsdMaxUsableBytes) {
+        MetricUtils.registerMetric(
+                STORAGE,
+                NUM_SSD_MAX_USABLE_BYTES,
+                new Gauge<Long>() {
+                    @Override
+                    public Long getValue() {
+                        return numSsdMaxUsableBytes.get();
+                    }
+
+                    @Override
+                    public long lastUpdateTime() {
+                        return System.currentTimeMillis();
+                    }
+                });
+    }
+
+    public static void registerGaugeForNumTotalPartitionFileBytes(
+            Supplier<Long> umTotalPartitionFileBytes) {
+        MetricUtils.registerMetric(
+                STORAGE,
+                NUM_TOTAL_PARTITION_FILE_BYTES,
+                new Gauge<Long>() {
+                    @Override
+                    public Long getValue() {
+                        return umTotalPartitionFileBytes.get();
                     }
 
                     @Override

--- a/shuffle-storage/src/main/java/com/alibaba/flink/shuffle/storage/partition/HDDOnlyLocalFileMapPartitionFactory.java
+++ b/shuffle-storage/src/main/java/com/alibaba/flink/shuffle/storage/partition/HDDOnlyLocalFileMapPartitionFactory.java
@@ -20,9 +20,12 @@ package com.alibaba.flink.shuffle.storage.partition;
 
 import com.alibaba.flink.shuffle.common.config.Configuration;
 import com.alibaba.flink.shuffle.common.exception.ConfigurationException;
-import com.alibaba.flink.shuffle.common.utils.CommonUtils;
 import com.alibaba.flink.shuffle.core.config.StorageOptions;
+import com.alibaba.flink.shuffle.core.storage.DataPartition;
 import com.alibaba.flink.shuffle.core.storage.StorageMeta;
+import com.alibaba.flink.shuffle.core.storage.StorageType;
+
+import static com.alibaba.flink.shuffle.common.utils.CommonUtils.checkNotNull;
 
 /**
  * A {@link LocalFileMapPartitionFactory} variant which only uses HDD to store data partition data.
@@ -43,8 +46,15 @@ public class HDDOnlyLocalFileMapPartitionFactory extends LocalFileMapPartitionFa
 
     @Override
     protected StorageMeta getNextDataStorageMeta() {
-        StorageMeta storageMeta = CommonUtils.checkNotNull(hddStorageMetas.poll());
-        hddStorageMetas.add(storageMeta);
-        return storageMeta;
+        return checkNotNull(getStorageMetaInNonEmptyQueue(hddStorageMetas));
+    }
+
+    @Override
+    public DataPartition.DataPartitionType getDataPartitionType() {
+        return super.getDataPartitionType();
+    }
+
+    public StorageType getPreferredStorageType() {
+        return StorageType.HDD;
     }
 }

--- a/shuffle-storage/src/main/java/com/alibaba/flink/shuffle/storage/partition/LocalFileMapPartition.java
+++ b/shuffle-storage/src/main/java/com/alibaba/flink/shuffle/storage/partition/LocalFileMapPartition.java
@@ -117,6 +117,11 @@ public class LocalFileMapPartition extends BaseMapPartition {
     }
 
     @Override
+    public long totalBytes() {
+        return partitionFile.totalBytes();
+    }
+
+    @Override
     protected DataPartitionReader getDataPartitionReader(
             int startPartitionIndex,
             int endPartitionIndex,

--- a/shuffle-storage/src/main/java/com/alibaba/flink/shuffle/storage/partition/LocalMapPartitionFileMeta.java
+++ b/shuffle-storage/src/main/java/com/alibaba/flink/shuffle/storage/partition/LocalMapPartitionFileMeta.java
@@ -129,9 +129,11 @@ public class LocalMapPartitionFileMeta implements PersistentFileMeta {
     public LocalMapPartitionFile createPersistentFile(Configuration configuration) {
         ConfigOption<Integer> configOption = StorageOptions.STORAGE_FILE_TOLERABLE_FAILURES;
         int tolerableFailures = CommonUtils.checkNotNull(configuration.getInteger(configOption));
+        long totalBytes =
+                getDataFilePath().toFile().length() + getIndexFilePath().toFile().length();
 
         LocalMapPartitionFile partitionFile =
-                new LocalMapPartitionFile(this, tolerableFailures, false);
+                new LocalMapPartitionFile(this, tolerableFailures, false, totalBytes);
         partitionFile.setConsumable(true);
         return partitionFile;
     }

--- a/shuffle-storage/src/main/java/com/alibaba/flink/shuffle/storage/partition/LocalMapPartitionFileWriter.java
+++ b/shuffle-storage/src/main/java/com/alibaba/flink/shuffle/storage/partition/LocalMapPartitionFileWriter.java
@@ -193,6 +193,7 @@ public class LocalMapPartitionFileWriter {
 
             long length = data.remaining() + header.remaining();
             totalBytes += length;
+            partitionFile.incrementTotalBytes(length);
             numReducePartitionBytes[reducePartitionIndex] += length;
 
             bufferWithHeaders[index] = header;
@@ -256,6 +257,7 @@ public class LocalMapPartitionFileWriter {
             for (int index = 0; index < indexBuffer.limit(); ++index) {
                 checksum.update(indexBuffer.get(index));
             }
+            partitionFile.incrementTotalBytes(indexBuffer.remaining());
             IOUtils.writeBuffer(indexFileChannel, indexBuffer);
         }
         indexBuffer.clear();

--- a/shuffle-storage/src/main/java/com/alibaba/flink/shuffle/storage/partition/PersistentFile.java
+++ b/shuffle-storage/src/main/java/com/alibaba/flink/shuffle/storage/partition/PersistentFile.java
@@ -30,6 +30,9 @@ public interface PersistentFile {
     /** Checks whether this persistent file is consumable or not and returns true if so. */
     boolean isConsumable();
 
+    /** Returns the total length in bytes, including data file and index file. */
+    long totalBytes();
+
     /** Gets the corresponding meta of this persistent file. */
     PersistentFileMeta getFileMeta();
 
@@ -41,4 +44,10 @@ public interface PersistentFile {
 
     /** Changes the consumable state of this persistent file. */
     void setConsumable(boolean consumable);
+
+    /**
+     * Increments the total length of this data partition in bytes, including data files and index
+     * files.
+     */
+    void incrementTotalBytes(long incrementBytes);
 }

--- a/shuffle-storage/src/main/java/com/alibaba/flink/shuffle/storage/partition/SSDOnlyLocalFileMapPartitionFactory.java
+++ b/shuffle-storage/src/main/java/com/alibaba/flink/shuffle/storage/partition/SSDOnlyLocalFileMapPartitionFactory.java
@@ -20,9 +20,11 @@ package com.alibaba.flink.shuffle.storage.partition;
 
 import com.alibaba.flink.shuffle.common.config.Configuration;
 import com.alibaba.flink.shuffle.common.exception.ConfigurationException;
-import com.alibaba.flink.shuffle.common.utils.CommonUtils;
 import com.alibaba.flink.shuffle.core.config.StorageOptions;
 import com.alibaba.flink.shuffle.core.storage.StorageMeta;
+import com.alibaba.flink.shuffle.core.storage.StorageType;
+
+import static com.alibaba.flink.shuffle.common.utils.CommonUtils.checkNotNull;
 
 /**
  * A {@link LocalFileMapPartitionFactory} variant which only uses SSD to store data partition data.
@@ -43,8 +45,10 @@ public class SSDOnlyLocalFileMapPartitionFactory extends LocalFileMapPartitionFa
 
     @Override
     protected StorageMeta getNextDataStorageMeta() {
-        StorageMeta storageMeta = CommonUtils.checkNotNull(ssdStorageMetas.poll());
-        ssdStorageMetas.add(storageMeta);
-        return storageMeta;
+        return checkNotNull(getStorageMetaInNonEmptyQueue(ssdStorageMetas));
+    }
+
+    public StorageType getPreferredStorageType() {
+        return StorageType.SSD;
     }
 }

--- a/shuffle-storage/src/main/java/com/alibaba/flink/shuffle/storage/utils/StorageConfigParseUtils.java
+++ b/shuffle-storage/src/main/java/com/alibaba/flink/shuffle/storage/utils/StorageConfigParseUtils.java
@@ -18,8 +18,10 @@
 
 package com.alibaba.flink.shuffle.storage.utils;
 
+import com.alibaba.flink.shuffle.common.config.Configuration;
 import com.alibaba.flink.shuffle.common.exception.ConfigurationException;
 import com.alibaba.flink.shuffle.core.config.StorageOptions;
+import com.alibaba.flink.shuffle.core.storage.StorageType;
 
 import java.io.File;
 import java.nio.file.Files;
@@ -110,5 +112,23 @@ public class StorageConfigParseUtils {
         }
 
         return new ParsedPathLists(ssdPaths, hddPaths, allPaths);
+    }
+
+    /**
+     * Helper method which parses the configuration and obtains the configured preferred storage
+     * type.
+     */
+    public static StorageType confPreferredStorageType(Configuration configuration) {
+        StorageType preferredStorageType;
+        String diskTypeString = configuration.getString(StorageOptions.STORAGE_PREFERRED_TYPE);
+        try {
+            preferredStorageType = StorageType.valueOf(checkNotNull(diskTypeString).trim());
+        } catch (Exception exception) {
+            throw new ConfigurationException(
+                    String.format(
+                            "Illegal configured value %s for %s. Must be SSD, HDD or UNKNOWN.",
+                            diskTypeString, StorageOptions.STORAGE_PREFERRED_TYPE.key()));
+        }
+        return preferredStorageType;
     }
 }

--- a/shuffle-storage/src/test/java/com/alibaba/flink/shuffle/storage/datastore/NoOpPartitionedDataStore.java
+++ b/shuffle-storage/src/test/java/com/alibaba/flink/shuffle/storage/datastore/NoOpPartitionedDataStore.java
@@ -37,6 +37,7 @@ import com.alibaba.flink.shuffle.storage.utils.StorageTestUtils;
 import javax.annotation.Nullable;
 
 import java.util.Properties;
+import java.util.Set;
 
 /** A no-op {@link PartitionedDataStore} implementation for tests. */
 public class NoOpPartitionedDataStore implements PartitionedDataStore {
@@ -84,6 +85,11 @@ public class NoOpPartitionedDataStore implements PartitionedDataStore {
     public void releaseDataByJobID(JobID jobID, @Nullable Throwable throwable) {}
 
     @Override
+    public long numDataPartitionTotalBytes() {
+        return 0;
+    }
+
+    @Override
     public void shutDown(boolean releaseData) {}
 
     @Override
@@ -109,5 +115,15 @@ public class NoOpPartitionedDataStore implements PartitionedDataStore {
     @Override
     public SingleThreadExecutorPool getExecutorPool(StorageMeta storageMeta) {
         return executorPool;
+    }
+
+    @Override
+    public Set<StorageMeta> getHddStorageMetas() {
+        return null;
+    }
+
+    @Override
+    public Set<StorageMeta> getSsdStorageMetas() {
+        return null;
     }
 }

--- a/shuffle-storage/src/test/java/com/alibaba/flink/shuffle/storage/partition/HDDOnlyLocalFileMapPartitionFactoryTest.java
+++ b/shuffle-storage/src/test/java/com/alibaba/flink/shuffle/storage/partition/HDDOnlyLocalFileMapPartitionFactoryTest.java
@@ -31,6 +31,7 @@ import org.junit.rules.TemporaryFolder;
 
 import java.util.Properties;
 
+import static com.alibaba.flink.shuffle.storage.partition.LocalFileMapPartitionFactoryTest.expectedEvenDiskUsedCount;
 import static org.junit.Assert.assertEquals;
 
 /** Tests for {@link HDDOnlyLocalFileMapPartitionFactory}. */
@@ -70,5 +71,22 @@ public class HDDOnlyLocalFileMapPartitionFactoryTest {
                     storageMeta.getStoragePath());
             assertEquals(StorageType.HDD, storageMeta.getStorageType());
         }
+    }
+
+    @Test
+    public void testAllDisksWillBeUsed() {
+        HDDOnlyLocalFileMapPartitionFactory partitionFactory =
+                new HDDOnlyLocalFileMapPartitionFactory();
+        Properties properties = new Properties();
+        properties.setProperty(
+                StorageOptions.STORAGE_LOCAL_DATA_DIRS.key(),
+                String.format(
+                        "[HDD]%s,[HDD]%s",
+                        temporaryFolder1.getRoot().getAbsolutePath(),
+                        temporaryFolder2.getRoot().getAbsolutePath()));
+        partitionFactory.initialize(new Configuration(properties));
+
+        expectedEvenDiskUsedCount(
+                partitionFactory, temporaryFolder1, temporaryFolder2, StorageType.HDD);
     }
 }

--- a/shuffle-storage/src/test/java/com/alibaba/flink/shuffle/storage/partition/SSDOnlyLocalFileMapPartitionFactoryTest.java
+++ b/shuffle-storage/src/test/java/com/alibaba/flink/shuffle/storage/partition/SSDOnlyLocalFileMapPartitionFactoryTest.java
@@ -31,6 +31,7 @@ import org.junit.rules.TemporaryFolder;
 
 import java.util.Properties;
 
+import static com.alibaba.flink.shuffle.storage.partition.LocalFileMapPartitionFactoryTest.expectedEvenDiskUsedCount;
 import static org.junit.Assert.assertEquals;
 
 /** Tests for {@link SSDOnlyLocalFileMapPartitionFactory}. */
@@ -71,5 +72,22 @@ public class SSDOnlyLocalFileMapPartitionFactoryTest {
                     storageMeta.getStoragePath());
             assertEquals(StorageType.SSD, storageMeta.getStorageType());
         }
+    }
+
+    @Test
+    public void testAllDisksWillBeUsed() {
+        SSDOnlyLocalFileMapPartitionFactory partitionFactory =
+                new SSDOnlyLocalFileMapPartitionFactory();
+        Properties properties = new Properties();
+        properties.setProperty(
+                StorageOptions.STORAGE_LOCAL_DATA_DIRS.key(),
+                String.format(
+                        "[SSD]%s,[SSD]%s",
+                        temporaryFolder1.getRoot().getAbsolutePath(),
+                        temporaryFolder2.getRoot().getAbsolutePath()));
+        partitionFactory.initialize(new Configuration(properties));
+
+        expectedEvenDiskUsedCount(
+                partitionFactory, temporaryFolder1, temporaryFolder2, StorageType.SSD);
     }
 }

--- a/shuffle-storage/src/test/java/com/alibaba/flink/shuffle/storage/partition/TestMapPartition.java
+++ b/shuffle-storage/src/test/java/com/alibaba/flink/shuffle/storage/partition/TestMapPartition.java
@@ -66,6 +66,11 @@ public class TestMapPartition extends BaseMapPartition {
     }
 
     @Override
+    public long totalBytes() {
+        return 0;
+    }
+
+    @Override
     protected DataPartitionReader getDataPartitionReader(
             int startPartitionIndex,
             int endPartitionIndex,

--- a/shuffle-transfer/src/test/java/com/alibaba/flink/shuffle/transfer/utils/NoOpPartitionedDataStore.java
+++ b/shuffle-transfer/src/test/java/com/alibaba/flink/shuffle/transfer/utils/NoOpPartitionedDataStore.java
@@ -34,6 +34,8 @@ import com.alibaba.flink.shuffle.core.storage.WritingViewContext;
 
 import javax.annotation.Nullable;
 
+import java.util.Set;
+
 /** An empty partitioned data store used for tests. */
 public class NoOpPartitionedDataStore implements PartitionedDataStore {
 
@@ -71,6 +73,11 @@ public class NoOpPartitionedDataStore implements PartitionedDataStore {
     public void releaseDataByJobID(JobID jobID, @Nullable Throwable throwable) {}
 
     @Override
+    public long numDataPartitionTotalBytes() {
+        return 0;
+    }
+
+    @Override
     public void shutDown(boolean releaseData) {}
 
     @Override
@@ -95,6 +102,16 @@ public class NoOpPartitionedDataStore implements PartitionedDataStore {
 
     @Override
     public SingleThreadExecutorPool getExecutorPool(StorageMeta storageMeta) {
+        return null;
+    }
+
+    @Override
+    public Set<StorageMeta> getHddStorageMetas() {
+        return null;
+    }
+
+    @Override
+    public Set<StorageMeta> getSsdStorageMetas() {
         return null;
     }
 }


### PR DESCRIPTION
<!--

*Thank you very much for contributing to remote-shuffle-service-for-flink. To help the community review your issue or contribution in the best possible way，please take a few minutes to fulfill following items.*

-->

## What is the purpose of the change

The current strategy of selecting workers in AssignmentTrackerImpl#requestShuffleResource is to give priority to the workers with the least number of data partitions, but this selection strategy is not balanced enough. This patch introduces more worker selection strategies to adapt to more usage scenarios and improve performance.


## Brief change log

  - *Abstracts data partition worker selection strategy.*
  - *Introduces more selection strategies, including random strategy, round-robin strategy, mini-number strategy.*


## Verifying this change

This change added tests.
