### PR TITLE
[FRS-42] Remove flink-shaded-zookeeper-3 dependency and upgrade zookeeper/curator version

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -12,8 +12,8 @@ This project bundles the following dependencies under the Apache Software Licens
 - commons-cli:commons-cli:1.3.1
 - org.apache.commons:commons-lang3:3.3.2
 - io.netty:netty:4.1.49.Final
-- org.apache.zookeeper:zookeeper:3.4.14
-- org.apache.curator:curator-framework:4.2.0
+- org.apache.zookeeper:zookeeper:3.5.9
+- org.apache.curator:curator-framework:5.2.0
 - io.fabric8:kubernetes-client:5.2.1
 - org.apache.logging.log4j:log4j-api:2.12.1
 - org.apache.logging.log4j:log4j-core:2.12.1

--- a/pom.xml
+++ b/pom.xml
@@ -50,12 +50,11 @@ under the License.
 		<maven.compiler.target>${target.java.version}</maven.compiler.target>
 		<jackson.version>2.12.1</jackson.version>
 		<snakeyaml.version>1.27</snakeyaml.version>
-		<curator.version>2.12.0</curator.version>
+		<curator.version>5.2.0</curator.version>
 		<hadoop.version>2.4.1</hadoop.version>
 		<alibaba.metrics.version>2.0.6</alibaba.metrics.version>
 		<commons.cli.version>1.3.1</commons.cli.version>
-		<!-- Only the curator2 TestingServer works with ZK 3.4 -->
-		<zookeeper.version>3.4.14-14.0</zookeeper.version>
+		<zookeeper.version>3.5.9</zookeeper.version>
 		<flink.version>1.14.0</flink.version>
 		<rpc.flink.version>1.14.0</rpc.flink.version>
 		<jetty.version>9.4.44.v20210927</jetty.version>

--- a/shuffle-coordinator/pom.xml
+++ b/shuffle-coordinator/pom.xml
@@ -75,9 +75,74 @@ under the License.
 		</dependency>
 
 		<dependency>
-			<groupId>org.apache.flink</groupId>
-			<artifactId>flink-shaded-zookeeper-3</artifactId>
+			<groupId>org.apache.zookeeper</groupId>
+			<artifactId>zookeeper</artifactId>
 			<version>${zookeeper.version}</version>
+			<exclusions>
+				<exclusion>
+					<!-- logging classes provided -->
+					<groupId>log4j</groupId>
+					<artifactId>log4j</artifactId>
+				</exclusion>
+				<exclusion>
+					<!-- not relevant at runtime -->
+					<groupId>org.apache.yetus</groupId>
+					<artifactId>audience-annotations</artifactId>
+				</exclusion>
+				<exclusion>
+					<!-- logging classes provided -->
+					<groupId>org.slf4j</groupId>
+					<artifactId>*</artifactId>
+				</exclusion>
+			</exclusions>
+		</dependency>
+
+		<dependency>
+			<groupId>org.apache.curator</groupId>
+			<artifactId>curator-recipes</artifactId>
+			<version>${curator.version}</version>
+			<exclusions>
+				<exclusion>
+					<!-- not relevant at runtime -->
+					<groupId>com.google.code.findbugs</groupId>
+					<artifactId>jsr305</artifactId>
+				</exclusion>
+				<exclusion>
+					<!-- not relevant at runtime -->
+					<groupId>com.google.errorprone</groupId>
+					<artifactId>error_prone_annotations</artifactId>
+				</exclusion>
+				<exclusion>
+					<!-- supposedly not required -->
+					<groupId>com.google.guava</groupId>
+					<artifactId>failureaccess</artifactId>
+				</exclusion>
+				<exclusion>
+					<!-- supposedly not required -->
+					<groupId>com.google.guava</groupId>
+					<artifactId>listenablefuture</artifactId>
+				</exclusion>
+				<exclusion>
+					<!-- not relevant at runtime -->
+					<groupId>com.google.j2objc</groupId>
+					<artifactId>j2objc-annotations</artifactId>
+				</exclusion>
+				<exclusion>
+					<!-- not relevant at runtime -->
+					<groupId>org.checkerframework</groupId>
+					<artifactId>checker-qual</artifactId>
+				</exclusion>
+				<exclusion>
+					<!-- not relevant at runtime -->
+					<groupId>org.codehaus.mojo</groupId>
+					<artifactId>animal-sniffer-annotations</artifactId>
+				</exclusion>
+				<exclusion>
+					<!-- logging classes provided -->
+					<groupId>org.slf4j</groupId>
+					<artifactId>slf4j-api</artifactId>
+				</exclusion>
+			</exclusions>
 		</dependency>
 
 		<dependency>

--- a/shuffle-coordinator/src/main/java/com/alibaba/flink/shuffle/coordinator/highavailability/zookeeper/ZooKeeperHaServices.java
+++ b/shuffle-coordinator/src/main/java/com/alibaba/flink/shuffle/coordinator/highavailability/zookeeper/ZooKeeperHaServices.java
@@ -24,10 +24,9 @@ import com.alibaba.flink.shuffle.coordinator.highavailability.HaServices;
 import com.alibaba.flink.shuffle.coordinator.highavailability.LeaderElectionService;
 import com.alibaba.flink.shuffle.coordinator.highavailability.LeaderRetrievalService;
 
