### PR TITLE
[FRS-36] Support to config the shuffle cluster name prefix to use at Flink side

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -77,6 +77,7 @@ be put in the Flink configuration file.
 
 | Key | Value Type | Default Value | Version | Required | Description |
 | --- | ---------- | ------------- | ------- | -------- | ----------- |
+| `remote-shuffle.cluster.id-prefix` | String | Same with `remote-shuffle.cluster.id` | 1.1.0 | false (Must be configured if `remote-shuffle.cluster.id` is configured at shuffle cluster side) | Identify the remote shuffle cluster to use for the job. It is treated as a name prefix, which means a job can only use the shuffle cluster whose cluster ID starts with the configured value. For example, if a shuffle cluster is configured with cluster ID 'ab', then the job configured with ID prefix 'a' or 'ab' can use it, but the job configured with ID prefix 'b' or 'ac' can't use it. |
 | `remote-shuffle.job.memory-per-partition` | MemorySize | `64m` | 1.0.0 | false | The size of network buffers required per result partition. The minimum valid value is 8M. Usually, several hundreds of megabytes memory is enough for large scale batch jobs. |
 | `remote-shuffle.job.memory-per-gate` | MemorySize | `32m` | 1.0.0 | false | The size of network buffers required per input gate. The minimum valid value is 8m. Usually, several hundreds of megabytes memory is enough for large scale batch jobs. |
 | `remote-shuffle.job.enable-data-compression` | Bool | `true` | 1.0.0 | false | Whether to enable shuffle data compression. Usually, enabling data compression can save the storage space and achieve better performance. |
@@ -130,7 +131,7 @@ conf/remote-shuffle-conf.yaml file.
 
 | Key | Value Type | Default Value | Version | Required | Description |
 | --- | ---------- | ------------- | ------- | -------- | ----------- |
-| `remote-shuffle.cluster.id` | String | `/default-cluster` | 1.0.0 | false | The unique ID of the remote shuffle cluster used by high-availability. Different shuffle clusters sharing the same zookeeper instance must be configured with different cluster id. This config must be consistent between the `ShuffleManager` and `ShuffleWorker`s. |
+| `remote-shuffle.cluster.id` | String | `/default-cluster` | 1.0.0 | false | The unique ID of the remote shuffle cluster used by high-availability. It must start with '/'. Different shuffle clusters must be configured with different cluster id. This config must be consistent between the `ShuffleManager` and `ShuffleWorker`s. |
 | `remote-shuffle.high-availability.mode` | String | `NONE` | 1.0.0 | false (Must be set if you want to enable HA) | Defines high-availability mode used for the cluster execution. To enable high-availability, set this mode to `ZOOKEEPER` or specify FQN of factory class. |
 | `remote-shuffle.ha.zookeeper.quorum` | String | `null` | 1.0.0 | false (Must be set if high-availability mode is ZOOKEEPER) | The ZooKeeper quorum to use when running the remote shuffle cluster in a high-availability mode with ZooKeeper. |
 | `remote-shuffle.ha.zookeeper.root-path` | String | `flink-remote-shuffle` | 1.0.0 | false | The root path in ZooKeeper under which the remote shuffle cluster stores its entries. Different remote shuffle clusters will be distinguished by the cluster id. This config must be consistent between the Flink cluster side and the shuffle cluster side. |

