### PR TITLE
[FRS-31] Upgrade log4j version to 2.17.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -51,7 +51,7 @@ under the License.
 	<properties>
 		<scala.binary.version>2.12</scala.binary.version>
 		<flink.shaded.version>13.0</flink.shaded.version>
-		<log4j.version>2.17.0</log4j.version>
+		<log4j.version>2.17.2</log4j.version>
 		<junit.version>4.13</junit.version>
 		<mockito.version>2.21.0</mockito.version>
 		<hamcrest.version>1.3</hamcrest.version>


### PR DESCRIPTION
## What is the purpose of the change

This solves #31 and upgrade log4j version to 2.17.2.

## Brief change log

  - Upgrade log4j version to 2.17.2.

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.