-import org.apache.flink.shaded.curator4.org.apache.curator.framework.CuratorFramework;
-import org.apache.flink.shaded.curator4.org.apache.curator.utils.ZKPaths;
-import org.apache.flink.shaded.zookeeper3.org.apache.zookeeper.KeeperException;
-
+import org.apache.curator.framework.CuratorFramework;
+import org.apache.curator.utils.ZKPaths;
+import org.apache.zookeeper.KeeperException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/shuffle-coordinator/src/main/java/com/alibaba/flink/shuffle/coordinator/highavailability/zookeeper/ZooKeeperLeaderElectionDriver.java
+++ b/shuffle-coordinator/src/main/java/com/alibaba/flink/shuffle/coordinator/highavailability/zookeeper/ZooKeeperLeaderElectionDriver.java
@@ -23,19 +23,18 @@ import com.alibaba.flink.shuffle.coordinator.highavailability.LeaderElectionDriv
 import com.alibaba.flink.shuffle.coordinator.highavailability.LeaderElectionEventHandler;
 import com.alibaba.flink.shuffle.coordinator.highavailability.LeaderInformation;
 
-import org.apache.flink.shaded.curator4.org.apache.curator.framework.CuratorFramework;
-import org.apache.flink.shaded.curator4.org.apache.curator.framework.api.UnhandledErrorListener;
-import org.apache.flink.shaded.curator4.org.apache.curator.framework.recipes.cache.ChildData;
-import org.apache.flink.shaded.curator4.org.apache.curator.framework.recipes.cache.NodeCache;
-import org.apache.flink.shaded.curator4.org.apache.curator.framework.recipes.cache.NodeCacheListener;
-import org.apache.flink.shaded.curator4.org.apache.curator.framework.recipes.leader.LeaderLatch;
-import org.apache.flink.shaded.curator4.org.apache.curator.framework.recipes.leader.LeaderLatchListener;
-import org.apache.flink.shaded.curator4.org.apache.curator.framework.state.ConnectionState;
-import org.apache.flink.shaded.curator4.org.apache.curator.framework.state.ConnectionStateListener;
-import org.apache.flink.shaded.zookeeper3.org.apache.zookeeper.CreateMode;
-import org.apache.flink.shaded.zookeeper3.org.apache.zookeeper.KeeperException;
-import org.apache.flink.shaded.zookeeper3.org.apache.zookeeper.data.Stat;
-
+import org.apache.curator.framework.CuratorFramework;
+import org.apache.curator.framework.api.UnhandledErrorListener;
+import org.apache.curator.framework.recipes.cache.ChildData;
+import org.apache.curator.framework.recipes.cache.NodeCache;
+import org.apache.curator.framework.recipes.cache.NodeCacheListener;
+import org.apache.curator.framework.recipes.leader.LeaderLatch;
+import org.apache.curator.framework.recipes.leader.LeaderLatchListener;
+import org.apache.curator.framework.state.ConnectionState;
+import org.apache.curator.framework.state.ConnectionStateListener;
+import org.apache.zookeeper.CreateMode;
+import org.apache.zookeeper.KeeperException;
+import org.apache.zookeeper.data.Stat;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/shuffle-coordinator/src/main/java/com/alibaba/flink/shuffle/coordinator/highavailability/zookeeper/ZooKeeperLeaderElectionDriverFactory.java
+++ b/shuffle-coordinator/src/main/java/com/alibaba/flink/shuffle/coordinator/highavailability/zookeeper/ZooKeeperLeaderElectionDriverFactory.java
@@ -22,7 +22,7 @@ import com.alibaba.flink.shuffle.common.handler.FatalErrorHandler;
 import com.alibaba.flink.shuffle.coordinator.highavailability.LeaderElectionDriverFactory;
 import com.alibaba.flink.shuffle.coordinator.highavailability.LeaderElectionEventHandler;
 
