### PR TITLE
[FRS-34] Adapt to Flink 1.15

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -49,7 +49,7 @@ under the License.
 	</repositories>
 
 	<properties>
-		<scala.binary.version>2.11</scala.binary.version>
+		<scala.binary.version>2.12</scala.binary.version>
 		<flink.shaded.version>13.0</flink.shaded.version>
 		<log4j.version>2.17.0</log4j.version>
 		<junit.version>4.13</junit.version>
@@ -65,11 +65,11 @@ under the License.
 		<jackson.version>2.12.1</jackson.version>
 		<snakeyaml.version>1.27</snakeyaml.version>
 		<curator.version>5.2.0</curator.version>
-		<hadoop.version>2.4.1</hadoop.version>
+		<hadoop.version>2.8.5</hadoop.version>
 		<alibaba.metrics.version>2.0.6</alibaba.metrics.version>
 		<commons.cli.version>1.3.1</commons.cli.version>
 		<zookeeper.version>3.5.9</zookeeper.version>
-		<flink.version>1.14.0</flink.version>
+		<flink.version>1.15-SNAPSHOT</flink.version>
 		<rpc.flink.version>1.14.0</rpc.flink.version>
 		<jetty.version>9.4.44.v20210927</jetty.version>
 		<http.client.version>4.5.13</http.client.version>

--- a/pom.xml
+++ b/pom.xml
@@ -34,6 +34,20 @@ under the License.
 		</license>
 	</licenses>
 
+	<repositories>
+		<repository>
+			<id>apache.snapshots</id>
+			<name>Apache Development Snapshot Repository</name>
+			<url>https://repository.apache.org/content/repositories/snapshots/</url>
+			<releases>
+				<enabled>false</enabled>
+			</releases>
+			<snapshots>
+				<enabled>true</enabled>
+			</snapshots>
+		</repository>
+	</repositories>
+
 	<properties>
 		<scala.binary.version>2.11</scala.binary.version>
 		<flink.shaded.version>13.0</flink.shaded.version>

--- a/shuffle-e2e-tests/pom.xml
+++ b/shuffle-e2e-tests/pom.xml
@@ -69,7 +69,7 @@ under the License.
 
 		<dependency>
 			<groupId>org.apache.flink</groupId>
-			<artifactId>flink-streaming-java_${scala.binary.version}</artifactId>
+			<artifactId>flink-streaming-java</artifactId>
 			<version>${flink.version}</version>
 			<scope>provided</scope>
 		</dependency>
@@ -83,7 +83,7 @@ under the License.
 
 		<dependency>
 			<groupId>org.apache.flink</groupId>
-			<artifactId>flink-clients_${scala.binary.version}</artifactId>
+			<artifactId>flink-clients</artifactId>
 			<version>${flink.version}</version>
 			<scope>provided</scope>
 		</dependency>

