### PR TITLE
[FRS-53] Not trigger fatal error if Flink job has finished when notifying new shuffle manager address

### DIFF
--- a/shuffle-coordinator/src/test/java/com/alibaba/flink/shuffle/client/ShuffleManagerClientTest.java
+++ b/shuffle-coordinator/src/test/java/com/alibaba/flink/shuffle/client/ShuffleManagerClientTest.java
@@ -459,6 +459,22 @@ public class ShuffleManagerClientTest {
         }
     }
 
+    @Test
+    public void testNotifyNewShuffleManagerLeaderAfterClosed() {
+        ShuffleManagerClientImpl shuffleManagerClient =
+                new ShuffleManagerClientImpl(
+                        RandomIDUtils.randomJobId(),
+                        new RecordShuffleWorkerStatusListener(),
+                        rpcService,
+                        testingFatalErrorHandler,
+                        ShuffleManagerClientConfiguration.fromConfiguration(configuration),
+                        haServices,
+                        new HeartbeatServices(Long.MAX_VALUE, Long.MAX_VALUE));
+        shuffleManagerClient.close();
+        // this should not throw any exception
+        shuffleManagerClient.notifyLeaderAddress(LeaderInformation.empty());
+    }
+
     private static class RecordShuffleWorkerStatusListener implements ShuffleWorkerStatusListener {
 
         private final BlockingQueue<InstanceID> unrelatedWorkers = new LinkedBlockingQueue<>();


### PR DESCRIPTION
## What is the purpose of the change

This solves #53 . Currently, if a job has finished (either error or not) and at the same time, the shuffle manager leader changes, the new leader notification may cause a fatal error which may lead to JM failover. It mainly influence session cluster when more than one jobs share the same cluster.


## Brief change log

  - Not trigger fatal error if Flink job has finished when notifying new shuffle manager address.


## Verifying this change

This change added tests.
