### PR TITLE
[FRS-40] SortBuffer supports reading data from the specified channel index

### DIFF
--- a/shuffle-plugin/src/main/java/com/alibaba/flink/shuffle/plugin/transfer/SortBuffer.java
+++ b/shuffle-plugin/src/main/java/com/alibaba/flink/shuffle/plugin/transfer/SortBuffer.java
@@ -48,11 +48,31 @@ public interface SortBuffer {
      */
     BufferWithChannel copyIntoSegment(MemorySegment target, BufferRecycler recycler, int offset);
 
+    /**
+     * Copies data from this {@link SortBuffer} to the target {@link MemorySegment} of specific
+     * channel index and returns {@link BufferWithChannel} which contains the copied data and the
+     * corresponding channel index.
+     */
+    BufferWithChannel copyChannelBuffersIntoSegment(
+            MemorySegment target, int targetChannelIndex, BufferRecycler recycler, int offset);
+
+    /** Returns the sub partition read index of this {@link SortBuffer}. */
+    int getSubpartitionReadOrderIndex(int channelIndex);
+
     /** Returns the number of records written to this {@link SortBuffer}. */
     long numRecords();
 
     /** Returns the number of bytes written to this {@link SortBuffer}. */
     long numBytes();
+
+    /** Returns the number of bytes for the specific target subpartition. */
+    long numSubpartitionBytes(int targetSubpartition);
+
+    /** Returns the number of events for the specific target subpartition. */
+    int numEvents(int targetSubpartition);
+
+    /** Returns true if there is no data can be consumed for the specific target subpartition. */
+    boolean hasSubpartitionReadFinish(int targetSubpartition);
 
     /** Returns true if there is still data can be consumed in this {@link SortBuffer}. */
     boolean hasRemaining();

--- a/shuffle-plugin/src/main/java/com/alibaba/flink/shuffle/plugin/utils/BufferUtils.java
+++ b/shuffle-plugin/src/main/java/com/alibaba/flink/shuffle/plugin/utils/BufferUtils.java
@@ -31,6 +31,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 import static com.alibaba.flink.shuffle.common.utils.CommonUtils.checkArgument;
+import static com.alibaba.flink.shuffle.common.utils.CommonUtils.checkState;
 
 /** Utility methods to process flink buffers. */
 public class BufferUtils {
@@ -101,5 +102,18 @@ public class BufferUtils {
         } finally {
             buffers.forEach(bufferPool::recycle);
         }
+    }
+
+    public static int calculateSubpartitionCredit(
+            long subPartitionToSendBytes, int headerBytes, int numEvents, int networkBufferSize) {
+        checkState(subPartitionToSendBytes >= 0, "Must be non-negative.");
+        checkState(headerBytes >= 0, "Must be non-negative.");
+        if (subPartitionToSendBytes == 0) {
+            return 0;
+        }
+
+        return (int) ((subPartitionToSendBytes - headerBytes) / (networkBufferSize - 64))
+                + 2 * numEvents
+                + 1;
     }
 }

--- a/shuffle-plugin/src/test/java/com/alibaba/flink/shuffle/plugin/transfer/PartitionSortedBufferTest.java
+++ b/shuffle-plugin/src/test/java/com/alibaba/flink/shuffle/plugin/transfer/PartitionSortedBufferTest.java
@@ -18,6 +18,8 @@
 
 package com.alibaba.flink.shuffle.plugin.transfer;
 
+import com.alibaba.flink.shuffle.plugin.utils.BufferUtils;
+
 import org.apache.flink.core.memory.MemorySegment;
 import org.apache.flink.core.memory.MemorySegmentFactory;
 import org.apache.flink.runtime.io.network.buffer.Buffer;
@@ -32,9 +34,11 @@ import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.List;
 import java.util.Queue;
 import java.util.Random;
+import java.util.stream.IntStream;
 
 import static org.apache.flink.runtime.io.network.buffer.Buffer.DataType;
 import static org.junit.Assert.assertEquals;