--- a/shuffle-e2e-tests/src/main/java/com/alibaba/flink/shuffle/e2e/TPCDSE2E.java
+++ b/shuffle-e2e-tests/src/main/java/com/alibaba/flink/shuffle/e2e/TPCDSE2E.java
@@ -38,8 +38,7 @@ public class TPCDSE2E {
         int parallelism = Integer.valueOf(args[1]);
         LOG.info("Running E2E under TPCDS: {}.", tpcdsHome);
 
-        EnvironmentSettings settings =
-                EnvironmentSettings.newInstance().useBlinkPlanner().inBatchMode().build();
+        EnvironmentSettings settings = EnvironmentSettings.newInstance().inBatchMode().build();
         TableEnvironment stEnv = TableEnvironment.create(settings);
         Configuration configuration = stEnv.getConfig().getConfiguration();
         configuration.setInteger("table.exec.resource.default-parallelism", parallelism);

--- a/shuffle-e2e-tests/src/test/java/com/alibaba/flink/shuffle/e2e/JobForShuffleTesting.java
+++ b/shuffle-e2e-tests/src/test/java/com/alibaba/flink/shuffle/e2e/JobForShuffleTesting.java
@@ -157,6 +157,7 @@ public class JobForShuffleTesting {
 
         StreamExecutionEnvironment env = createRemoteEnvironment("localhost", 1337, config);
         env.setParallelism(parallelism);
+        env.setBufferTimeout(-1);
 
         TupleTypeInfo<Tuple2<Long, Long>> typeInfo =
                 new TupleTypeInfo<>(BasicTypeInfo.LONG_TYPE_INFO, BasicTypeInfo.LONG_TYPE_INFO);

--- a/shuffle-e2e-tests/src/test/java/com/alibaba/flink/shuffle/e2e/flinkcluster/TaskManagerProcess.java
+++ b/shuffle-e2e-tests/src/test/java/com/alibaba/flink/shuffle/e2e/flinkcluster/TaskManagerProcess.java
@@ -31,6 +31,7 @@ import org.apache.flink.runtime.blob.BlobCacheService;
 import org.apache.flink.runtime.clusterframework.TaskExecutorProcessSpec;
 import org.apache.flink.runtime.clusterframework.TaskExecutorProcessUtils;
 import org.apache.flink.runtime.clusterframework.types.ResourceID;
+import org.apache.flink.runtime.entrypoint.WorkingDirectory;
 import org.apache.flink.runtime.externalresource.ExternalResourceInfoProvider;
 import org.apache.flink.runtime.heartbeat.HeartbeatServices;
 import org.apache.flink.runtime.highavailability.HighAvailabilityServices;
@@ -152,6 +153,7 @@ public class TaskManagerProcess extends TestJvmProcess {
                 BlobCacheService blobCacheService,
                 boolean localCommunicationOnly,
                 ExternalResourceInfoProvider externalResourceInfoProvider,
+                WorkingDirectory workingDirectory,
                 FatalErrorHandler fatalErrorHandler)
                 throws Exception {
 
@@ -166,6 +168,7 @@ public class TaskManagerProcess extends TestJvmProcess {
                             blobCacheService,
                             localCommunicationOnly,
                             externalResourceInfoProvider,
+                            workingDirectory,
                             fatalErrorHandler);
             startMetricsReportingDaemon(configuration, taskExecutor);
             return TaskExecutorToServiceAdapter.createFor(taskExecutor);

--- a/shuffle-examples/pom.xml
+++ b/shuffle-examples/pom.xml
@@ -30,7 +30,7 @@ under the License.
 	<dependencies>
 		<dependency>
 			<groupId>org.apache.flink</groupId>
-			<artifactId>flink-streaming-java_${scala.binary.version}</artifactId>
+			<artifactId>flink-streaming-java</artifactId>
 			<version>${flink.version}</version>
 			<scope>provided</scope>
 		</dependency>

--- a/shuffle-examples/src/main/java/com/alibaba/flink/shuffle/examples/BatchJobDemo.java
+++ b/shuffle-examples/src/main/java/com/alibaba/flink/shuffle/examples/BatchJobDemo.java
@@ -39,6 +39,7 @@ public class BatchJobDemo {
         int numRecordsToSend = 1024;
         StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
         env.setParallelism(parallelism);
+        env.setBufferTimeout(-1);
         DataStream<byte[]> source =
                 env.addSource(new ByteArraySource(numRecordsToSend, recordSize, numRecords));
         source.rebalance()

--- a/shuffle-plugin/pom.xml
+++ b/shuffle-plugin/pom.xml
@@ -127,7 +127,7 @@ under the License.
 
 		<dependency>
 			<groupId>org.apache.flink</groupId>
-			<artifactId>flink-streaming-java_${scala.binary.version}</artifactId>
+			<artifactId>flink-streaming-java</artifactId>
 			<version>${flink.version}</version>
 			<scope>test</scope>
 		</dependency>

--- a/shuffle-plugin/src/main/java/com/alibaba/flink/shuffle/plugin/transfer/RemoteShuffleInputGate.java
+++ b/shuffle-plugin/src/main/java/com/alibaba/flink/shuffle/plugin/transfer/RemoteShuffleInputGate.java
@@ -37,6 +37,7 @@ import org.apache.flink.runtime.checkpoint.channel.ChannelStateWriter;
 import org.apache.flink.runtime.checkpoint.channel.InputChannelInfo;
 import org.apache.flink.runtime.checkpoint.channel.ResultSubpartitionInfo;
 import org.apache.flink.runtime.deployment.InputGateDeploymentDescriptor;
+import org.apache.flink.runtime.deployment.SubpartitionIndexRange;
 import org.apache.flink.runtime.event.AbstractEvent;
 import org.apache.flink.runtime.event.TaskEvent;
 import org.apache.flink.runtime.io.network.ConnectionID;
@@ -44,6 +45,7 @@ import org.apache.flink.runtime.io.network.LocalConnectionManager;
 import org.apache.flink.runtime.io.network.api.CheckpointBarrier;
 import org.apache.flink.runtime.io.network.api.EndOfData;
 import org.apache.flink.runtime.io.network.api.EndOfPartitionEvent;
+import org.apache.flink.runtime.io.network.api.StopMode;
 import org.apache.flink.runtime.io.network.api.serialization.EventSerializer;
 import org.apache.flink.runtime.io.network.buffer.Buffer;
 import org.apache.flink.runtime.io.network.buffer.BufferDecompressor;
@@ -57,8 +59,10 @@ import org.apache.flink.runtime.io.network.partition.consumer.RemoteInputChannel
 import org.apache.flink.runtime.io.network.partition.consumer.SingleInputGate;
 import org.apache.flink.runtime.jobgraph.IntermediateDataSetID;
 import org.apache.flink.runtime.shuffle.ShuffleDescriptor;
+import org.apache.flink.runtime.throughput.ThroughputCalculator;
 import org.apache.flink.util.CloseableIterator;
 import org.apache.flink.util.FlinkRuntimeException;
+import org.apache.flink.util.clock.SystemClock;
 import org.apache.flink.util.function.SupplierWithException;
 
 import org.apache.flink.shaded.netty4.io.netty.buffer.ByteBuf;
@@ -157,6 +161,9 @@ public class RemoteShuffleInputGate extends IndexedInputGate {
     /** Number of pending {@link EndOfData} events to be received. */
     private long pendingEndOfDataEvents;
 
+    /** Keep compatibility with streaming mode. */
+    private boolean shouldDrainOnEndOfData = true;
+
     public RemoteShuffleInputGate(
             String taskName,
             boolean shuffleChannels,
@@ -187,8 +194,8 @@ public class RemoteShuffleInputGate extends IndexedInputGate {
     }
 
     private long initShuffleReadClients(int bufferSize, boolean shuffleChannels) {
-        int startSubIdx = gateDescriptor.getConsumedSubpartitionIndex();
-        int endSubIdx = gateDescriptor.getConsumedSubpartitionIndex();
+        int startSubIdx = gateDescriptor.getConsumedSubpartitionIndexRange().getStartIndex();
+        int endSubIdx = gateDescriptor.getConsumedSubpartitionIndexRange().getEndIndex();
         checkState(endSubIdx >= startSubIdx);
         int numSubpartitionsPerChannel = endSubIdx - startSubIdx + 1;
         long numUnconsumedSubpartitions = 0;
@@ -584,8 +591,9 @@ public class RemoteShuffleInputGate extends IndexedInputGate {
                 }
             }
         } else if (event.getClass() == EndOfData.class) {
-            CommonUtils.checkState(!hasReceivedEndOfData());
+            CommonUtils.checkState(pendingEndOfDataEvents > 0, "Too many EndOfData event.");
             --pendingEndOfDataEvents;
+            shouldDrainOnEndOfData &= ((EndOfData) event).getStopMode() == StopMode.DRAIN;
         }
 
         return Optional.of(
@@ -633,17 +641,20 @@ public class RemoteShuffleInputGate extends IndexedInputGate {
     }
 
     @Override
-    public int getBuffersInUseCount() {
-        return 0;
+    public void triggerDebloating() {
+        // do-nothing.
     }
 
     @Override
-    public boolean hasReceivedEndOfData() {
-        return pendingEndOfDataEvents <= 0;
+    public EndOfDataStatus hasReceivedEndOfData() {
+        if (pendingEndOfDataEvents > 0) {
+            return EndOfDataStatus.NOT_END_OF_DATA;
+        } else if (shouldDrainOnEndOfData) {
+            return EndOfDataStatus.DRAINED;
+        } else {
+            return EndOfDataStatus.STOPPED;
+        }
     }
-
-    @Override
-    public void announceBufferSize(int bufferSize) {}
 
     @Override
     public void finishReadRecoveredState() {
@@ -689,15 +700,18 @@ public class RemoteShuffleInputGate extends IndexedInputGate {
                             gateIndex,
                             new IntermediateDataSetID(),
                             ResultPartitionType.BLOCKING,
-                            0,
+                            new SubpartitionIndexRange(0, 0),
                             1,
                             (a, b, c) -> {},
                             () -> null,
                             null,
                             new FakedMemorySegmentProvider(),
-                            0),
+                            0,
+                            new ThroughputCalculator(SystemClock.getInstance()),
+                            null),
                     channelIndex,
                     new ResultPartitionID(),
+                    0,
                     new ConnectionID(new InetSocketAddress("", 0), 0),
                     new LocalConnectionManager(),
                     0,
@@ -712,12 +726,12 @@ public class RemoteShuffleInputGate extends IndexedInputGate {
     /** Accommodation for the incompleteness of Flink pluggable shuffle service. */
     private static class FakedMemorySegmentProvider implements MemorySegmentProvider {
         @Override
-        public Collection<MemorySegment> requestMemorySegments(int i) {
+        public Collection<MemorySegment> requestUnpooledMemorySegments(int i) {
             return null;
         }
 
         @Override
-        public void recycleMemorySegments(Collection<MemorySegment> collection) {}
+        public void recycleUnpooledMemorySegments(Collection<MemorySegment> collection) {}
     }
 
     /** Accommodation for the incompleteness of Flink pluggable shuffle service. */

--- a/shuffle-plugin/src/test/java/com/alibaba/flink/shuffle/plugin/itcase/AdaptiveBatchJobSchedulerITCase.java
+++ b/shuffle-plugin/src/test/java/com/alibaba/flink/shuffle/plugin/itcase/AdaptiveBatchJobSchedulerITCase.java
@@ -1,0 +1,144 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.flink.shuffle.plugin.itcase;
+
+import org.apache.flink.api.common.JobID;
+import org.apache.flink.api.common.RuntimeExecutionMode;
+import org.apache.flink.api.common.functions.RichMapFunction;
+import org.apache.flink.configuration.JobManagerOptions;
+import org.apache.flink.configuration.MemorySize;
+import org.apache.flink.runtime.jobgraph.JobGraph;
+import org.apache.flink.runtime.jobgraph.JobType;
+import org.apache.flink.runtime.jobmaster.JobResult;
+import org.apache.flink.streaming.api.datastream.DataStream;
+import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
+import org.apache.flink.streaming.api.graph.GlobalStreamExchangeMode;
+import org.apache.flink.streaming.api.graph.StreamGraph;
+import org.apache.flink.streaming.api.graph.StreamingJobGraphGenerator;
+
+import org.junit.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import java.util.stream.LongStream;
+
+import static org.junit.Assert.assertEquals;
+
+/** IT case for adaptive batch scheduler. */
+public class AdaptiveBatchJobSchedulerITCase extends BatchJobITCaseBase {
+
+    private static final int DEFAULT_MAX_PARALLELISM = 4;
+    private static final int SOURCE_PARALLELISM_1 = 2;
+    private static final int SOURCE_PARALLELISM_2 = 8;
+    private static final int NUMBERS_TO_PRODUCE = 10000;
+
+    private static ConcurrentLinkedQueue<Map<Long, Long>> numberCountResults;
+
+    private Map<Long, Long> expectedResult;
+
+    @Override
+    public void setup() {
+        expectedResult =
+                LongStream.range(0, NUMBERS_TO_PRODUCE)
+                        .boxed()
+                        .collect(Collectors.toMap(Function.identity(), i -> 2L));
+
+        numberCountResults = new ConcurrentLinkedQueue<>();
+
+        // adaptive batch job scheduler config.
+        flinkConfiguration.set(
+                JobManagerOptions.SCHEDULER, JobManagerOptions.SchedulerType.AdaptiveBatch);
+        flinkConfiguration.setInteger(
+                JobManagerOptions.ADAPTIVE_BATCH_SCHEDULER_MAX_PARALLELISM,
+                DEFAULT_MAX_PARALLELISM);
+        flinkConfiguration.set(
+                JobManagerOptions.ADAPTIVE_BATCH_SCHEDULER_AVG_DATA_VOLUME_PER_TASK,
+                MemorySize.parse("256k"));
+    }
+
+    @Test
+    public void testAdaptiveBatchJobScheduler() throws Exception {
+        executeJob();
+
+        Map<Long, Long> numberCountResultMap =
+                numberCountResults.stream()
+                        .flatMap(map -> map.entrySet().stream())
+                        .collect(
+                                Collectors.toMap(
+                                        Map.Entry::getKey, Map.Entry::getValue, Long::sum));
+        assertEquals(expectedResult, numberCountResultMap);
+    }
+
+    private void executeJob() throws Exception {
+        final StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
+        env.setParallelism(-1);
+        env.setBufferTimeout(-1);
+        env.setRuntimeMode(RuntimeExecutionMode.BATCH);
+
+        final DataStream<Long> source1 =
+                env.fromSequence(0, NUMBERS_TO_PRODUCE - 1)
+                        .setParallelism(SOURCE_PARALLELISM_1)
+                        .name("source1")
+                        .slotSharingGroup("group1");
+
+        final DataStream<Long> source2 =
+                env.fromSequence(0, NUMBERS_TO_PRODUCE - 1)
+                        .setParallelism(SOURCE_PARALLELISM_2)
+                        .name("source2")
+                        .slotSharingGroup("group2");
+
+        source1.union(source2)
+                .rescale()
+                .map(new NumberCounter())
+                .name("map")
+                .slotSharingGroup("group3");
+
+        StreamGraph streamGraph = env.getStreamGraph();
+        streamGraph.setGlobalStreamExchangeMode(GlobalStreamExchangeMode.ALL_EDGES_BLOCKING);
+        streamGraph.setJobType(JobType.BATCH);
+        JobGraph jobGraph = StreamingJobGraphGenerator.createJobGraph(streamGraph);
+        JobID jobID = flinkCluster.submitJob(jobGraph).get().getJobID();
+        JobResult jobResult = flinkCluster.requestJobResult(jobID).get();
+        if (jobResult.getSerializedThrowable().isPresent()) {
+            throw new AssertionError(jobResult.getSerializedThrowable().get());
+        }
+    }
+
+    private static class NumberCounter extends RichMapFunction<Long, Long> {
+
+        private static final long serialVersionUID = -3329103026044705105L;
+
+        private final Map<Long, Long> numberCountResult = new HashMap<>();
+
+        @Override
+        public Long map(Long value) throws Exception {
+            numberCountResult.put(value, numberCountResult.getOrDefault(value, 0L) + 1L);
+
+            return value;
+        }
+
+        @Override
+        public void close() throws Exception {
+            numberCountResults.add(numberCountResult);
+        }
+    }
+}

--- a/shuffle-plugin/src/test/java/com/alibaba/flink/shuffle/plugin/itcase/AdaptiveBatchJobSchedulerWithForwardEdgeITCase.java
+++ b/shuffle-plugin/src/test/java/com/alibaba/flink/shuffle/plugin/itcase/AdaptiveBatchJobSchedulerWithForwardEdgeITCase.java
@@ -1,0 +1,156 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.flink.shuffle.plugin.itcase;
+
+import org.apache.flink.api.common.JobID;
+import org.apache.flink.api.common.RuntimeExecutionMode;
+import org.apache.flink.configuration.JobManagerOptions;
+import org.apache.flink.configuration.MemorySize;
+import org.apache.flink.runtime.jobgraph.JobGraph;
+import org.apache.flink.runtime.jobgraph.JobType;
+import org.apache.flink.runtime.jobmaster.JobResult;
+import org.apache.flink.streaming.api.datastream.DataStream;
+import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
+import org.apache.flink.streaming.api.functions.sink.SinkFunction;
+import org.apache.flink.streaming.api.graph.GlobalStreamExchangeMode;
+import org.apache.flink.streaming.api.graph.StreamGraph;
+import org.apache.flink.streaming.api.graph.StreamingJobGraphGenerator;
+
+import org.junit.Test;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import java.util.stream.LongStream;
+
+import static org.junit.Assert.assertEquals;
+
+/** IT case for adaptive batch scheduler which covers cases with forward edge. */
+public class AdaptiveBatchJobSchedulerWithForwardEdgeITCase extends BatchJobITCaseBase {
+
+    private static final int DEFAULT_MAX_PARALLELISM = 100;
+    private static final int SOURCE_PARALLELISM_1 = 8;
+    private static final int SOURCE_PARALLELISM_2 = 12;
+    private static final int NUMBERS_TO_PRODUCE = 10000;
+
+    @Override
+    void setup() {
+        CountSink.countResults.clear();
+
+        // adaptive batch job scheduler config.
+        flinkConfiguration.set(
+                JobManagerOptions.SCHEDULER, JobManagerOptions.SchedulerType.AdaptiveBatch);
+        flinkConfiguration.setInteger(
+                JobManagerOptions.ADAPTIVE_BATCH_SCHEDULER_MAX_PARALLELISM,
+                DEFAULT_MAX_PARALLELISM);
+        flinkConfiguration.set(
+                JobManagerOptions.ADAPTIVE_BATCH_SCHEDULER_AVG_DATA_VOLUME_PER_TASK,
+                MemorySize.parse("128k"));
+        numTaskManagers = 5;
+        numSlotsPerTaskManager = 2;
+    }
+
+    @Test
+    public void testAdaptiveBatchJobSchedulerWithForwardEdge() throws Exception {
+        final StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
+        env.setParallelism(-1);
+        env.setBufferTimeout(-1);
+        env.setRuntimeMode(RuntimeExecutionMode.BATCH);
+
+        JobGraph jobGraph = createJobGraph(env);
+
+        JobID jobID = flinkCluster.submitJob(jobGraph).get().getJobID();
+        JobResult jobResult = flinkCluster.requestJobResult(jobID).get();
+        if (jobResult.getSerializedThrowable().isPresent()) {
+            throw new AssertionError(jobResult.getSerializedThrowable().get());
+        }
+        checkCountResults();
+    }
+
+    private static void checkCountResults() {
+        Map<Long, Long> countResults = CountSink.countResults;
+
+        Map<Long, Long> expectedResults =
+                LongStream.range(0, NUMBERS_TO_PRODUCE)
+                        .boxed()
+                        .collect(Collectors.toMap(Function.identity(), i -> 2L));
+
+        assertEquals(countResults.size(), NUMBERS_TO_PRODUCE);
+        assertEquals(countResults, expectedResults);
+    }
+
+    /**
+     * Create job vertices and connect them as the following JobGraph:
+     *
+     * <pre>
+     *             hash               forward
+     * 	source1 ----------> middle -----------> sink
+     * 	                                        /
+     * 	                    hash               /
+     *  source2 ----------------------------->/
+     *
+     * </pre>
+     *
+     * <p>All edges are BLOCKING. Edge (source1 --> middle) is hash. Edge (middle --> sink) is
+     * forward. Edge (source2 --> sink) is hash.
+     */
+    private JobGraph createJobGraph(StreamExecutionEnvironment env) throws Exception {
+
+        final DataStream<Long> source1 =
+                env.fromSequence(0, NUMBERS_TO_PRODUCE - 1)
+                        .setParallelism(SOURCE_PARALLELISM_1)
+                        .name("source1")
+                        .slotSharingGroup("group1");
+
+        final DataStream<Long> source2 =
+                env.fromSequence(0, NUMBERS_TO_PRODUCE - 1)
+                        .setParallelism(SOURCE_PARALLELISM_2)
+                        .name("source2")
+                        .slotSharingGroup("group2");
+
+        source1.map(number -> number)
+                .name("middle")
+                .slotSharingGroup("group3")
+                .forward()
+                .union(source2)
+                .addSink(new CountSink())
+                .name("sink")
+                .slotSharingGroup("group4");
+
+        StreamGraph streamGraph = env.getStreamGraph();
+        streamGraph.setGlobalStreamExchangeMode(GlobalStreamExchangeMode.ALL_EDGES_BLOCKING);
+        streamGraph.setJobType(JobType.BATCH);
+        return StreamingJobGraphGenerator.createJobGraph(streamGraph);
+    }
+
+    private static class CountSink implements SinkFunction<Long> {
+
+        private static final long serialVersionUID = -4152019990787526775L;
+
+        private static final Map<Long, Long> countResults = new ConcurrentHashMap<>();
+
+        @Override
+        public void invoke(Long value, Context context) throws Exception {
+            synchronized (countResults) {
+                countResults.put(value, countResults.getOrDefault(value, 0L) + 1L);
+            }
+        }
+    }
+}

--- a/shuffle-plugin/src/test/java/com/alibaba/flink/shuffle/plugin/itcase/BatchJobITCaseBase.java
+++ b/shuffle-plugin/src/test/java/com/alibaba/flink/shuffle/plugin/itcase/BatchJobITCaseBase.java
@@ -122,7 +122,9 @@ public abstract class BatchJobITCaseBase {
                         .build();
 
         flinkCluster =
-                new TestingMiniCluster(miniClusterConfiguration, highAvailabilityServicesSupplier);
+                TestingMiniCluster.newBuilder(miniClusterConfiguration)
+                        .setHighAvailabilityServicesSupplier(highAvailabilityServicesSupplier)
+                        .build();
         flinkCluster.start();
     }
 

--- a/shuffle-yarn/pom.xml
+++ b/shuffle-yarn/pom.xml
@@ -60,7 +60,7 @@ under the License.
 
 		<dependency>
 			<groupId>org.apache.flink</groupId>
-			<artifactId>flink-yarn_${scala.binary.version}</artifactId>
+			<artifactId>flink-yarn</artifactId>
 			<version>${flink.version}</version>
 			<scope>test</scope>
 			<exclusions>
@@ -75,6 +75,13 @@ under the License.
 			<groupId>org.apache.flink</groupId>
 			<artifactId>flink-test-utils-junit</artifactId>
 			<version>${flink.version}</version>
+			<scope>test</scope>
+		</dependency>
+
+		<dependency>
+			<groupId>org.apache.curator</groupId>
+			<artifactId>curator-client</artifactId>
+			<version>${curator.version}</version>
 			<scope>test</scope>
 		</dependency>
 
@@ -185,7 +192,7 @@ under the License.
 		<dependency>
 			<groupId>org.apache.flink</groupId>
 			<artifactId>flink-examples-batch_${scala.binary.version}</artifactId>
-			<version>${flink.version}</version>
+			<version>${rpc.flink.version}</version>
 			<scope>test</scope>
 		</dependency>
 

--- a/shuffle-yarn/src/test/java/com/alibaba/flink/shuffle/yarn/BatchJobTestBase.java
+++ b/shuffle-yarn/src/test/java/com/alibaba/flink/shuffle/yarn/BatchJobTestBase.java
@@ -140,7 +140,9 @@ public abstract class BatchJobTestBase {
                         .build();
 
         flinkCluster =
-                new TestingMiniCluster(miniClusterConfiguration, highAvailabilityServicesSupplier);
+                TestingMiniCluster.newBuilder(miniClusterConfiguration)
+                        .setHighAvailabilityServicesSupplier(highAvailabilityServicesSupplier)
+                        .build();
         flinkCluster.start();
     }
 


### PR DESCRIPTION
## What is the purpose of the change

This solves #34 . Flink remote shuffle can work with Flink 1.15 now.

## Brief change log

  - Adapt to interface changes of Flink 1.15.
  - Upgrade the curator version and hadoop version.


## Verifying this change

This change is already covered by existing tests.