-import org.apache.flink.shaded.curator4.org.apache.curator.framework.CuratorFramework;
+import org.apache.curator.framework.CuratorFramework;
 
 /**
  * {@link LeaderElectionDriverFactory} implementation for Zookeeper.

--- a/shuffle-coordinator/src/main/java/com/alibaba/flink/shuffle/coordinator/highavailability/zookeeper/ZooKeeperLeaderRetrievalDriverFactory.java
+++ b/shuffle-coordinator/src/main/java/com/alibaba/flink/shuffle/coordinator/highavailability/zookeeper/ZooKeeperLeaderRetrievalDriverFactory.java
@@ -25,7 +25,7 @@ import com.alibaba.flink.shuffle.coordinator.highavailability.LeaderRetrievalDri
 import com.alibaba.flink.shuffle.coordinator.highavailability.LeaderRetrievalDriverFactory;
 import com.alibaba.flink.shuffle.coordinator.highavailability.LeaderRetrievalEventHandler;
 
-import org.apache.flink.shaded.curator4.org.apache.curator.framework.CuratorFramework;
+import org.apache.curator.framework.CuratorFramework;
 
 import static com.alibaba.flink.shuffle.common.utils.CommonUtils.checkArgument;
 

--- a/shuffle-coordinator/src/main/java/com/alibaba/flink/shuffle/coordinator/highavailability/zookeeper/ZooKeeperMultiLeaderRetrievalDriver.java
+++ b/shuffle-coordinator/src/main/java/com/alibaba/flink/shuffle/coordinator/highavailability/zookeeper/ZooKeeperMultiLeaderRetrievalDriver.java
@@ -24,13 +24,12 @@ import com.alibaba.flink.shuffle.coordinator.highavailability.LeaderInformation;
 import com.alibaba.flink.shuffle.coordinator.highavailability.LeaderRetrievalDriver;
 import com.alibaba.flink.shuffle.coordinator.highavailability.LeaderRetrievalEventHandler;
 
-import org.apache.flink.shaded.curator4.org.apache.curator.framework.CuratorFramework;
-import org.apache.flink.shaded.curator4.org.apache.curator.framework.api.UnhandledErrorListener;
-import org.apache.flink.shaded.curator4.org.apache.curator.framework.recipes.cache.ChildData;
-import org.apache.flink.shaded.curator4.org.apache.curator.framework.recipes.cache.PathChildrenCache;
-import org.apache.flink.shaded.curator4.org.apache.curator.framework.recipes.cache.PathChildrenCacheEvent;
-import org.apache.flink.shaded.curator4.org.apache.curator.framework.recipes.cache.PathChildrenCacheListener;
-
+import org.apache.curator.framework.CuratorFramework;
+import org.apache.curator.framework.api.UnhandledErrorListener;
+import org.apache.curator.framework.recipes.cache.ChildData;
+import org.apache.curator.framework.recipes.cache.PathChildrenCache;
+import org.apache.curator.framework.recipes.cache.PathChildrenCacheEvent;
+import org.apache.curator.framework.recipes.cache.PathChildrenCacheListener;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/shuffle-coordinator/src/main/java/com/alibaba/flink/shuffle/coordinator/highavailability/zookeeper/ZooKeeperSingleLeaderRetrievalDriver.java
+++ b/shuffle-coordinator/src/main/java/com/alibaba/flink/shuffle/coordinator/highavailability/zookeeper/ZooKeeperSingleLeaderRetrievalDriver.java
@@ -24,14 +24,13 @@ import com.alibaba.flink.shuffle.coordinator.highavailability.LeaderRetrievalDri
 import com.alibaba.flink.shuffle.coordinator.highavailability.LeaderRetrievalEventHandler;
 import com.alibaba.flink.shuffle.coordinator.highavailability.LeaderRetrievalService;
 
-import org.apache.flink.shaded.curator4.org.apache.curator.framework.CuratorFramework;
-import org.apache.flink.shaded.curator4.org.apache.curator.framework.api.UnhandledErrorListener;
-import org.apache.flink.shaded.curator4.org.apache.curator.framework.recipes.cache.ChildData;
-import org.apache.flink.shaded.curator4.org.apache.curator.framework.recipes.cache.NodeCache;
-import org.apache.flink.shaded.curator4.org.apache.curator.framework.recipes.cache.NodeCacheListener;
-import org.apache.flink.shaded.curator4.org.apache.curator.framework.state.ConnectionState;
-import org.apache.flink.shaded.curator4.org.apache.curator.framework.state.ConnectionStateListener;
-
+import org.apache.curator.framework.CuratorFramework;
+import org.apache.curator.framework.api.UnhandledErrorListener;
+import org.apache.curator.framework.recipes.cache.ChildData;
+import org.apache.curator.framework.recipes.cache.NodeCache;
+import org.apache.curator.framework.recipes.cache.NodeCacheListener;
+import org.apache.curator.framework.state.ConnectionState;
+import org.apache.curator.framework.state.ConnectionStateListener;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/shuffle-coordinator/src/main/java/com/alibaba/flink/shuffle/coordinator/highavailability/zookeeper/ZooKeeperUtils.java
+++ b/shuffle-coordinator/src/main/java/com/alibaba/flink/shuffle/coordinator/highavailability/zookeeper/ZooKeeperUtils.java
@@ -29,12 +29,11 @@ import com.alibaba.flink.shuffle.coordinator.highavailability.LeaderRetrievalDri
 import com.alibaba.flink.shuffle.core.config.ClusterOptions;
 import com.alibaba.flink.shuffle.core.config.HighAvailabilityOptions;
 
-import org.apache.flink.shaded.curator4.org.apache.curator.framework.CuratorFramework;
-import org.apache.flink.shaded.curator4.org.apache.curator.framework.CuratorFrameworkFactory;
-import org.apache.flink.shaded.curator4.org.apache.curator.framework.imps.DefaultACLProvider;
-import org.apache.flink.shaded.curator4.org.apache.curator.retry.ExponentialBackoffRetry;
-
 import org.apache.commons.lang3.StringUtils;
+import org.apache.curator.framework.CuratorFramework;
+import org.apache.curator.framework.CuratorFrameworkFactory;
+import org.apache.curator.framework.imps.DefaultACLProvider;
+import org.apache.curator.retry.ExponentialBackoffRetry;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/shuffle-coordinator/src/test/java/com/alibaba/flink/shuffle/coordinator/leaderelection/LeaderElectionTest.java
+++ b/shuffle-coordinator/src/test/java/com/alibaba/flink/shuffle/coordinator/leaderelection/LeaderElectionTest.java
@@ -30,8 +30,7 @@ import com.alibaba.flink.shuffle.coordinator.highavailability.zookeeper.ZooKeepe
 import com.alibaba.flink.shuffle.core.config.HighAvailabilityOptions;
 import com.alibaba.flink.shuffle.core.utils.TestLogger;
 
-import org.apache.flink.shaded.curator4.org.apache.curator.framework.CuratorFramework;
-
+import org.apache.curator.framework.CuratorFramework;
 import org.apache.curator.test.TestingServer;
 import org.junit.After;
 import org.junit.Before;

--- a/shuffle-coordinator/src/test/java/com/alibaba/flink/shuffle/coordinator/leaderelection/ZooKeeperLeaderElectionConnectionHandlingTest.java
+++ b/shuffle-coordinator/src/test/java/com/alibaba/flink/shuffle/coordinator/leaderelection/ZooKeeperLeaderElectionConnectionHandlingTest.java
@@ -34,8 +34,7 @@ import com.alibaba.flink.shuffle.core.config.ClusterOptions;
 import com.alibaba.flink.shuffle.core.config.HighAvailabilityOptions;
 import com.alibaba.flink.shuffle.core.utils.TestLogger;
 
-import org.apache.flink.shaded.curator4.org.apache.curator.framework.CuratorFramework;
-
+import org.apache.curator.framework.CuratorFramework;
 import org.apache.curator.test.TestingServer;
 import org.junit.After;
 import org.junit.Before;

--- a/shuffle-coordinator/src/test/java/com/alibaba/flink/shuffle/coordinator/leaderelection/ZooKeeperLeaderElectionTest.java
+++ b/shuffle-coordinator/src/test/java/com/alibaba/flink/shuffle/coordinator/leaderelection/ZooKeeperLeaderElectionTest.java
@@ -36,15 +36,14 @@ import com.alibaba.flink.shuffle.core.config.ClusterOptions;
 import com.alibaba.flink.shuffle.core.config.HighAvailabilityOptions;
 import com.alibaba.flink.shuffle.core.utils.TestLogger;
 
-import org.apache.flink.shaded.curator4.org.apache.curator.framework.CuratorFramework;
-import org.apache.flink.shaded.curator4.org.apache.curator.framework.api.CreateBuilder;
-import org.apache.flink.shaded.curator4.org.apache.curator.framework.recipes.cache.ChildData;
-import org.apache.flink.shaded.curator4.org.apache.curator.framework.recipes.cache.NodeCache;
-import org.apache.flink.shaded.curator4.org.apache.curator.framework.recipes.cache.NodeCacheListener;
-import org.apache.flink.shaded.zookeeper3.org.apache.zookeeper.CreateMode;
-import org.apache.flink.shaded.zookeeper3.org.apache.zookeeper.KeeperException;
-
+import org.apache.curator.framework.CuratorFramework;
+import org.apache.curator.framework.api.CreateBuilder;
+import org.apache.curator.framework.recipes.cache.ChildData;
+import org.apache.curator.framework.recipes.cache.NodeCache;
+import org.apache.curator.framework.recipes.cache.NodeCacheListener;
 import org.apache.curator.test.TestingServer;
+import org.apache.zookeeper.CreateMode;
+import org.apache.zookeeper.KeeperException;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;

--- a/shuffle-coordinator/src/test/java/com/alibaba/flink/shuffle/coordinator/leaderelection/ZooKeeperLeaderRetrievalTest.java
+++ b/shuffle-coordinator/src/test/java/com/alibaba/flink/shuffle/coordinator/leaderelection/ZooKeeperLeaderRetrievalTest.java
@@ -31,8 +31,7 @@ import com.alibaba.flink.shuffle.core.config.HighAvailabilityOptions;
 import com.alibaba.flink.shuffle.core.utils.TestLogger;
 import com.alibaba.flink.shuffle.rpc.utils.AkkaRpcServiceUtils;
 
-import org.apache.flink.shaded.curator4.org.apache.curator.framework.CuratorFramework;
-
+import org.apache.curator.framework.CuratorFramework;
 import org.apache.curator.test.TestingServer;
 import org.junit.After;
 import org.junit.Before;

--- a/shuffle-coordinator/src/test/java/com/alibaba/flink/shuffle/coordinator/zookeeper/ZooKeeperHaServicesTest.java
+++ b/shuffle-coordinator/src/test/java/com/alibaba/flink/shuffle/coordinator/zookeeper/ZooKeeperHaServicesTest.java
@@ -31,10 +31,9 @@ import com.alibaba.flink.shuffle.coordinator.leaderelection.TestingListener;
 import com.alibaba.flink.shuffle.core.config.HighAvailabilityOptions;
 import com.alibaba.flink.shuffle.core.utils.TestLogger;
 
-import org.apache.flink.shaded.curator4.org.apache.curator.framework.CuratorFramework;
-import org.apache.flink.shaded.curator4.org.apache.curator.framework.CuratorFrameworkFactory;
-import org.apache.flink.shaded.curator4.org.apache.curator.retry.RetryNTimes;
-
+import org.apache.curator.framework.CuratorFramework;
+import org.apache.curator.framework.CuratorFrameworkFactory;
+import org.apache.curator.retry.RetryNTimes;
 import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.BeforeClass;

--- a/shuffle-dist/pom.xml
+++ b/shuffle-dist/pom.xml
@@ -112,12 +112,6 @@ under the License.
 			<version>4.1.49.Final-${flink.shaded.version}</version>
 		</dependency>
 
-		<dependency>
-			<groupId>org.apache.flink</groupId>
-			<artifactId>flink-shaded-zookeeper-3</artifactId>
-			<version>${zookeeper.version}</version>
-		</dependency>
-
 		<!-- Concrete logging framework - we add this only here (and not in the
 		root POM) to not tie the projects to one specific framework and make
 		it easier for users to swap logging frameworks -->
@@ -274,6 +268,42 @@ under the License.
 									<pattern>javax.ws.rs</pattern>
 									<shadedPattern>
 										com.alibaba.flink.shuffle.shaded.javax.ws.rs
+									</shadedPattern>
+								</relocation>
+								<relocation>
+									<pattern>org.apache.zookeeper</pattern>
+									<shadedPattern>
+										com.alibaba.flink.shuffle.shaded.org.apache.zookeeper
+									</shadedPattern>
+								</relocation>
+								<relocation>
+									<pattern>io.netty</pattern>
+									<shadedPattern>
+										com.alibaba.flink.shuffle.shaded.io.netty
+									</shadedPattern>
+								</relocation>
+								<relocation>
+									<pattern>org.apache.jute</pattern>
+									<shadedPattern>
+										com.alibaba.flink.shuffle.shaded.org.apache.jute
+									</shadedPattern>
+								</relocation>
+								<relocation>
+									<pattern>com.codahale.metrics</pattern>
+									<shadedPattern>
+										com.alibaba.flink.shuffle.shaded.com.codahale.metrics
+									</shadedPattern>
+								</relocation>
+								<relocation>
+									<pattern>org.apache.curator</pattern>
+									<shadedPattern>
+										com.alibaba.flink.shuffle.shaded.org.apache.curator
+									</shadedPattern>
+								</relocation>
+								<relocation>
+									<pattern>com.google</pattern>
+									<shadedPattern>
+										com.alibaba.flink.shuffle.shaded.com.google
 									</shadedPattern>
 								</relocation>
 							</relocations>

--- a/shuffle-e2e-tests/pom.xml
+++ b/shuffle-e2e-tests/pom.xml
@@ -29,6 +29,11 @@ under the License.
 	<artifactId>shuffle-e2e-tests</artifactId>
 
 	<dependencies>
+		<dependency>
+			<groupId>com.alibaba.flink.shuffle</groupId>
+			<artifactId>shuffle-coordinator</artifactId>
+			<version>${project.version}</version>
+		</dependency>
 
 		<dependency>
 			<groupId>org.apache.flink</groupId>
@@ -114,10 +119,10 @@ under the License.
 		</dependency>
 
 		<dependency>
-			<groupId>org.apache.flink</groupId>
-			<artifactId>flink-shaded-hadoop-2</artifactId>
-			<version>2.4.1-9.0</version>
-			<scope>provided</scope>
+			<groupId>org.apache.curator</groupId>
+			<artifactId>curator-test</artifactId>
+			<version>${curator.version}</version>
+			<scope>test</scope>
 			<exclusions>
 				<exclusion>
 					<groupId>log4j</groupId>
@@ -128,13 +133,6 @@ under the License.
 					<artifactId>slf4j-log4j12</artifactId>
 				</exclusion>
 			</exclusions>
-		</dependency>
-
-		<dependency>
-			<groupId>org.apache.curator</groupId>
-			<artifactId>curator-test</artifactId>
-			<version>${curator.version}</version>
-			<scope>test</scope>
 		</dependency>
 
 		<dependency>

--- a/shuffle-e2e-tests/src/test/java/com/alibaba/flink/shuffle/e2e/AbstractInstableE2ETest.java
+++ b/shuffle-e2e-tests/src/test/java/com/alibaba/flink/shuffle/e2e/AbstractInstableE2ETest.java
@@ -23,9 +23,8 @@ import com.alibaba.flink.shuffle.e2e.flinkcluster.FlinkLocalCluster;
 import com.alibaba.flink.shuffle.e2e.shufflecluster.LocalShuffleCluster;
 import com.alibaba.flink.shuffle.e2e.zookeeper.ZooKeeperTestEnvironment;
 
-import org.apache.flink.shaded.curator4.org.apache.curator.framework.CuratorFramework;
-
 import org.apache.commons.io.FileUtils;
+import org.apache.curator.framework.CuratorFramework;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;

--- a/shuffle-e2e-tests/src/test/java/com/alibaba/flink/shuffle/e2e/JobForShuffleTesting.java
+++ b/shuffle-e2e-tests/src/test/java/com/alibaba/flink/shuffle/e2e/JobForShuffleTesting.java
@@ -19,7 +19,6 @@ package com.alibaba.flink.shuffle.e2e;
 
 import com.alibaba.flink.shuffle.common.functions.ConsumerWithException;
 import com.alibaba.flink.shuffle.e2e.flinkcluster.FlinkLocalCluster;
-import com.alibaba.flink.shuffle.e2e.utils.LogErrorHandler;
 import com.alibaba.flink.shuffle.e2e.zookeeper.ZooKeeperTestUtils;
 
 import org.apache.flink.api.common.ExecutionConfig;
@@ -43,7 +42,6 @@ import org.apache.flink.runtime.execution.Environment;
 import org.apache.flink.runtime.executiongraph.ExecutionAttemptID;
 import org.apache.flink.runtime.io.network.partition.ResultPartitionID;
 import org.apache.flink.runtime.jobgraph.IntermediateResultPartitionID;
-import org.apache.flink.runtime.util.ZooKeeperUtils;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
 import org.apache.flink.streaming.api.graph.GlobalStreamExchangeMode;
 import org.apache.flink.streaming.api.graph.StreamConfig;
@@ -55,14 +53,14 @@ import org.apache.flink.streaming.api.operators.Output;
 import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
 import org.apache.flink.streaming.runtime.tasks.StreamTask;
 
-import org.apache.flink.shaded.curator4.org.apache.curator.framework.CuratorFramework;
-import org.apache.flink.shaded.curator4.org.apache.curator.framework.recipes.cache.ChildData;
-import org.apache.flink.shaded.curator4.org.apache.curator.framework.recipes.cache.NodeCache;
-import org.apache.flink.shaded.curator4.org.apache.curator.framework.recipes.cache.NodeCacheListener;
 import org.apache.flink.shaded.netty4.io.netty.buffer.ByteBuf;
 import org.apache.flink.shaded.netty4.io.netty.buffer.Unpooled;
-import org.apache.flink.shaded.zookeeper3.org.apache.zookeeper.CreateMode;
 
+import org.apache.curator.framework.CuratorFramework;
+import org.apache.curator.framework.recipes.cache.ChildData;
+import org.apache.curator.framework.recipes.cache.NodeCache;
+import org.apache.curator.framework.recipes.cache.NodeCacheListener;
+import org.apache.zookeeper.CreateMode;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -373,7 +371,7 @@ public class JobForShuffleTesting {
             super.open();
             Configuration conf =
                     ZooKeeperTestUtils.createZooKeeperHAConfigForFlink(zkConnect, zkPath);
-            zkClient = ZooKeeperUtils.startCuratorFramework(conf, LogErrorHandler.INSTANCE);
+            zkClient = ZooKeeperTestUtils.createZKClientForFlink(conf);
             taskIdx = getRuntimeContext().getIndexOfThisSubtask();
             attempt = getRuntimeContext().getAttemptNumber();
             final ResultPartitionID resultPartitionID;

--- a/shuffle-e2e-tests/src/test/java/com/alibaba/flink/shuffle/e2e/ShuffleManagerHAE2ETest.java
+++ b/shuffle-e2e-tests/src/test/java/com/alibaba/flink/shuffle/e2e/ShuffleManagerHAE2ETest.java
@@ -31,9 +31,8 @@ import org.apache.flink.api.common.JobID;
 import org.apache.flink.configuration.PipelineOptionsInternal;
 import org.apache.flink.configuration.WebOptions;
 
-import org.apache.flink.shaded.curator4.org.apache.curator.framework.CuratorFramework;
-
 import org.apache.commons.io.FileUtils;
+import org.apache.curator.framework.CuratorFramework;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.ClassRule;

--- a/shuffle-e2e-tests/src/test/java/com/alibaba/flink/shuffle/e2e/flinkcluster/FlinkLocalCluster.java
+++ b/shuffle-e2e-tests/src/test/java/com/alibaba/flink/shuffle/e2e/flinkcluster/FlinkLocalCluster.java
@@ -55,9 +55,8 @@ import org.apache.flink.table.api.config.ExecutionConfigOptions;
 import org.apache.flink.util.concurrent.FutureUtils;
 import org.apache.flink.util.concurrent.ScheduledExecutorServiceAdapter;
 
-import org.apache.flink.shaded.curator4.org.apache.curator.framework.CuratorFramework;
-
 import org.apache.commons.lang3.tuple.Pair;
+import org.apache.curator.framework.CuratorFramework;
 import org.junit.rules.TemporaryFolder;
 
 import java.io.File;

--- a/shuffle-e2e-tests/src/test/java/com/alibaba/flink/shuffle/e2e/flinkcluster/TaskManagerProcess.java
+++ b/shuffle-e2e-tests/src/test/java/com/alibaba/flink/shuffle/e2e/flinkcluster/TaskManagerProcess.java
@@ -19,7 +19,7 @@
 package com.alibaba.flink.shuffle.e2e.flinkcluster;
 
 import com.alibaba.flink.shuffle.e2e.TestJvmProcess;
-import com.alibaba.flink.shuffle.e2e.utils.LogErrorHandler;
+import com.alibaba.flink.shuffle.e2e.zookeeper.ZooKeeperTestUtils;
 import com.alibaba.flink.shuffle.plugin.RemoteShuffleEnvironment;
 
 import org.apache.flink.api.java.utils.ParameterTool;
@@ -41,12 +41,11 @@ import org.apache.flink.runtime.rpc.RpcService;
 import org.apache.flink.runtime.taskexecutor.TaskExecutor;
 import org.apache.flink.runtime.taskexecutor.TaskExecutorToServiceAdapter;
 import org.apache.flink.runtime.taskexecutor.TaskManagerRunner;
-import org.apache.flink.runtime.util.ZooKeeperUtils;
 
-import org.apache.flink.shaded.curator4.org.apache.curator.framework.CuratorFramework;
 import org.apache.flink.shaded.netty4.io.netty.buffer.ByteBuf;
 import org.apache.flink.shaded.netty4.io.netty.buffer.Unpooled;
 
+import org.apache.curator.framework.CuratorFramework;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -179,8 +178,7 @@ public class TaskManagerProcess extends TestJvmProcess {
             field.setAccessible(true);
             RemoteShuffleEnvironment env = (RemoteShuffleEnvironment) field.get(taskExecutor);
             NetworkBufferPool bufferPool = env.getNetworkBufferPool();
-            CuratorFramework zkClient =
-                    ZooKeeperUtils.startCuratorFramework(conf, LogErrorHandler.INSTANCE);
+            CuratorFramework zkClient = ZooKeeperTestUtils.createZKClientForFlink(conf);
             int index = conf.getInteger("taskmanager.index", -1);
             String zkPath = "/taskmanager-" + index;
             if (zkClient.checkExists().forPath(zkPath) != null) {

--- a/shuffle-e2e-tests/src/test/java/com/alibaba/flink/shuffle/e2e/shufflecluster/LocalShuffleCluster.java
+++ b/shuffle-e2e-tests/src/test/java/com/alibaba/flink/shuffle/e2e/shufflecluster/LocalShuffleCluster.java
@@ -54,8 +54,7 @@ import com.alibaba.flink.shuffle.transfer.AbstractNettyTest;
 
 import org.apache.flink.api.common.time.Deadline;
 
-import org.apache.flink.shaded.curator4.org.apache.curator.framework.CuratorFramework;
-
+import org.apache.curator.framework.CuratorFramework;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/shuffle-e2e-tests/src/test/java/com/alibaba/flink/shuffle/e2e/zookeeper/ZooKeeperTestUtils.java
+++ b/shuffle-e2e-tests/src/test/java/com/alibaba/flink/shuffle/e2e/zookeeper/ZooKeeperTestUtils.java
@@ -21,22 +21,26 @@ package com.alibaba.flink.shuffle.e2e.zookeeper;
 import com.alibaba.flink.shuffle.common.config.Configuration;
 import com.alibaba.flink.shuffle.coordinator.highavailability.zookeeper.ZooKeeperUtils;
 import com.alibaba.flink.shuffle.core.config.HighAvailabilityOptions;
-import com.alibaba.flink.shuffle.e2e.utils.LogErrorHandler;
 
 import org.apache.flink.configuration.AkkaOptions;
 import org.apache.flink.configuration.CheckpointingOptions;
 import org.apache.flink.runtime.jobmanager.HighAvailabilityMode;
+import org.apache.flink.util.Preconditions;
 
-import org.apache.flink.shaded.curator4.org.apache.curator.framework.CuratorFramework;
-import org.apache.flink.shaded.curator4.org.apache.curator.utils.ZKPaths;
-import org.apache.flink.shaded.zookeeper3.org.apache.zookeeper.KeeperException;
-
+import org.apache.commons.lang3.StringUtils;
+import org.apache.curator.framework.CuratorFramework;
+import org.apache.curator.framework.CuratorFrameworkFactory;
+import org.apache.curator.framework.imps.DefaultACLProvider;
+import org.apache.curator.retry.ExponentialBackoffRetry;
+import org.apache.curator.utils.ZKPaths;
+import org.apache.zookeeper.KeeperException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.time.Duration;
 
 import static com.alibaba.flink.shuffle.common.utils.CommonUtils.checkNotNull;
+import static org.apache.flink.runtime.util.ZooKeeperUtils.generateZookeeperPath;
 
 /** ZooKeeper test utilities. */
 public class ZooKeeperTestUtils {
@@ -131,8 +135,62 @@ public class ZooKeeperTestUtils {
 
     public static CuratorFramework createZKClientForFlink(
             org.apache.flink.configuration.Configuration configuration) {
-        return org.apache.flink.runtime.util.ZooKeeperUtils.startCuratorFramework(
-                configuration, LogErrorHandler.INSTANCE);
+        Preconditions.checkNotNull(configuration, "configuration");
+        String zkQuorum =
+                configuration.getValue(
+                        org.apache.flink.configuration.HighAvailabilityOptions.HA_ZOOKEEPER_QUORUM);
+
+        if (zkQuorum == null || StringUtils.isBlank(zkQuorum)) {
+            throw new RuntimeException(
+                    "No valid ZooKeeper quorum has been specified. "
+                            + "You can specify the quorum via the configuration key '"
+                            + org.apache.flink.configuration.HighAvailabilityOptions
+                                    .HA_ZOOKEEPER_QUORUM
+                                    .key()
+                            + "'.");
+        }
+
+        int sessionTimeout =
+                configuration.getInteger(
+                        org.apache.flink.configuration.HighAvailabilityOptions
+                                .ZOOKEEPER_SESSION_TIMEOUT);
+        int connectionTimeout =
+                configuration.getInteger(
+                        org.apache.flink.configuration.HighAvailabilityOptions
+                                .ZOOKEEPER_CONNECTION_TIMEOUT);
+        int retryWait =
+                configuration.getInteger(
+                        org.apache.flink.configuration.HighAvailabilityOptions
+                                .ZOOKEEPER_RETRY_WAIT);
+        int maxRetryAttempts =
+                configuration.getInteger(
+                        org.apache.flink.configuration.HighAvailabilityOptions
+                                .ZOOKEEPER_MAX_RETRY_ATTEMPTS);
+        String root =
+                configuration.getValue(
+                        org.apache.flink.configuration.HighAvailabilityOptions.HA_ZOOKEEPER_ROOT);
+        String namespace =
+                configuration.getValue(
+                        org.apache.flink.configuration.HighAvailabilityOptions.HA_CLUSTER_ID);
+        String rootWithNamespace = generateZookeeperPath(root, namespace);
+
+        LOG.info("Using '{}' as Zookeeper namespace.", rootWithNamespace);
+        CuratorFramework cf =
+                CuratorFrameworkFactory.builder()
+                        .connectString(zkQuorum)
+                        .sessionTimeoutMs(sessionTimeout)
+                        .connectionTimeoutMs(connectionTimeout)
+                        .retryPolicy(new ExponentialBackoffRetry(retryWait, maxRetryAttempts))
+                        // Curator prepends a '/' manually and throws an Exception if the
+                        // namespace starts with a '/'.
+                        .namespace(
+                                rootWithNamespace.startsWith("/")
+                                        ? rootWithNamespace.substring(1)
+                                        : rootWithNamespace)
+                        .aclProvider(new DefaultACLProvider())
+                        .build();
+        cf.start();
+        return cf;
     }
 
     public static CuratorFramework createZKClientForRemoteShuffle(Configuration configuration) {

--- a/shuffle-plugin/pom.xml
+++ b/shuffle-plugin/pom.xml
@@ -172,6 +172,44 @@ under the License.
 									</excludes>
 								</filter>
 							</filters>
+							<relocations>
+								<relocation>
+									<pattern>org.apache.zookeeper</pattern>
+									<shadedPattern>
+										com.alibaba.flink.shuffle.shaded.org.apache.zookeeper
+									</shadedPattern>
+								</relocation>
+								<relocation>
+									<pattern>io.netty</pattern>
+									<shadedPattern>
+										com.alibaba.flink.shuffle.shaded.io.netty
+									</shadedPattern>
+								</relocation>
+								<relocation>
+									<pattern>org.apache.jute</pattern>
+									<shadedPattern>
+										com.alibaba.flink.shuffle.shaded.org.apache.jute
+									</shadedPattern>
+								</relocation>
+								<relocation>
+									<pattern>com.codahale.metrics</pattern>
+									<shadedPattern>
+										com.alibaba.flink.shuffle.shaded.com.codahale.metrics
+									</shadedPattern>
+								</relocation>
+								<relocation>
+									<pattern>org.apache.curator</pattern>
+									<shadedPattern>
+										com.alibaba.flink.shuffle.shaded.org.apache.curator
+									</shadedPattern>
+								</relocation>
+								<relocation>
+									<pattern>com.google</pattern>
+									<shadedPattern>
+										com.alibaba.flink.shuffle.shaded.com.google
+									</shadedPattern>
+								</relocation>
+							</relocations>
 						</configuration>
 					</execution>
 				</executions>

--- a/shuffle-yarn/src/test/java/com/alibaba/flink/shuffle/yarn/RemoteShuffleOnYarnTestCluster.java
+++ b/shuffle-yarn/src/test/java/com/alibaba/flink/shuffle/yarn/RemoteShuffleOnYarnTestCluster.java
@@ -23,10 +23,9 @@ import com.alibaba.flink.shuffle.yarn.entry.manager.AppClient;
 import com.alibaba.flink.shuffle.yarn.entry.worker.YarnShuffleWorkerEntrypoint;
 import com.alibaba.flink.shuffle.yarn.utils.YarnConstants;
 
-import org.apache.flink.shaded.curator4.org.apache.curator.framework.CuratorFramework;
-import org.apache.flink.shaded.curator4.org.apache.curator.framework.CuratorFrameworkFactory;
-import org.apache.flink.shaded.curator4.org.apache.curator.retry.RetryNTimes;
-
+import org.apache.curator.framework.CuratorFramework;
+import org.apache.curator.framework.CuratorFrameworkFactory;
+import org.apache.curator.retry.RetryNTimes;
 import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;

--- a/shuffle-yarn/src/test/java/com/alibaba/flink/shuffle/yarn/YarnTestBase.java
+++ b/shuffle-yarn/src/test/java/com/alibaba/flink/shuffle/yarn/YarnTestBase.java
@@ -21,8 +21,7 @@ package com.alibaba.flink.shuffle.yarn;
 import com.alibaba.flink.shuffle.core.utils.TestLogger;
 import com.alibaba.flink.shuffle.yarn.zk.ZookeeperTestServer;
 
-import org.apache.flink.shaded.curator4.org.apache.curator.framework.CuratorFramework;
-
+import org.apache.curator.framework.CuratorFramework;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hdfs.MiniDFSCluster;
 import org.apache.hadoop.service.Service;


### PR DESCRIPTION
## What is the purpose of the change

This solves #42 . Zookeeper 3.4 does not work with JDK 15. This patch upgrade the ZK version to 3.5.9 and Curator version to 5.2.0. At the same time, this patch removes the flink-shaded-zookeeper-3 dependency.

## Brief change log

  - Remove flink-shaded-zookeeper-3 dependency and upgrade zookeeper/curator version.

## Verifying this change

This change is already covered by existing tests.