--- a/shuffle-coordinator/src/main/java/com/alibaba/flink/shuffle/coordinator/highavailability/zookeeper/ZooKeeperLeaderRetrievalDriverFactory.java
+++ b/shuffle-coordinator/src/main/java/com/alibaba/flink/shuffle/coordinator/highavailability/zookeeper/ZooKeeperLeaderRetrievalDriverFactory.java
@@ -68,7 +68,11 @@ public class ZooKeeperLeaderRetrievalDriverFactory implements LeaderRetrievalDri
         switch (receptor) {
             case SHUFFLE_CLIENT:
                 return new ZooKeeperMultiLeaderRetrievalDriver(
-                        client, retrievalPathSuffix, leaderEventHandler, fatalErrorHandler);
+                        client,
+                        retrievalPathSuffix,
+                        clusterID,
+                        leaderEventHandler,
+                        fatalErrorHandler);
             case SHUFFLE_WORKER:
                 return new ZooKeeperSingleLeaderRetrievalDriver(
                         client,

--- a/shuffle-coordinator/src/main/java/com/alibaba/flink/shuffle/coordinator/highavailability/zookeeper/ZooKeeperMultiLeaderRetrievalDriver.java
+++ b/shuffle-coordinator/src/main/java/com/alibaba/flink/shuffle/coordinator/highavailability/zookeeper/ZooKeeperMultiLeaderRetrievalDriver.java
@@ -54,6 +54,8 @@ public class ZooKeeperMultiLeaderRetrievalDriver
 
     private final String retrievalPathSuffix;
 
+    private final String retrievalPathPrefix;
+
     private final LeaderRetrievalEventHandler leaderListener;
 
     private final PathChildrenCache pathChildrenCache;
@@ -69,16 +71,20 @@ public class ZooKeeperMultiLeaderRetrievalDriver
     public ZooKeeperMultiLeaderRetrievalDriver(
             CuratorFramework client,
             String retrievalPathSuffix,
+            String retrievalPathPrefix,
             LeaderRetrievalEventHandler leaderListener,
             FatalErrorHandler fatalErrorHandler)
             throws Exception {
         checkArgument(client != null, "Must be not null.");
         checkArgument(retrievalPathSuffix != null, "Must be not null.");
+        checkArgument(retrievalPathPrefix != null, "Must be not null.");
+        checkArgument(retrievalPathPrefix.startsWith("/"), "Path must start with '/'.");
         checkArgument(leaderListener != null, "Must be not null.");
         checkArgument(fatalErrorHandler != null, "Must be not null.");
 
         this.client = client;
         this.retrievalPathSuffix = retrievalPathSuffix;
+        this.retrievalPathPrefix = retrievalPathPrefix;
         this.leaderListener = leaderListener;
         this.fatalErrorHandler = fatalErrorHandler;
 
@@ -98,7 +104,9 @@ public class ZooKeeperMultiLeaderRetrievalDriver
         String leaderPath = currentLeaderPath.get();
         try {
             for (ChildData childData : childDataList) {
-                if (childData == null || !childData.getPath().endsWith(retrievalPathSuffix)) {
+                if (childData == null
+                        || !childData.getPath().endsWith(retrievalPathSuffix)
+                        || !childData.getPath().startsWith(retrievalPathPrefix)) {
                     continue;
                 }
 

--- a/shuffle-core/src/main/java/com/alibaba/flink/shuffle/core/config/ClusterOptions.java
+++ b/shuffle-core/src/main/java/com/alibaba/flink/shuffle/core/config/ClusterOptions.java
@@ -25,12 +25,19 @@ import java.time.Duration;
 /** Options which control the cluster behaviour. */
 public class ClusterOptions {
 
-    /** The unique ID of the remote shuffle cluster used by HA. */
+    /**
+     * The unique ID of the remote shuffle cluster used by HA. It must start with '/'. Different
+     * shuffle clusters must be configured with different cluster id. This config must be consistent
+     * between the shuffle manager and workers.
+     */
     public static final ConfigOption<String> REMOTE_SHUFFLE_CLUSTER_ID =
             new ConfigOption<String>("remote-shuffle.cluster.id")
                     .defaultValue("/default-cluster")
                     .description(
-                            "The unique ID of the remote shuffle cluster used by high-availability.");
+                            "The unique ID of the remote shuffle cluster used by high-availability."
+                                    + " It must start with '/'. Different shuffle clusters must be "
+                                    + "configured with different cluster id. This config must be "
+                                    + "consistent between the shuffle manager and workers.");
 
     /**
      * Defines the timeout for the shuffle worker or client registration to the shuffle manager. If

--- a/shuffle-plugin/src/main/java/com/alibaba/flink/shuffle/plugin/RemoteShuffleMaster.java
+++ b/shuffle-plugin/src/main/java/com/alibaba/flink/shuffle/plugin/RemoteShuffleMaster.java
@@ -31,6 +31,7 @@ import com.alibaba.flink.shuffle.coordinator.heartbeat.HeartbeatServicesUtils;
 import com.alibaba.flink.shuffle.coordinator.highavailability.HaServiceUtils;
 import com.alibaba.flink.shuffle.coordinator.highavailability.HaServices;
 import com.alibaba.flink.shuffle.coordinator.manager.DataPartitionCoordinate;
+import com.alibaba.flink.shuffle.core.config.ClusterOptions;
 import com.alibaba.flink.shuffle.core.config.WorkerOptions;
 import com.alibaba.flink.shuffle.core.ids.DataSetID;
 import com.alibaba.flink.shuffle.core.ids.InstanceID;
@@ -122,6 +123,11 @@ public class RemoteShuffleMaster implements ShuffleMaster<RemoteShuffleDescripto
 
         HaServices tmpHAService = null;
         try {
+            // replace the remote shuffle cluster id with a name prefix to enable selection from
+            // multiple remote clusters with the same name prefix
+            configuration.setString(
+                    ClusterOptions.REMOTE_SHUFFLE_CLUSTER_ID,
+                    configuration.getString(PluginOptions.TARGET_CLUSTER_ID_PREFIX));
             tmpHAService = HaServiceUtils.createHAServices(configuration);
         } catch (Throwable throwable) {
             LOG.error("Failed to create the shuffle master HA service.", throwable);

--- a/shuffle-plugin/src/main/java/com/alibaba/flink/shuffle/plugin/config/PluginOptions.java
+++ b/shuffle-plugin/src/main/java/com/alibaba/flink/shuffle/plugin/config/PluginOptions.java
@@ -20,6 +20,7 @@ package com.alibaba.flink.shuffle.plugin.config;
 
 import com.alibaba.flink.shuffle.common.config.ConfigOption;
 import com.alibaba.flink.shuffle.common.config.MemorySize;
+import com.alibaba.flink.shuffle.core.config.ClusterOptions;
 
 /** Config options for shuffle jobs using the remote shuffle service. */
 public class PluginOptions {
@@ -27,6 +28,25 @@ public class PluginOptions {
     public static final MemorySize MIN_MEMORY_PER_PARTITION = MemorySize.parse("8m");
 
     public static final MemorySize MIN_MEMORY_PER_GATE = MemorySize.parse("8m");
+
+    /**
+     * Identify the remote shuffle cluster to use for the job. It is treated as a name prefix, which
+     * means a job can only use the shuffle cluster whose cluster ID starts with the configured
+     * value. For example, if a shuffle cluster is configured with cluster ID 'ab', then the job
+     * configured with ID prefix 'a' or 'ab' can use it, but the job configured with ID prefix 'b'
+     * or 'ac' can't use it.
+     */
+    public static final ConfigOption<String> TARGET_CLUSTER_ID_PREFIX =
+            new ConfigOption<String>("remote-shuffle.cluster.id-prefix")
+                    .defaultValue(ClusterOptions.REMOTE_SHUFFLE_CLUSTER_ID.defaultValue())
+                    .description(
+                            "Identify the remote shuffle cluster to use for the job. It is treated "
+                                    + "as a name prefix, which means a job can only use the shuffle"
+                                    + " cluster whose cluster ID starts with the configured value. "
+                                    + "For example, if a shuffle cluster is configured with cluster"
+                                    + " ID 'ab', then the job configured with ID prefix 'a' or 'ab'"
+                                    + " can use it, but the job configured with ID prefix 'b' or "
+                                    + "'ac' can't use it.");
 
     /**
      * The maximum number of remote shuffle channels to open and read concurrently per input gate.


### PR DESCRIPTION
## What is the purpose of the change

This solves #36 . It enables a Flink job to select the specific shuffle cluster. If a cluster version is updated, the job can select the higher version with the same name prefix.

## Brief change log

  - Support to config the shuffle cluster name prefix to use at Flink side.


## Verifying this change

This change added tests.