@@ -65,13 +69,166 @@ public class PartitionSortedBufferTest {
         Arrays.fill(numBytesRead, 0);
 
         // fill the sort buffer with randomly generated data
-        int totalBytesWritten = 0;
         SortBuffer sortBuffer =
                 createSortBuffer(
                         bufferPoolSize,
                         bufferSize,
                         numSubpartitions,
                         getRandomSubpartitionOrder(numSubpartitions));
+
+        int totalBytesWritten =
+                writeDataToSortBuffer(
+                        sortBuffer,
+                        numSubpartitions,
+                        bufferSize,
+                        random,
+                        dataWritten,
+                        numBytesWritten);
+
+        // read all data from the sort buffer
+        while (sortBuffer.hasRemaining()) {
+            MemorySegment readBuffer = MemorySegmentFactory.allocateUnpooledSegment(bufferSize);
+            SortBuffer.BufferWithChannel bufferAndChannel =
+                    sortBuffer.copyIntoSegment(readBuffer, ignore -> {}, 0);
+            int subpartition = bufferAndChannel.getChannelIndex();
+            buffersRead[subpartition].add(bufferAndChannel.getBuffer());
+            numBytesRead[subpartition] += bufferAndChannel.getBuffer().readableBytes();
+        }
+
+        assertEquals(totalBytesWritten, sortBuffer.numBytes());
+        checkWriteReadResult(
+                numSubpartitions, numBytesWritten, numBytesRead, dataWritten, buffersRead);
+    }
+
+    @Test
+    public void testCalculateSubpartitionBufferCounts() throws IOException {
+        testReadSpecificChannelSortBuffer(true);
+    }
+
+    @Test
+    public void testWriteAndReadSpecificChannel() throws Exception {
+        testReadSpecificChannelSortBuffer(false);
+    }
+
+    private void testReadSpecificChannelSortBuffer(boolean checkCalculateBufferCount)
+            throws IOException {
+        int numSubpartitions = 10;
+        int bufferSize = 1024;
+        int bufferPoolSize = 1000;
+        Random random = new Random(1111);
+
+        // used to store data written to and read from sort buffer for correctness check
+        Queue<DataAndType>[] dataWritten = new Queue[numSubpartitions];
+        Queue<Buffer>[] buffersRead = new Queue[numSubpartitions];
+        for (int i = 0; i < numSubpartitions; ++i) {
+            dataWritten[i] = new ArrayDeque<>();
+            buffersRead[i] = new ArrayDeque<>();
+        }
+
+        int[] numBytesWritten = new int[numSubpartitions];
+        int[] numBytesRead = new int[numSubpartitions];
+        Arrays.fill(numBytesWritten, 0);
+        Arrays.fill(numBytesRead, 0);
+
+        // fill the sort buffer with randomly generated data
+        int[] customReadOrder = getRandomSubpartitionOrder(numSubpartitions);
+        SortBuffer sortBuffer =
+                createSortBuffer(bufferPoolSize, bufferSize, numSubpartitions, customReadOrder);
+        for (int i = 0; i < numSubpartitions; i++) {
+            assertEquals(customReadOrder[i], sortBuffer.getSubpartitionReadOrderIndex(i));
+        }
+        int totalBytesWritten =
+                writeDataToSortBuffer(
+                        sortBuffer,
+                        numSubpartitions,
+                        bufferSize,
+                        random,
+                        dataWritten,
+                        numBytesWritten);
+
+        int[] numBufferCounts = new int[numSubpartitions];
+        IntStream.range(0, numSubpartitions)
+                .forEach(
+                        i -> {
+                            assertTrue(sortBuffer.numEvents(i) > 0);
+                            numBufferCounts[i] =
+                                    BufferUtils.calculateSubpartitionCredit(
+                                            sortBuffer.numSubpartitionBytes(i),
+                                            0,
+                                            sortBuffer.numEvents(i),
+                                            bufferSize);
+                        });
+        IntStream.range(0, numSubpartitions).forEach(i -> assertTrue(sortBuffer.numEvents(i) > 0));
+        List<Integer> channels = new ArrayList<>();
+        IntStream.range(0, numSubpartitions).forEach(channels::add);
+
+        // read all data from the sort buffer
+        readDataFromSortBuffer(
+                numSubpartitions,
+                bufferSize,
+                buffersRead,
+                numBytesRead,
+                sortBuffer,
+                numBufferCounts,
+                channels,
+                checkCalculateBufferCount);
+
+        assertEquals(totalBytesWritten, sortBuffer.numBytes());
+        checkWriteReadResult(
+                numSubpartitions, numBytesWritten, numBytesRead, dataWritten, buffersRead);
+    }
+
+    private static void readDataFromSortBuffer(
+            int numSubpartitions,
+            int bufferSize,
+            Queue<Buffer>[] buffersRead,
+            int[] numBytesRead,
+            SortBuffer sortBuffer,
+            int[] numBufferCounts,
+            List<Integer> channels,
+            boolean checkCalculateCount) {
+        int i = 0;
+        while (sortBuffer.hasRemaining()) {
+            if (!checkCalculateCount) {
+                Collections.shuffle(channels);
+            }
+            MemorySegment readBuffer = MemorySegmentFactory.allocateUnpooledSegment(bufferSize);
+            SortBuffer.BufferWithChannel bufferAndChannel =
+                    sortBuffer.copyChannelBuffersIntoSegment(
+                            readBuffer, channels.get(i), ignore -> {}, 0);
+
+            // Some channel may read finish firstly
+            if (bufferAndChannel == null) {
+                i++;
+                i %= numSubpartitions;
+                continue;
+            }
+
+            if (checkCalculateCount) {
+                numBufferCounts[i]--;
+                assertTrue(numBufferCounts[i] >= 0);
+            }
+
+            int subpartition = bufferAndChannel.getChannelIndex();
+            buffersRead[subpartition].add(bufferAndChannel.getBuffer());
+            numBytesRead[subpartition] += bufferAndChannel.getBuffer().readableBytes();
+            i++;
+            i %= numSubpartitions;
+        }
+
+        IntStream.range(0, numSubpartitions)
+                .forEach(idx -> assertTrue(sortBuffer.hasSubpartitionReadFinish(idx)));
+    }
+
+    private static int writeDataToSortBuffer(
+            SortBuffer sortBuffer,
+            int numSubpartitions,
+            int bufferSize,
+            Random random,
+            Queue<DataAndType>[] dataWritten,
+            int[] numBytesWritten)
+            throws IOException {
+        int totalBytesWritten = 0;
         while (true) {
             // record size may be larger than buffer size so a record may span multiple segments
             int recordSize = random.nextInt(bufferSize * 4 - 1) + 1;
@@ -96,20 +253,7 @@ public class PartitionSortedBufferTest {
             numBytesWritten[subpartition] += recordSize;
             totalBytesWritten += recordSize;
         }
-
-        // read all data from the sort buffer
-        while (sortBuffer.hasRemaining()) {
-            MemorySegment readBuffer = MemorySegmentFactory.allocateUnpooledSegment(bufferSize);
-            SortBuffer.BufferWithChannel bufferAndChannel =
-                    sortBuffer.copyIntoSegment(readBuffer, ignore -> {}, 0);
-            int subpartition = bufferAndChannel.getChannelIndex();
-            buffersRead[subpartition].add(bufferAndChannel.getBuffer());
-            numBytesRead[subpartition] += bufferAndChannel.getBuffer().readableBytes();
-        }
-
-        assertEquals(totalBytesWritten, sortBuffer.numBytes());
-        checkWriteReadResult(
-                numSubpartitions, numBytesWritten, numBytesRead, dataWritten, buffersRead);
+        return totalBytesWritten;
     }
 
     public static void checkWriteReadResult(


### PR DESCRIPTION


<!--

*Thank you very much for contributing to remote-shuffle-service-for-flink. To help the community review your issue or contribution in the best possible way，please take a few minutes to fulfill following items.*

-->

## What is the purpose of the change

SortBuffer can improve read performance significantly, but it doesn't support read data from a specific channel. The development of some new functions, for example, ReducePartition implementation, depends on the ability of SortBuffer to read data from the specified channel. This issue is to support the feature for SortBuffer.

## Brief change log

  - *SortBuffer supports reading data from the specified channel index.*

## Verifying this change
This change added tests.
