### PR TITLE
[FRS-55] Ensure all resources will be released for result partition and input gate when closed

### DIFF
--- a/shuffle-plugin/src/main/java/com/alibaba/flink/shuffle/plugin/transfer/BufferPacker.java
+++ b/shuffle-plugin/src/main/java/com/alibaba/flink/shuffle/plugin/transfer/BufferPacker.java
@@ -82,9 +82,10 @@ public class BufferPacker {
 
     public void drain() throws InterruptedException {
         if (cachedBuffer != null) {
-            handleRipeBuffer(cachedBuffer, currentSubIdx);
+            Buffer dumpedBuffer = cachedBuffer;
+            cachedBuffer = null;
+            handleRipeBuffer(dumpedBuffer, currentSubIdx);
         }
-        cachedBuffer = null;
         currentSubIdx = -1;
     }
 

--- a/shuffle-plugin/src/main/java/com/alibaba/flink/shuffle/plugin/transfer/RemoteShuffleResultPartition.java
+++ b/shuffle-plugin/src/main/java/com/alibaba/flink/shuffle/plugin/transfer/RemoteShuffleResultPartition.java
@@ -327,13 +327,37 @@ public class RemoteShuffleResultPartition extends ResultPartition {
 
     @Override
     public synchronized void close() {
-        releaseSortBuffer(unicastSortBuffer);
-        releaseSortBuffer(broadcastSortBuffer);
-        super.close();
+        Throwable closeException = null;
+        try {
+            releaseSortBuffer(unicastSortBuffer);
+        } catch (Throwable throwable) {
+            closeException = throwable;
+            LOG.error("Failed to release unicast sort buffer.", throwable);
+        }
+
+        try {
+            releaseSortBuffer(broadcastSortBuffer);
+        } catch (Throwable throwable) {
+            closeException = closeException == null ? throwable : closeException;
+            LOG.error("Failed to release broadcast sort buffer.", throwable);
+        }
+
+        try {
+            super.close();
+        } catch (Throwable throwable) {
+            closeException = closeException == null ? throwable : closeException;
+            LOG.error("Failed to call super#close() method.", throwable);
+        }
+
         try {
             outputGate.close();
-        } catch (Exception e) {
-            ExceptionUtils.rethrowAsRuntimeException(e);
+        } catch (Throwable throwable) {
+            closeException = closeException == null ? throwable : closeException;
+            LOG.error("Failed to close remote shuffle output gate.", throwable);
+        }
+
+        if (closeException != null) {
+            ExceptionUtils.rethrowAsRuntimeException(closeException);
         }
     }
 


### PR DESCRIPTION
## What is the purpose of the change

This solves #55 . It fix the bug by:

1. Fix the duplicate recycle issue;
2. Try to release all resources even when release one resource fails. 

## Brief change log

  - Fix the duplicate recycle issue;
  - Try to release all resources even when release one resource fails. 


## Verifying this change

This change added tests.
