### PR TITLE
[FRS-28] Introduce a simple disk health checker to automatically detect and remove unhealthy disks

### DIFF
--- a/shuffle-coordinator/src/main/java/com/alibaba/flink/shuffle/coordinator/worker/checker/ShuffleWorkerCheckerImpl.java
+++ b/shuffle-coordinator/src/main/java/com/alibaba/flink/shuffle/coordinator/worker/checker/ShuffleWorkerCheckerImpl.java
@@ -121,17 +121,26 @@ public class ShuffleWorkerCheckerImpl implements ShuffleWorkerChecker {
     private class StorageCheckRunnable implements Runnable {
         @Override
         public void run() {
+            long start = System.nanoTime();
+
+            try {
+                numTotalPartitionFileBytes = dataStore.numDataPartitionTotalBytes();
+            } catch (Throwable t) {
+                LOG.error("Failed to update the data size.", t);
+            }
+
+            try {
+                dataStore.updateStorageHealthStatus();
+            } catch (Throwable t) {
+                LOG.error("Failed to update the health status.", t);
+            }
+
             try {
                 updateStorageUsableSpaces();
             } catch (Throwable t) {
-                LOG.error("Failed to update the usable spaces,", t);
+                LOG.error("Failed to update the usable spaces.", t);
             }
-        }
 
-        private void updateStorageUsableSpaces() {
-            long start = System.nanoTime();
-            updateUsableStorageSpace();
-            numTotalPartitionFileBytes = dataStore.numDataPartitionTotalBytes();
             LOG.info(
                     "Update data store info in {} ms, max usable space, HDD: {}({}), SSD:{}({}), "
                             + "total partition file bytes: {}({}).",
@@ -144,7 +153,7 @@ public class ShuffleWorkerCheckerImpl implements ShuffleWorkerChecker {
                     numTotalPartitionFileBytes);
         }
 
-        private void updateUsableStorageSpace() {
+        private void updateStorageUsableSpaces() {
             dataStore.updateUsableStorageSpace();
             UsableStorageSpaceInfo usableSpace =
                     dataStore

--- a/shuffle-coordinator/src/test/java/com/alibaba/flink/shuffle/coordinator/utils/EmptyPartitionedDataStore.java
+++ b/shuffle-coordinator/src/test/java/com/alibaba/flink/shuffle/coordinator/utils/EmptyPartitionedDataStore.java
@@ -109,6 +109,9 @@ public class EmptyPartitionedDataStore implements PartitionedDataStore {
     public void updateUsableStorageSpace() {}
 
     @Override
+    public void updateStorageHealthStatus() {}
+
+    @Override
     public Map<String, UsableStorageSpaceInfo> getUsableStorageSpace() {
         return new HashMap<>();
     }

--- a/shuffle-core/src/main/java/com/alibaba/flink/shuffle/core/storage/DataPartitionFactory.java
+++ b/shuffle-core/src/main/java/com/alibaba/flink/shuffle/core/storage/DataPartitionFactory.java
@@ -83,6 +83,12 @@ public interface DataPartitionFactory {
     /** Whether the given usable storage space is enough for this data partition factory. */
     boolean isUsableStorageSpaceEnough(UsableStorageSpaceInfo usableSpace, long reservedSpaceBytes);
 
+    /**
+     * Checks the health status of the underlying storage. It will remove the unhealthy storage and
+     * add the healthy storage back.
+     */
+    void updateStorageHealthStatus();
+
     /** Whether this partition factory only uses SSD as storage device. */
     boolean useSsdOnly();
 

--- a/shuffle-core/src/main/java/com/alibaba/flink/shuffle/core/storage/PartitionedDataStore.java
+++ b/shuffle-core/src/main/java/com/alibaba/flink/shuffle/core/storage/PartitionedDataStore.java
@@ -139,6 +139,12 @@ public interface PartitionedDataStore {
     /** Updates the available storage space information for the target shuffle worker. */
     void updateUsableStorageSpace();
 
+    /**
+     * Checks the health status of the underlying storage. It will remove the unhealthy storage and
+     * add the healthy storage back.
+     */
+    void updateStorageHealthStatus();
+
     /** Gets the available storage space information for the target shuffle worker. */
     Map<String, UsableStorageSpaceInfo> getUsableStorageSpace();
 }

--- a/shuffle-core/src/main/java/com/alibaba/flink/shuffle/core/storage/UsableStorageSpaceInfo.java
+++ b/shuffle-core/src/main/java/com/alibaba/flink/shuffle/core/storage/UsableStorageSpaceInfo.java
@@ -26,16 +26,16 @@ import java.io.Serializable;
 @NotThreadSafe
 public class UsableStorageSpaceInfo implements Serializable {
 
+    private static final long serialVersionUID = 8761204897411057994L;
+
     public static final UsableStorageSpaceInfo ZERO_USABLE_SPACE = new UsableStorageSpaceInfo(0, 0);
 
     public static final UsableStorageSpaceInfo INFINITE_USABLE_SPACE =
             new UsableStorageSpaceInfo(Long.MAX_VALUE, Long.MAX_VALUE);
 
-    private static final long serialVersionUID = 8761204897411057994L;
+    private volatile long ssdUsableSpaceBytes;
 
-    private long ssdUsableSpaceBytes;
-
-    private long hddUsableSpaceBytes;
+    private volatile long hddUsableSpaceBytes;
 
     public UsableStorageSpaceInfo(long hddUsableSpaceBytes, long ssdUsableSpaceBytes) {
         this.hddUsableSpaceBytes = hddUsableSpaceBytes;

--- a/shuffle-storage/src/main/java/com/alibaba/flink/shuffle/storage/datastore/PartitionedDataStoreImpl.java
+++ b/shuffle-storage/src/main/java/com/alibaba/flink/shuffle/storage/datastore/PartitionedDataStoreImpl.java
@@ -644,22 +644,25 @@ public class PartitionedDataStoreImpl implements PartitionedDataStore {
 
     @Override
     public void updateUsableStorageSpace() {
-        synchronized (lock) {
-            for (DataPartitionFactory partitionFactory : partitionFactories.values()) {
-                partitionFactory.updateUsableStorageSpace();
-            }
+        for (DataPartitionFactory partitionFactory : partitionFactories.values()) {
+            partitionFactory.updateUsableStorageSpace();
         }
     }
 
     @Override
     public Map<String, UsableStorageSpaceInfo> getUsableStorageSpace() {
         Map<String, UsableStorageSpaceInfo> usableSpace = new HashMap<>();
-        synchronized (lock) {
-            for (Map.Entry<String, DataPartitionFactory> entry : partitionFactories.entrySet()) {
-                usableSpace.put(entry.getKey(), entry.getValue().getUsableStorageSpace());
-            }
+        for (Map.Entry<String, DataPartitionFactory> entry : partitionFactories.entrySet()) {
+            usableSpace.put(entry.getKey(), entry.getValue().getUsableStorageSpace());
         }
         return usableSpace;
+    }
+
+    @Override
+    public void updateStorageHealthStatus() {
+        for (DataPartitionFactory partitionFactory : partitionFactories.values()) {
+            partitionFactory.updateStorageHealthStatus();
+        }
     }
 
     // ---------------------------------------------------------------------------------------------

--- a/shuffle-storage/src/main/java/com/alibaba/flink/shuffle/storage/partition/LocalFileStorageMeta.java
+++ b/shuffle-storage/src/main/java/com/alibaba/flink/shuffle/storage/partition/LocalFileStorageMeta.java
@@ -1,0 +1,81 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.flink.shuffle.storage.partition;
+
+import com.alibaba.flink.shuffle.common.utils.CommonUtils;
+import com.alibaba.flink.shuffle.core.storage.StorageMeta;
+import com.alibaba.flink.shuffle.core.storage.StorageType;
+import com.alibaba.flink.shuffle.storage.utils.IOUtils;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.channels.FileChannel;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+/** {@link StorageMeta} for local file system. */
+public class LocalFileStorageMeta extends StorageMeta {
+
+    private static final long serialVersionUID = 6742470314776719614L;
+
+    private static final Logger LOG = LoggerFactory.getLogger(LocalFileStorageMeta.class);
+
+    private static final String HEALTH_CHECK_FILE_SUFFIX = ".health_check";
+
+    public LocalFileStorageMeta(String storagePath, StorageType storageType) {
+        super(storagePath, storageType);
+    }
+
+    @Override
+    public long updateUsableStorageSpace() {
+        numUsableSpaceBytes = Paths.get(storagePath).toFile().getUsableSpace();
+        return numUsableSpaceBytes;
+    }
+
+    @Override
+    public void updateStorageHealthStatus() {
+        CommonUtils.checkState(storagePath.endsWith("/"), "Storage path must end with '/'.");
+        Path path =
+                new File(storagePath + CommonUtils.randomHexString(32) + HEALTH_CHECK_FILE_SUFFIX)
+                        .toPath();
+        FileChannel file = null;
+        try {
+            file = IOUtils.createWritableFileChannel(path);
+            file.close();
+            if (!Files.isWritable(path) || !Files.isReadable(path)) {
+                throw new IOException("File is not readable/writable.");
+            }
+            Files.delete(path);
+            isHealthy = true;
+        } catch (Throwable throwable) {
+            isHealthy = false;
+            LOG.warn("Found unhealthy storage: {}.", this, throwable);
+
+            if (file == null) {
+                return;
+            }
+            CommonUtils.runQuietly(file::close);
+            CommonUtils.runQuietly(() -> Files.deleteIfExists(path));
+        }
+    }
+}

--- a/shuffle-storage/src/test/java/com/alibaba/flink/shuffle/storage/datastore/NoOpPartitionedDataStore.java
+++ b/shuffle-storage/src/test/java/com/alibaba/flink/shuffle/storage/datastore/NoOpPartitionedDataStore.java
@@ -122,6 +122,9 @@ public class NoOpPartitionedDataStore implements PartitionedDataStore {
     public void updateUsableStorageSpace() {}
 
     @Override
+    public void updateStorageHealthStatus() {}
+
+    @Override
     public Map<String, UsableStorageSpaceInfo> getUsableStorageSpace() {
         return null;
     }

--- a/shuffle-transfer/src/test/java/com/alibaba/flink/shuffle/transfer/utils/NoOpPartitionedDataStore.java
+++ b/shuffle-transfer/src/test/java/com/alibaba/flink/shuffle/transfer/utils/NoOpPartitionedDataStore.java
@@ -110,6 +110,9 @@ public class NoOpPartitionedDataStore implements PartitionedDataStore {
     public void updateUsableStorageSpace() {}
 
     @Override
+    public void updateStorageHealthStatus() {}
+
+    @Override
     public Map<String, UsableStorageSpaceInfo> getUsableStorageSpace() {
         return null;
     }


### PR DESCRIPTION
## What is the purpose of the change

This solves #28 . A simple disk health checker is introduced to automatically detect and remove unhealthy disks.

## Brief change log

  - Introduce a simple disk health checker to automatically detect and remove unhealthy disks. It works by creating new file, check readability/writability and delete the file. The corresponding disk will be marked as unhealthy if any operation fails.

## Verifying this change

This change added tests.
