### PR TITLE
[FRS-13] Implement ReducePartition for remote shuffle service

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -68,7 +68,7 @@
 		<alibaba.metrics.version>2.0.6</alibaba.metrics.version>
 		<commons.cli.version>1.3.1</commons.cli.version>
 		<zookeeper.version>3.5.9</zookeeper.version>
-		<flink.version>1.15-SNAPSHOT</flink.version>
+		<flink.version>1.16-SNAPSHOT</flink.version>
 		<rpc.flink.version>1.14.0</rpc.flink.version>
 		<jetty.version>9.4.44.v20210927</jetty.version>
 		<http.client.version>4.5.13</http.client.version>

--- a/shuffle-coordinator/src/main/java/com/alibaba/flink/shuffle/client/ShuffleManagerClient.java
+++ b/shuffle-coordinator/src/main/java/com/alibaba/flink/shuffle/client/ShuffleManagerClient.java
@@ -40,12 +40,7 @@ public interface ShuffleManagerClient extends AutoCloseable {
             DataSetID dataSetId,
             MapPartitionID mapPartitionId,
             int numberOfSubpartitions,
-            String dataPartitionFactoryName);
-
-    CompletableFuture<ShuffleResource> requestShuffleResource(
-            DataSetID dataSetId,
-            MapPartitionID mapPartitionId,
-            int numberOfSubpartitions,
+            long consumerGroupID,
             String dataPartitionFactoryName,
             String taskLocation);
 

--- a/shuffle-coordinator/src/main/java/com/alibaba/flink/shuffle/client/ShuffleManagerClientImpl.java
+++ b/shuffle-coordinator/src/main/java/com/alibaba/flink/shuffle/client/ShuffleManagerClientImpl.java
@@ -492,23 +492,7 @@ public class ShuffleManagerClientImpl implements ShuffleManagerClient, LeaderRet
             DataSetID dataSetId,
             MapPartitionID mapPartitionId,
             int numberOfSubpartitions,
-            String dataPartitionFactoryName) {
-        return sendRpcCall(
-                (shuffleManagerJobGateway) ->
-                        shuffleManagerJobGateway.requestShuffleResource(
-                                jobID,
-                                clientID,
-                                dataSetId,
-                                mapPartitionId,
-                                numberOfSubpartitions,
-                                dataPartitionFactoryName));
-    }
-
-    @Override
-    public CompletableFuture<ShuffleResource> requestShuffleResource(
-            DataSetID dataSetId,
-            MapPartitionID mapPartitionId,
-            int numberOfSubpartitions,
+            long consumerGroupID,
             String dataPartitionFactoryName,
             String taskLocation) {
         return sendRpcCall(
@@ -519,6 +503,7 @@ public class ShuffleManagerClientImpl implements ShuffleManagerClient, LeaderRet
                                 dataSetId,
                                 mapPartitionId,
                                 numberOfSubpartitions,
+                                consumerGroupID,
                                 dataPartitionFactoryName,
                                 taskLocation));
     }

--- a/shuffle-coordinator/src/main/java/com/alibaba/flink/shuffle/coordinator/manager/ShuffleManager.java
+++ b/shuffle-coordinator/src/main/java/com/alibaba/flink/shuffle/coordinator/manager/ShuffleManager.java
@@ -351,6 +351,7 @@ public class ShuffleManager extends RemoteShuffleFencedRpcEndpoint<UUID>
             DataSetID dataSetID,
             MapPartitionID mapPartitionID,
             int numberOfConsumers,
+            long consumerGroupID,
             String dataPartitionFactoryName) {
         return requestShuffleResource(
                 jobID,
@@ -358,6 +359,7 @@ public class ShuffleManager extends RemoteShuffleFencedRpcEndpoint<UUID>
                 dataSetID,
                 mapPartitionID,
                 numberOfConsumers,
+                consumerGroupID,
                 dataPartitionFactoryName,
                 null);
     }
@@ -369,6 +371,7 @@ public class ShuffleManager extends RemoteShuffleFencedRpcEndpoint<UUID>
             DataSetID dataSetID,
             MapPartitionID mapPartitionID,
             int numberOfConsumers,
+            long consumerGroupID,
             String dataPartitionFactoryName,
             String taskLocation) {
         resourceRequestThroughput.mark();
@@ -393,6 +396,7 @@ public class ShuffleManager extends RemoteShuffleFencedRpcEndpoint<UUID>
                             dataSetID,
                             mapPartitionID,
                             numberOfConsumers,
+                            consumerGroupID,
                             dataPartitionFactoryName,
                             taskLocation);
             return CompletableFuture.completedFuture(allocatedShuffleResource);

--- a/shuffle-coordinator/src/main/java/com/alibaba/flink/shuffle/coordinator/manager/ShuffleManagerJobGateway.java
+++ b/shuffle-coordinator/src/main/java/com/alibaba/flink/shuffle/coordinator/manager/ShuffleManagerJobGateway.java
@@ -69,6 +69,7 @@ public interface ShuffleManagerJobGateway extends RemoteShuffleFencedRpcGateway<
      * @param dataSetID The id of the dataset that contains this partition.
      * @param mapPartitionID The id represents the map task.
      * @param numberOfConsumers The number of consumers of the partition.
+     * @param consumerGroupID The id of consumer vertex group of the partition.
      * @param dataPartitionFactoryName The factory name of the data partition.
      * @return The allocated shuffle resources.
      */
@@ -78,6 +79,7 @@ public interface ShuffleManagerJobGateway extends RemoteShuffleFencedRpcGateway<
             DataSetID dataSetID,
             MapPartitionID mapPartitionID,
             int numberOfConsumers,
+            long consumerGroupID,
             String dataPartitionFactoryName);
 
     /**
@@ -89,6 +91,7 @@ public interface ShuffleManagerJobGateway extends RemoteShuffleFencedRpcGateway<
      * @param dataSetID The id of the dataset that contains this partition.
      * @param mapPartitionID The id represents the map task.
      * @param numberOfConsumers The number of consumers of the partition.
+     * @param consumerGroupID The id of consumer vertex group of the partition.
      * @param dataPartitionFactoryName The factory name of the data partition.
      * @param taskLocation The location (host name) of the target task requesting resources.
      * @return The allocated shuffle resources.
@@ -99,6 +102,7 @@ public interface ShuffleManagerJobGateway extends RemoteShuffleFencedRpcGateway<
             DataSetID dataSetID,
             MapPartitionID mapPartitionID,
             int numberOfConsumers,
+            long consumerGroupID,
             String dataPartitionFactoryName,
             @Nullable String taskLocation);
 

--- a/shuffle-coordinator/src/main/java/com/alibaba/flink/shuffle/coordinator/manager/ShuffleResource.java
+++ b/shuffle-coordinator/src/main/java/com/alibaba/flink/shuffle/coordinator/manager/ShuffleResource.java
@@ -16,6 +16,9 @@
 
 package com.alibaba.flink.shuffle.coordinator.manager;
 
+import com.alibaba.flink.shuffle.core.storage.DataPartition;
+import com.alibaba.flink.shuffle.core.storage.DiskType;
+
 import java.io.Serializable;
 
 /**
@@ -26,4 +29,12 @@ public interface ShuffleResource extends Serializable {
     ShuffleWorkerDescriptor[] getReducePartitionLocations();
 
     ShuffleWorkerDescriptor getMapPartitionLocation();
+
+    void setConsumerGroupID(long consumerGroupID);
+
+    long getConsumerGroupID();
+
+    DataPartition.DataPartitionType getDataPartitionType();
+
+    DiskType getDiskType();
 }

--- a/shuffle-coordinator/src/main/java/com/alibaba/flink/shuffle/coordinator/manager/assignmenttracker/AssignmentTracker.java
+++ b/shuffle-coordinator/src/main/java/com/alibaba/flink/shuffle/coordinator/manager/assignmenttracker/AssignmentTracker.java
@@ -121,6 +121,7 @@ public interface AssignmentTracker {
      * @param dataSetID The id of the dataset that contains this partition.
      * @param mapPartitionID The id represents the map task.
      * @param numberOfConsumers The number of consumers of the partition.
+     * @param consumerGroupID The id of consumer vertex gourp of the partition.
      * @param dataPartitionFactoryName The factory name of the data partition.
      * @param taskLocation The location (host name) of the target task requesting resources.
      * @return The allocated shuffle resources.
@@ -130,6 +131,7 @@ public interface AssignmentTracker {
             DataSetID dataSetID,
             MapPartitionID mapPartitionID,
             int numberOfConsumers,
+            long consumerGroupID,
             String dataPartitionFactoryName,
             String taskLocation)
             throws ShuffleResourceAllocationException;

--- a/shuffle-coordinator/src/test/java/com/alibaba/flink/shuffle/client/ShuffleManagerClientTest.java
+++ b/shuffle-coordinator/src/test/java/com/alibaba/flink/shuffle/client/ShuffleManagerClientTest.java
@@ -38,6 +38,7 @@ import com.alibaba.flink.shuffle.core.ids.InstanceID;
 import com.alibaba.flink.shuffle.core.ids.JobID;
 import com.alibaba.flink.shuffle.core.ids.MapPartitionID;
 import com.alibaba.flink.shuffle.core.storage.DataPartition;
+import com.alibaba.flink.shuffle.core.storage.DiskType;
 import com.alibaba.flink.shuffle.rpc.message.Acknowledge;
 import com.alibaba.flink.shuffle.rpc.test.TestingRpcService;
 import com.alibaba.flink.shuffle.rpc.utils.RpcUtils;
@@ -393,7 +394,8 @@ public class ShuffleManagerClientTest {
                         new ShuffleWorkerDescriptor[] {
                             new ShuffleWorkerDescriptor(new InstanceID("worker1"), "worker1", 20480)
                         },
-                        DataPartition.DataPartitionType.MAP_PARTITION);
+                        DataPartition.DataPartitionType.MAP_PARTITION,
+                        DiskType.ANY_TYPE);
         smGateway.setAllocateShuffleResourceConsumer(
                 (jobID, dataSetID, mapPartitionID, numberOfSubpartitions) -> {
                     resourceRequestFuture.complete(
@@ -436,7 +438,9 @@ public class ShuffleManagerClientTest {
                             dataSetId,
                             dataPartitionId,
                             numberOfSubpartitions,
-                            partitionFactoryName);
+                            0,
+                            partitionFactoryName,
+                            null);
             result1.join();
 
             assertThat(

--- a/shuffle-coordinator/src/test/java/com/alibaba/flink/shuffle/coordinator/manager/ShuffleManagerHATest.java
+++ b/shuffle-coordinator/src/test/java/com/alibaba/flink/shuffle/coordinator/manager/ShuffleManagerHATest.java
@@ -180,6 +180,7 @@ public class ShuffleManagerHATest {
                 DataSetID dataSetID,
                 MapPartitionID mapPartitionID,
                 int numberOfConsumers,
+                long consumerGroupID,
                 String dataPartitionFactoryName,
                 String taskLocation) {
             return null;

--- a/shuffle-coordinator/src/test/java/com/alibaba/flink/shuffle/coordinator/manager/ShuffleManagerTest.java
+++ b/shuffle-coordinator/src/test/java/com/alibaba/flink/shuffle/coordinator/manager/ShuffleManagerTest.java
@@ -395,7 +395,7 @@ public class ShuffleManagerTest extends TestLogger {
         MapPartitionID dataPartitionID = RandomIDUtils.randomMapPartitionId();
         shuffleManagerGateway
                 .requestShuffleResource(
-                        jobID, instanceId, dataSetID, dataPartitionID, 1, partitionFactoryName)
+                        jobID, instanceId, dataSetID, dataPartitionID, 1, 0, partitionFactoryName)
                 .get();
 
         shuffleManagerGateway.unregisterClient(jobID, instanceId).get();
@@ -445,6 +445,7 @@ public class ShuffleManagerTest extends TestLogger {
                                 dataSetID,
                                 mapPartitionID,
                                 128,
+                                0,
                                 partitionFactoryName)
                         .get();
         assertTrue(shuffleResource instanceof DefaultShuffleResource);
@@ -485,6 +486,7 @@ public class ShuffleManagerTest extends TestLogger {
                             RandomIDUtils.randomDataSetId(),
                             RandomIDUtils.randomMapPartitionId(),
                             2,
+                            0,
                             partitionFactoryName);
             assertFailedWithInconsistentInstanceId(result);
         }

--- a/shuffle-coordinator/src/test/java/com/alibaba/flink/shuffle/coordinator/manager/assignmenttracker/AssignmentTrackerTest.java
+++ b/shuffle-coordinator/src/test/java/com/alibaba/flink/shuffle/coordinator/manager/assignmenttracker/AssignmentTrackerTest.java
@@ -39,8 +39,6 @@ import com.alibaba.flink.shuffle.rpc.message.Acknowledge;
 
 import org.apache.commons.lang3.tuple.Triple;
 import org.junit.Test;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -66,7 +64,6 @@ import static org.junit.Assert.fail;
 
 /** Tests the assignment tracker implementation by {@link AssignmentTrackerImpl}. */
 public class AssignmentTrackerTest {
-    private static final Logger LOG = LoggerFactory.getLogger(AssignmentTrackerTest.class);
 
     private static final String partitionFactory =
             "com.alibaba.flink.shuffle.storage.partition.LocalFileMapPartitionFactory";
@@ -107,7 +104,7 @@ public class AssignmentTrackerTest {
         assignmentTracker.registerJob(jobId);
 
         assignmentTracker.requestShuffleResource(
-                jobId, randomDataSetId(), randomMapPartitionId(), 3, partitionFactory, null);
+                jobId, randomDataSetId(), randomMapPartitionId(), 3, 0, partitionFactory, null);
     }
 
     @Test
@@ -148,10 +145,10 @@ public class AssignmentTrackerTest {
         List<ShuffleResource> allocatedResources = new ArrayList<>();
         allocatedResources.add(
                 assignmentTracker.requestShuffleResource(
-                        jobId, randomDataSetId(), dataPartitionId1, 2, partitionFactory, null));
+                        jobId, randomDataSetId(), dataPartitionId1, 2, 0, partitionFactory, null));
         allocatedResources.add(
                 assignmentTracker.requestShuffleResource(
-                        jobId, randomDataSetId(), dataPartitionId2, 2, partitionFactory, null));
+                        jobId, randomDataSetId(), dataPartitionId2, 2, 0, partitionFactory, null));
         assertThat(
                 allocatedResources.stream()
                         .map(
@@ -177,12 +174,12 @@ public class AssignmentTrackerTest {
         MapPartitionID dataPartitionId = randomMapPartitionId();
         ShuffleResource shuffleResource1 =
                 assignmentTracker.requestShuffleResource(
-                        jobId, dataSetId, dataPartitionId, 2, partitionFactory, null);
+                        jobId, dataSetId, dataPartitionId, 2, 0, partitionFactory, null);
 
         // reallocation the same data partition on the same worker should remain unchanged
         ShuffleResource shuffleResource2 =
                 assignmentTracker.requestShuffleResource(
-                        jobId, dataSetId, dataPartitionId, 2, partitionFactory, null);
+                        jobId, dataSetId, dataPartitionId, 2, 0, partitionFactory, null);
         assertEquals(shuffleResource1, shuffleResource2);
     }
 
@@ -232,7 +229,7 @@ public class AssignmentTrackerTest {
                         jobId, worker1, new InstanceID("worker1"), shuffleWorkerGateway);
 
         assignmentTracker.requestShuffleResource(
-                jobId, dataSetID, dataPartitionID, 2, partitionFactory, null);
+                jobId, dataSetID, dataPartitionID, 2, 0, partitionFactory, null);
         assignmentTracker.synchronizeWorkerDataPartitions(
                 worker1,
                 Collections.singletonList(
@@ -267,7 +264,7 @@ public class AssignmentTrackerTest {
                         jobId, worker1, new InstanceID("worker1"), shuffleWorkerGateway);
 
         assignmentTracker.requestShuffleResource(
-                jobId, dataSetID, dataPartitionID, 2, partitionFactory, null);
+                jobId, dataSetID, dataPartitionID, 2, 0, partitionFactory, null);
         assignmentTracker.releaseShuffleResource(jobId, dataSetID, dataPartitionID);
         shuffleWorkerGateway.reset();
 
@@ -305,7 +302,7 @@ public class AssignmentTrackerTest {
                         jobId, worker1, new InstanceID("worker1"), shuffleWorkerGateway);
 
         assignmentTracker.requestShuffleResource(
-                jobId, dataSetID, dataPartitionID, 2, partitionFactory, null);
+                jobId, dataSetID, dataPartitionID, 2, 0, partitionFactory, null);
         assignmentTracker.releaseShuffleResource(jobId, dataSetID, dataPartitionID);
         shuffleWorkerGateway.reset();
 
@@ -343,7 +340,7 @@ public class AssignmentTrackerTest {
                 new DataPartitionCoordinate(dataSetId, dataPartitionId);
 
         assignmentTracker.requestShuffleResource(
-                jobId, dataSetId, dataPartitionId, 2, partitionFactory, null);
+                jobId, dataSetId, dataPartitionId, 2, 0, partitionFactory, null);
 
         // Step 1. Client asks to releasing the data partition
         assignmentTracker.releaseShuffleResource(jobId, dataSetId, dataPartitionId);
@@ -414,7 +411,7 @@ public class AssignmentTrackerTest {
                 new DataPartitionCoordinate(dataSetId, dataPartitionId);
 
         assignmentTracker.requestShuffleResource(
-                jobId, dataSetId, dataPartitionId, 2, partitionFactory, null);
+                jobId, dataSetId, dataPartitionId, 2, 0, partitionFactory, null);
 
         // Step 1. Worker reports the data is released
         assignmentTracker.workerReportDataPartitionReleased(
@@ -491,7 +488,7 @@ public class AssignmentTrackerTest {
         // Requesting two shuffle resources, which would be assigned in the two workers
         InstanceID firstWorkerId =
                 (assignmentTracker.requestShuffleResource(
-                                jobId, dataSetID, mapPartitionID, 2, partitionFactory, null))
+                                jobId, dataSetID, mapPartitionID, 2, 0, partitionFactory, null))
                         .getMapPartitionLocation()
                         .getWorkerId();
         InstanceID secondWorkerId =
@@ -500,6 +497,7 @@ public class AssignmentTrackerTest {
                                 RandomIDUtils.randomDataSetId(),
                                 RandomIDUtils.randomMapPartitionId(),
                                 2,
+                                0,
                                 partitionFactory,
                                 null))
                         .getMapPartitionLocation()
@@ -547,7 +545,7 @@ public class AssignmentTrackerTest {
         MapPartitionID mapPartitionID = RandomIDUtils.randomMapPartitionId();
 
         assignmentTracker.requestShuffleResource(
-                jobId, dataSetID, mapPartitionID, 2, partitionFactory, null);
+                jobId, dataSetID, mapPartitionID, 2, 0, partitionFactory, null);
 
         // This is a safe guard, in reality the following should not happen, but
         // we still want to have this.
@@ -576,9 +574,9 @@ public class AssignmentTrackerTest {
                         jobId, worker1, new InstanceID("worker1"), shuffleWorkerGateway);
 
         assignmentTracker.requestShuffleResource(
-                jobId, dataSetId, dataPartitionID1, 2, partitionFactory, null);
+                jobId, dataSetId, dataPartitionID1, 2, 0, partitionFactory, null);
         assignmentTracker.requestShuffleResource(
-                jobId, dataSetId, dataPartitionID2, 2, partitionFactory, null);
+                jobId, dataSetId, dataPartitionID2, 2, 0, partitionFactory, null);
 
         assignmentTracker.unregisterJob(jobId);
 
@@ -610,9 +608,9 @@ public class AssignmentTrackerTest {
                         jobId, worker1, new InstanceID("worker1"), shuffleWorkerGateway);
 
         assignmentTracker.requestShuffleResource(
-                jobId, dataSetId, dataPartitionID1, 2, partitionFactory, null);
+                jobId, dataSetId, dataPartitionID1, 2, 0, partitionFactory, null);
         assignmentTracker.requestShuffleResource(
-                jobId, dataSetId, dataPartitionID2, 2, partitionFactory, null);
+                jobId, dataSetId, dataPartitionID2, 2, 0, partitionFactory, null);
 
         assignmentTracker.unregisterWorker(worker1);
 
@@ -636,9 +634,9 @@ public class AssignmentTrackerTest {
                         jobId, worker1, new InstanceID("worker1"), shuffleWorkerGateway);
 
         assignmentTracker.requestShuffleResource(
-                jobId, dataSetId, dataPartitionID1, 2, partitionFactory, null);
+                jobId, dataSetId, dataPartitionID1, 2, 0, partitionFactory, null);
         assignmentTracker.requestShuffleResource(
-                jobId, dataSetId, dataPartitionID2, 2, partitionFactory, null);
+                jobId, dataSetId, dataPartitionID2, 2, 0, partitionFactory, null);
 
         assignmentTracker.releaseShuffleResource(jobId, dataSetId, dataPartitionID1);
 
@@ -664,7 +662,7 @@ public class AssignmentTrackerTest {
                         jobId, worker1, new InstanceID("worker1"), shuffleWorkerGateway1);
 
         assignmentTracker.requestShuffleResource(
-                jobId, dataSetId, dataPartitionId, 2, partitionFactory, null);
+                jobId, dataSetId, dataPartitionId, 2, 0, partitionFactory, null);
         assertEquals(1, assignmentTracker.getWorkers().get(worker1).getDataPartitions().size());
         assertEquals(1, assignmentTracker.getJobs().get(jobId).getDataPartitions().size());
 
@@ -767,7 +765,7 @@ public class AssignmentTrackerTest {
 
         try {
             assignmentTracker.requestShuffleResource(
-                    jobId, randomDataSetId(), randomMapPartitionId(), 2, partitionFactory, null);
+                    jobId, randomDataSetId(), randomMapPartitionId(), 2, 0, partitionFactory, null);
         } catch (Exception e) {
             fail(e.getMessage());
         }
@@ -776,7 +774,46 @@ public class AssignmentTrackerTest {
         storageSpaceInfos.put(partitionFactory, StorageSpaceInfo.ZERO_STORAGE_SPACE);
         assignmentTracker.getWorkers().get(worker1).updateStorageSpaceInfo(storageSpaceInfos);
         assignmentTracker.requestShuffleResource(
-                jobId, randomDataSetId(), randomMapPartitionId(), 2, partitionFactory, null);
+                jobId, randomDataSetId(), randomMapPartitionId(), 2, 0, partitionFactory, null);
+    }
+
+    @Test
+    public void testChooseSortedWorkers() throws ShuffleResourceAllocationException {
+        JobID jobId = randomJobId();
+        Configuration configuration = new Configuration();
+        AssignmentTrackerImpl assignmentTracker = new AssignmentTrackerImpl(configuration);
+        assignmentTracker.registerJob(jobId);
+
+        // Registers two workers
+        RegistrationID worker1 = new RegistrationID();
+        RegistrationID worker2 = new RegistrationID();
+        RegistrationID worker3 = new RegistrationID();
+
+        assignmentTracker.registerWorker(
+                new InstanceID("worker1"),
+                worker1,
+                new EmptyShuffleWorkerGateway(),
+                "worker1",
+                1024);
+        assignmentTracker.registerWorker(
+                new InstanceID("worker2"),
+                worker2,
+                new EmptyShuffleWorkerGateway(),
+                "worker2",
+                1026);
+        assignmentTracker.registerWorker(
+                new InstanceID("worker3"),
+                worker3,
+                new EmptyShuffleWorkerGateway(),
+                "worker3",
+                1027);
+        assertEquals(3, assignmentTracker.getNumberOfWorkers());
+
+        List<WorkerStatus> chosenWorkers = assignmentTracker.chooseWorkers(2);
+        assertEquals(2, chosenWorkers.size());
+
+        chosenWorkers = assignmentTracker.chooseWorkers(7);
+        assertEquals(7, chosenWorkers.size());
     }
 
     // ------------------------------- Utilities ----------------------------------------------

--- a/shuffle-coordinator/src/test/java/com/alibaba/flink/shuffle/coordinator/manager/assignmenttracker/LocalityPlacementStrategyTest.java
+++ b/shuffle-coordinator/src/test/java/com/alibaba/flink/shuffle/coordinator/manager/assignmenttracker/LocalityPlacementStrategyTest.java
@@ -71,6 +71,7 @@ public class LocalityPlacementStrategyTest {
                             randomDataSetId(),
                             dataPartitionId,
                             2,
+                            0,
                             PARTITION_FACTORY_CLASS,
                             "localhost");
             assertEquals("localhost", shuffleResource.getMapPartitionLocation().getWorkerAddress());
@@ -92,6 +93,7 @@ public class LocalityPlacementStrategyTest {
                             randomDataSetId(),
                             dataPartitionId,
                             2,
+                            0,
                             PARTITION_FACTORY_CLASS,
                             "localhost");
             assertEquals("remote", shuffleResource.getMapPartitionLocation().getWorkerAddress());

--- a/shuffle-coordinator/src/test/java/com/alibaba/flink/shuffle/coordinator/manager/assignmenttracker/MinNumberPlacementStrategyTest.java
+++ b/shuffle-coordinator/src/test/java/com/alibaba/flink/shuffle/coordinator/manager/assignmenttracker/MinNumberPlacementStrategyTest.java
@@ -72,6 +72,7 @@ public class MinNumberPlacementStrategyTest {
                         randomDataSetId(),
                         dataPartitionId1,
                         2,
+                        0,
                         PARTITION_FACTORY_CLASS,
                         null);
         String workerAddress1 = shuffleResource1.getMapPartitionLocation().getWorkerAddress();
@@ -81,6 +82,7 @@ public class MinNumberPlacementStrategyTest {
                         randomDataSetId(),
                         dataPartitionId2,
                         2,
+                        0,
                         PARTITION_FACTORY_CLASS,
                         null);
         String workerAddress2 = shuffleResource2.getMapPartitionLocation().getWorkerAddress();

--- a/shuffle-coordinator/src/test/java/com/alibaba/flink/shuffle/coordinator/manager/assignmenttracker/PlacementStrategyTestUtils.java
+++ b/shuffle-coordinator/src/test/java/com/alibaba/flink/shuffle/coordinator/manager/assignmenttracker/PlacementStrategyTestUtils.java
@@ -147,6 +147,7 @@ public class PlacementStrategyTestUtils {
                             randomDataSetId(),
                             dataPartitionId,
                             2,
+                            0,
                             PARTITION_FACTORY_CLASS,
                             taskLocation);
             shuffleResources.add(shuffleResource);
@@ -214,6 +215,7 @@ public class PlacementStrategyTestUtils {
                     randomDataSetId(),
                     randomMapPartitionId(),
                     2,
+                    0,
                     PARTITION_FACTORY_CLASS,
                     taskLocation);
         } catch (ShuffleResourceAllocationException e) {

--- a/shuffle-coordinator/src/test/java/com/alibaba/flink/shuffle/coordinator/manager/assignmenttracker/RandomPlacementStrategyTest.java
+++ b/shuffle-coordinator/src/test/java/com/alibaba/flink/shuffle/coordinator/manager/assignmenttracker/RandomPlacementStrategyTest.java
@@ -82,6 +82,7 @@ public class RandomPlacementStrategyTest {
                             randomDataSetId(),
                             dataPartitionId,
                             2,
+                            0,
                             PARTITION_FACTORY_CLASS,
                             null);
             shuffleResources.add(shuffleResource);

--- a/shuffle-coordinator/src/test/java/com/alibaba/flink/shuffle/coordinator/manager/assignmenttracker/RoundRobinPlacementStrategyTest.java
+++ b/shuffle-coordinator/src/test/java/com/alibaba/flink/shuffle/coordinator/manager/assignmenttracker/RoundRobinPlacementStrategyTest.java
@@ -84,6 +84,7 @@ public class RoundRobinPlacementStrategyTest {
                             randomDataSetId(),
                             dataPartitionId,
                             2,
+                            0,
                             PARTITION_FACTORY_CLASS,
                             null);
             shuffleResources.add(shuffleResource);

--- a/shuffle-coordinator/src/test/java/com/alibaba/flink/shuffle/coordinator/utils/EmptyPartitionedDataStore.java
+++ b/shuffle-coordinator/src/test/java/com/alibaba/flink/shuffle/coordinator/utils/EmptyPartitionedDataStore.java
@@ -22,6 +22,7 @@ import com.alibaba.flink.shuffle.core.ids.DataPartitionID;
 import com.alibaba.flink.shuffle.core.ids.DataSetID;
 import com.alibaba.flink.shuffle.core.ids.JobID;
 import com.alibaba.flink.shuffle.core.memory.BufferDispatcher;
+import com.alibaba.flink.shuffle.core.storage.DataPartitionFactory;
 import com.alibaba.flink.shuffle.core.storage.DataPartitionMeta;
 import com.alibaba.flink.shuffle.core.storage.DataPartitionReadingView;
 import com.alibaba.flink.shuffle.core.storage.DataPartitionWritingView;
@@ -53,6 +54,11 @@ public class EmptyPartitionedDataStore implements PartitionedDataStore {
     @Override
     public boolean isDataPartitionConsumable(DataPartitionMeta partitionMeta) {
         return false;
+    }
+
+    @Override
+    public Map<String, DataPartitionFactory> partitionFactories() {
+        return null;
     }
 
     @Override

--- a/shuffle-coordinator/src/test/java/com/alibaba/flink/shuffle/coordinator/utils/TestingShuffleManagerGateway.java
+++ b/shuffle-coordinator/src/test/java/com/alibaba/flink/shuffle/coordinator/utils/TestingShuffleManagerGateway.java
@@ -300,6 +300,7 @@ public class TestingShuffleManagerGateway implements ShuffleManagerGateway {
             DataSetID dataSetID,
             MapPartitionID mapPartitionID,
             int numberOfConsumers,
+            long consumerGroupID,
             String dataPartitionFactoryName) {
         return requestShuffleResource(
                 jobID,
@@ -307,6 +308,7 @@ public class TestingShuffleManagerGateway implements ShuffleManagerGateway {
                 dataSetID,
                 mapPartitionID,
                 numberOfConsumers,
+                consumerGroupID,
                 dataPartitionFactoryName,
                 null);
     }
@@ -318,6 +320,7 @@ public class TestingShuffleManagerGateway implements ShuffleManagerGateway {
             DataSetID dataSetID,
             MapPartitionID mapPartitionID,
             int numberOfConsumers,
+            long consumerGroupID,
             String dataPartitionFactoryName,
             String taskLocation) {
         QuadFunction<JobID, DataSetID, MapPartitionID, Integer, CompletableFuture<ShuffleResource>>

--- a/shuffle-coordinator/src/test/java/com/alibaba/flink/shuffle/minicluster/ShuffleMiniClusterTest.java
+++ b/shuffle-coordinator/src/test/java/com/alibaba/flink/shuffle/minicluster/ShuffleMiniClusterTest.java
@@ -62,7 +62,7 @@ public class ShuffleMiniClusterTest {
             MapPartitionID mapPartitionId = RandomIDUtils.randomMapPartitionId();
             CompletableFuture<ShuffleResource> shuffleResource =
                     client.requestShuffleResource(
-                            dataSetId, mapPartitionId, 2, partitionFactoryName);
+                            dataSetId, mapPartitionId, 2, 0, partitionFactoryName, null);
             shuffleResource.get(60_000, TimeUnit.MILLISECONDS);
         }
     }

--- a/shuffle-core/src/main/java/com/alibaba/flink/shuffle/core/config/StorageOptions.java
+++ b/shuffle-core/src/main/java/com/alibaba/flink/shuffle/core/config/StorageOptions.java
@@ -153,6 +153,20 @@ public class StorageOptions {
                                     MIN_WRITING_READING_MEMORY_SIZE.toHumanReadableString(),
                                     MIN_WRITING_READING_MEMORY_SIZE.toHumanReadableString()));
 
+    public static final ConfigOption<MemorySize> STORAGE_PARTITION_LAZY_RECYCLE_WRITING_MEMORY =
+            new ConfigOption<MemorySize>(
+                            "remote-shuffle.storage.partition.lazy-recycle-writing-memory")
+                    .defaultValue(MemorySize.parse("1m"))
+                    .description(
+                            String.format(
+                                    "When writing data partition, some buffers are reserved when "
+                                            + "recycling to avoid requesting buffers too frequently. "
+                                            + "This is the memory size to reserve. Note that if the "
+                                            + "configured value is more than %s, the value of %s "
+                                            + "will be used.",
+                                    STORAGE_MAX_PARTITION_WRITING_MEMORY.key(),
+                                    STORAGE_MAX_PARTITION_WRITING_MEMORY.key()));
+
     /**
      * The update interval of the worker check thread which will periodically get the status like
      * disk space at this time interval.

--- a/shuffle-core/src/main/java/com/alibaba/flink/shuffle/core/storage/DataPartitionFactory.java
+++ b/shuffle-core/src/main/java/com/alibaba/flink/shuffle/core/storage/DataPartitionFactory.java
@@ -42,6 +42,7 @@ public interface DataPartitionFactory {
      * @param jobID ID of the job which is trying to write data to the {@link PartitionedDataStore}.
      * @param dataSetID ID of the dataset to witch the {@link DataPartition} belongs to.
      * @param dataPartitionID ID of the {@link DataPartition} to be created and written.
+     * @param numMapPartitions Number of logic {@link MapPartition}s of the {@link DataSet}.
      * @param numReducePartitions Number of logic {@link ReducePartition}s of the {@link DataSet}.
      * @return A new {@link DataPartition} to write data to and read data from.
      */
@@ -50,6 +51,7 @@ public interface DataPartitionFactory {
             JobID jobID,
             DataSetID dataSetID,
             DataPartitionID dataPartitionID,
+            int numMapPartitions,
             int numReducePartitions)
             throws Exception;
 
@@ -94,6 +96,9 @@ public interface DataPartitionFactory {
      */
     void updateStorageHealthStatus();
 
+    /** Returns the disk type of the {@link DataPartitionFactory}. */
+    DiskType getDiskType();
+
     /** Whether this partition factory only uses SSD as storage device. */
     boolean useSsdOnly();
 
@@ -105,4 +110,10 @@ public interface DataPartitionFactory {
 
     /** Updates the storage spaces in bytes already used. */
     void updateUsedStorageSpace(Map<String, Long> storageUsedBytes);
+
+    static DataPartition.DataPartitionType getDataPartitionType(String dataPartitionFactoryName)
+            throws ClassNotFoundException, InstantiationException, IllegalAccessException {
+        return ((DataPartitionFactory) Class.forName(dataPartitionFactoryName).newInstance())
+                .getDataPartitionType();
+    }
 }

--- a/shuffle-core/src/main/java/com/alibaba/flink/shuffle/core/storage/DataPartitionWritingView.java
+++ b/shuffle-core/src/main/java/com/alibaba/flink/shuffle/core/storage/DataPartitionWritingView.java
@@ -49,7 +49,7 @@ public interface DataPartitionWritingView {
      * Writes a {@link Buffer} of the given {@link MapPartitionID} and {@link ReducePartitionID} to
      * the corresponding {@link DataPartition} through this partition writing view.
      */
-    void onBuffer(Buffer buffer, ReducePartitionID reducePartitionID);
+    void onBuffer(Buffer buffer, int regionIndex, ReducePartitionID reducePartitionID);
 
     /**
      * Marks the starting of a new data region and announces the number of credits required by the
@@ -61,10 +61,20 @@ public interface DataPartitionWritingView {
     void regionStarted(int dataRegionIndex, boolean isBroadcastRegion);
 
     /**
+     * Marks the starting of a new data region and announces the number of credits required by the
+     * new data region.
+     *
+     * @param dataRegionIndex Index of the new data region to be written.
+     * @param numMaps The number of map partitions.
+     * @param isBroadcastRegion Whether to broadcast data to all reduce partitions in this region.
+     */
+    void regionStarted(int dataRegionIndex, int numMaps, int needCredit, boolean isBroadcastRegion);
+
+    /**
      * Marks the current data region as finished, after which no data of the same region will be
      * written any more and the current data region is completed and ready to be processed.
      */
-    void regionFinished();
+    void regionFinished(int dataRegionIndex);
 
     /**
      * Finishes the data input, which means no data will be written through this partition writing

--- a/shuffle-core/src/main/java/com/alibaba/flink/shuffle/core/storage/DiskType.java
+++ b/shuffle-core/src/main/java/com/alibaba/flink/shuffle/core/storage/DiskType.java
@@ -1,0 +1,26 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.flink.shuffle.core.storage;
+
+/** An enumeration indicating the disk type for the shuffle resource. */
+public enum DiskType {
+    HDD_ONLY,
+    SSD_ONLY,
+    ANY_TYPE,
+}

--- a/shuffle-core/src/main/java/com/alibaba/flink/shuffle/core/storage/PartitionedDataStore.java
+++ b/shuffle-core/src/main/java/com/alibaba/flink/shuffle/core/storage/PartitionedDataStore.java
@@ -57,6 +57,9 @@ public interface PartitionedDataStore {
     /** Returns a boolean flag indicating whether the target {@link DataPartition} is consumable. */
     boolean isDataPartitionConsumable(DataPartitionMeta partitionMeta);
 
+    /** Returns a map including all {@link DataPartitionFactory}s in the data store. */
+    Map<String, DataPartitionFactory> partitionFactories();
+
     /**
      * Adds a new {@link DataPartition} to this data store. This happens when adding an external
      * {@link DataPartition} or restarting from failure. Exception will be thrown if the target

--- a/shuffle-core/src/main/java/com/alibaba/flink/shuffle/core/storage/ReadingViewContext.java
+++ b/shuffle-core/src/main/java/com/alibaba/flink/shuffle/core/storage/ReadingViewContext.java
@@ -19,7 +19,6 @@ package com.alibaba.flink.shuffle.core.storage;
 import com.alibaba.flink.shuffle.common.utils.CommonUtils;
 import com.alibaba.flink.shuffle.core.ids.DataPartitionID;
 import com.alibaba.flink.shuffle.core.ids.DataSetID;
-import com.alibaba.flink.shuffle.core.ids.ReducePartitionID;
 import com.alibaba.flink.shuffle.core.listener.BacklogListener;
 import com.alibaba.flink.shuffle.core.listener.DataListener;
 import com.alibaba.flink.shuffle.core.listener.FailureListener;
@@ -39,6 +38,9 @@ public class ReadingViewContext {
     /** Index of the last logic {@link ReducePartition} to be read (inclusive). */
     private final int endPartitionIndex;
 
+    /** Number of the {@link ReducePartition}s of the whole {@link DataSet}. */
+    private final int numReducePartitions;
+
     /** Listener to be notified when there is any data available for reading. */
     private final DataListener dataListener;
 
@@ -56,26 +58,40 @@ public class ReadingViewContext {
             DataListener dataListener,
             BacklogListener backlogListener,
             FailureListener failureListener) {
+        this(
+                dataSetID,
+                partitionID,
+                startPartitionIndex,
+                endPartitionIndex,
+                Integer.MAX_VALUE,
+                dataListener,
+                backlogListener,
+                failureListener);
+    }
+
+    public ReadingViewContext(
+            DataSetID dataSetID,
+            DataPartitionID partitionID,
+            int startPartitionIndex,
+            int endPartitionIndex,
+            int numReducePartitions,
+            DataListener dataListener,
+            BacklogListener backlogListener,
+            FailureListener failureListener) {
         CommonUtils.checkArgument(dataSetID != null, "Must be not null.");
         CommonUtils.checkArgument(partitionID != null, "Must be not null.");
         CommonUtils.checkArgument(startPartitionIndex >= 0, "Must be non-negative.");
         CommonUtils.checkArgument(endPartitionIndex >= startPartitionIndex, "Illegal index range.");
+        CommonUtils.checkArgument(numReducePartitions >= 0, "Must be non-negative.");
         CommonUtils.checkArgument(dataListener != null, "Must be not null.");
         CommonUtils.checkArgument(backlogListener != null, "Must be not null.");
         CommonUtils.checkArgument(failureListener != null, "Must be not null.");
-
-        if (partitionID.getPartitionType() == DataPartition.DataPartitionType.REDUCE_PARTITION) {
-            ReducePartitionID reducePartitionID = (ReducePartitionID) partitionID;
-            CommonUtils.checkArgument(
-                    reducePartitionID.getPartitionIndex() == endPartitionIndex
-                            && reducePartitionID.getPartitionIndex() == startPartitionIndex,
-                    "Illegal reduce partition index range.");
-        }
 
         this.partitionID = partitionID;
         this.dataSetID = dataSetID;
         this.startPartitionIndex = startPartitionIndex;
         this.endPartitionIndex = endPartitionIndex;
+        this.numReducePartitions = numReducePartitions;
         this.dataListener = dataListener;
         this.backlogListener = backlogListener;
         this.failureListener = failureListener;
@@ -95,6 +111,10 @@ public class ReadingViewContext {
 
     public int getEndPartitionIndex() {
         return endPartitionIndex;
+    }
+
+    public int getNumReducePartitions() {
+        return numReducePartitions;
     }
 
     public DataListener getDataListener() {

--- a/shuffle-core/src/main/java/com/alibaba/flink/shuffle/core/storage/WritingViewContext.java
+++ b/shuffle-core/src/main/java/com/alibaba/flink/shuffle/core/storage/WritingViewContext.java
@@ -39,6 +39,9 @@ public class WritingViewContext {
     /** ID of the logic {@link MapPartition} that the written data belongs to. */
     private final MapPartitionID mapPartitionID;
 
+    /** The total number of partitions, which is equal to the upstream parallelism. */
+    private final int numMapPartitions;
+
     /** Number of the {@link ReducePartition}s of the whole {@link DataSet}. */
     private final int numReducePartitions;
 
@@ -56,6 +59,7 @@ public class WritingViewContext {
             DataSetID dataSetID,
             DataPartitionID dataPartitionID,
             MapPartitionID mapPartitionID,
+            int numMapPartitions,
             int numReducePartitions,
             String partitionFactoryClassName,
             DataRegionCreditListener dataRegionCreditListener,
@@ -64,6 +68,7 @@ public class WritingViewContext {
         CommonUtils.checkArgument(dataSetID != null, "Must be not null.");
         CommonUtils.checkArgument(dataPartitionID != null, "Must be not null.");
         CommonUtils.checkArgument(mapPartitionID != null, "Must be not null.");
+        CommonUtils.checkArgument(numMapPartitions >= 0, "Must be non-negative.");
         CommonUtils.checkArgument(numReducePartitions > 0, "Must be positive.");
         CommonUtils.checkArgument(partitionFactoryClassName != null, "Must be not null.");
         CommonUtils.checkArgument(dataRegionCreditListener != null, "Must be not null.");
@@ -73,6 +78,7 @@ public class WritingViewContext {
         this.dataSetID = dataSetID;
         this.dataPartitionID = dataPartitionID;
         this.mapPartitionID = mapPartitionID;
+        this.numMapPartitions = numMapPartitions;
         this.numReducePartitions = numReducePartitions;
         this.partitionFactoryClassName = partitionFactoryClassName;
         this.dataRegionCreditListener = dataRegionCreditListener;
@@ -93,6 +99,10 @@ public class WritingViewContext {
 
     public MapPartitionID getMapPartitionID() {
         return mapPartitionID;
+    }
+
+    public int getNumMapPartitions() {
+        return numMapPartitions;
     }
 
     public int getNumReducePartitions() {

--- a/shuffle-core/src/main/java/com/alibaba/flink/shuffle/core/utils/PartitionUtils.java
+++ b/shuffle-core/src/main/java/com/alibaba/flink/shuffle/core/utils/PartitionUtils.java
@@ -1,0 +1,80 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.flink.shuffle.core.utils;
+
+import com.alibaba.flink.shuffle.core.storage.DataPartition;
+import com.alibaba.flink.shuffle.core.storage.DataPartitionFactory;
+
+/** Utility methods to manipulate data partitions. */
+public class PartitionUtils {
+
+    public static final String HDD_MAP_PARTITION_FACTORY =
+            "com.alibaba.flink.shuffle.storage.partition.HDDOnlyLocalFileMapPartitionFactory";
+
+    public static final String SSD_MAP_PARTITION_FACTORY =
+            "com.alibaba.flink.shuffle.storage.partition.SSDOnlyLocalFileMapPartitionFactory";
+
+    public static final String MAP_PARTITION_FACTORY =
+            "com.alibaba.flink.shuffle.storage.partition.LocalFileMapPartitionFactory";
+
+    public static final String HDD_REDUCE_PARTITION_FACTORY =
+            "com.alibaba.flink.shuffle.storage.partition.HDDOnlyLocalFileReducePartitionFactory";
+
+    public static final String SSD_REDUCE_PARTITION_FACTORY =
+            "com.alibaba.flink.shuffle.storage.partition.SSDOnlyLocalFileReducePartitionFactory";
+
+    public static final String REDUCE_PARTITION_FACTORY =
+            "com.alibaba.flink.shuffle.storage.partition.LocalFileReducePartitionFactory";
+
+    public static String convertToMapPartitionFactory(String partitionFactory) {
+        switch (partitionFactory) {
+            case HDD_REDUCE_PARTITION_FACTORY:
+                return HDD_MAP_PARTITION_FACTORY;
+            case SSD_REDUCE_PARTITION_FACTORY:
+                return SSD_MAP_PARTITION_FACTORY;
+            case REDUCE_PARTITION_FACTORY:
+                return MAP_PARTITION_FACTORY;
+            default:
+                return partitionFactory;
+        }
+    }
+
+    public static boolean isMapPartitionFactory(String partitionFactory) {
+        return partitionFactory.equals(HDD_MAP_PARTITION_FACTORY)
+                || partitionFactory.equals(SSD_MAP_PARTITION_FACTORY)
+                || partitionFactory.equals(MAP_PARTITION_FACTORY);
+    }
+
+    public static boolean isMapPartition(String dataPartitionFactoryName) {
+        return isMapPartition(getDataPartitionType(dataPartitionFactoryName));
+    }
+
+    public static boolean isMapPartition(DataPartition.DataPartitionType partitionType) {
+        return partitionType.equals(DataPartition.DataPartitionType.MAP_PARTITION);
+    }
+
+    public static DataPartition.DataPartitionType getDataPartitionType(
+            String dataPartitionFactoryName) {
+        try {
+            return DataPartitionFactory.getDataPartitionType(dataPartitionFactoryName);
+        } catch (Throwable throwable) {
+            throw new RuntimeException("Failed to get data partition type, ", throwable);
+        }
+    }
+}

--- a/shuffle-e2e-tests/src/test/java/com/alibaba/flink/shuffle/e2e/flinkcluster/FlinkLocalCluster.java
+++ b/shuffle-e2e-tests/src/test/java/com/alibaba/flink/shuffle/e2e/flinkcluster/FlinkLocalCluster.java
@@ -150,7 +150,7 @@ public class FlinkLocalCluster {
 
         leaderRetrievalService.stop();
 
-        RpcUtils.terminateRpcService(rpcService, Time.seconds(30L));
+        RpcUtils.terminateRpcService(rpcService);
 
         highAvailabilityServices.closeAndCleanupAllData();
 
@@ -232,7 +232,7 @@ public class FlinkLocalCluster {
                         () ->
                                 dispatcherGateway.requestClusterOverview(
                                         Time.milliseconds(timeLeft.toMillis())),
-                        Time.milliseconds(50L),
+                        Duration.ofMillis(50L),
                         org.apache.flink.api.common.time.Deadline.fromNow(
                                 Duration.ofMillis(timeLeft.toMillis())),
                         overview -> overview.getNumTaskManagersConnected() >= numTaskManagers,

--- a/shuffle-plugin/src/main/java/com/alibaba/flink/shuffle/plugin/RemoteShuffleDescriptor.java
+++ b/shuffle-plugin/src/main/java/com/alibaba/flink/shuffle/plugin/RemoteShuffleDescriptor.java
@@ -28,6 +28,8 @@ import org.apache.flink.runtime.shuffle.ShuffleDescriptor;
 
 import java.util.Optional;
 
+import static com.alibaba.flink.shuffle.common.utils.CommonUtils.checkState;
+
 /** {@link ShuffleDescriptor} for the flink remote shuffle. */
 public class RemoteShuffleDescriptor implements ShuffleDescriptor {
 
@@ -42,11 +44,22 @@ public class RemoteShuffleDescriptor implements ShuffleDescriptor {
     /** The allocated shuffle resource. */
     private final ShuffleResource shuffleResource;
 
+    private final int numMaps;
+
+    private final boolean isMapPartition;
+
     public RemoteShuffleDescriptor(
-            ResultPartitionID resultPartitionID, JobID jobId, ShuffleResource shuffleResource) {
+            ResultPartitionID resultPartitionID,
+            JobID jobId,
+            ShuffleResource shuffleResource,
+            boolean isMapPartition,
+            int numMaps) {
         this.resultPartitionID = resultPartitionID;
         this.jobId = jobId;
         this.shuffleResource = shuffleResource;
+        this.isMapPartition = isMapPartition;
+        this.numMaps = numMaps;
+        checkState(isMapPartition || numMaps > 0);
     }
 
     @Override
@@ -76,6 +89,14 @@ public class RemoteShuffleDescriptor implements ShuffleDescriptor {
         return shuffleResource;
     }
 
+    public boolean isMapPartition() {
+        return isMapPartition;
+    }
+
+    public int getNumMaps() {
+        return numMaps;
+    }
+
     @Override
     public String toString() {
         return "RemoteShuffleDescriptor{"
@@ -89,6 +110,8 @@ public class RemoteShuffleDescriptor implements ShuffleDescriptor {
                 + getDataPartitionID()
                 + ", shuffleResource="
                 + shuffleResource
+                + ", isMapPartition="
+                + isMapPartition
                 + '}';
     }
 }

--- a/shuffle-plugin/src/main/java/com/alibaba/flink/shuffle/plugin/RemoteShuffleMaster.java
+++ b/shuffle-plugin/src/main/java/com/alibaba/flink/shuffle/plugin/RemoteShuffleMaster.java
@@ -29,6 +29,8 @@ import com.alibaba.flink.shuffle.coordinator.heartbeat.HeartbeatServicesUtils;
 import com.alibaba.flink.shuffle.coordinator.highavailability.HaServiceUtils;
 import com.alibaba.flink.shuffle.coordinator.highavailability.HaServices;
 import com.alibaba.flink.shuffle.coordinator.manager.DataPartitionCoordinate;
+import com.alibaba.flink.shuffle.coordinator.manager.ShuffleResource;
+import com.alibaba.flink.shuffle.coordinator.manager.ShuffleWorkerDescriptor;
 import com.alibaba.flink.shuffle.core.config.ClusterOptions;
 import com.alibaba.flink.shuffle.core.config.WorkerOptions;
 import com.alibaba.flink.shuffle.core.ids.DataSetID;
@@ -61,8 +63,11 @@ import java.util.Arrays;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
+import java.util.Objects;
+import java.util.Random;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.ScheduledThreadPoolExecutor;
@@ -70,10 +75,17 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 
+import static com.alibaba.flink.shuffle.common.utils.CommonUtils.checkArgument;
+import static com.alibaba.flink.shuffle.common.utils.CommonUtils.checkState;
+import static com.alibaba.flink.shuffle.core.utils.PartitionUtils.convertToMapPartitionFactory;
+import static com.alibaba.flink.shuffle.core.utils.PartitionUtils.isMapPartitionFactory;
+
 /** The shuffle manager implementation for remote shuffle service plugin. */
 public class RemoteShuffleMaster implements ShuffleMaster<RemoteShuffleDescriptor> {
 
     private static final Logger LOG = LoggerFactory.getLogger(RemoteShuffleMaster.class);
+
+    public static final Random RANDOM = new Random();
 
     private static final int MAX_RETRY_TIMES = 3;
 
@@ -87,6 +99,12 @@ public class RemoteShuffleMaster implements ShuffleMaster<RemoteShuffleDescripto
     private final Duration workerRecoverTimeout;
 
     private final Map<JobID, ShuffleClient> shuffleClients = new HashMap<>();
+
+    private final Map<DataSetIDCoordinate, Long> consumerGroupIDMap = new HashMap<>();
+
+    // Cache shuffle resources by the job ID and the dataset ID
+    private final Map<DataSetIDCoordinate, ShuffleResource> cacheShuffleResources =
+            new ConcurrentHashMap<>();
 
     private final ScheduledThreadPoolExecutor executor =
             new ScheduledThreadPoolExecutor(
@@ -145,11 +163,18 @@ public class RemoteShuffleMaster implements ShuffleMaster<RemoteShuffleDescripto
             org.apache.flink.api.common.JobID jobID,
             PartitionDescriptor partitionDescriptor,
             ProducerDescriptor producerDescriptor) {
+        PartitionTypeConverter partitionTypeConverter =
+                new PartitionTypeConverter(partitionDescriptor);
+        boolean isMapPartition = partitionTypeConverter.isMapPartition();
+        String partitionFactoryName = partitionTypeConverter.getPartitionFactory();
+        int numResultPartitions = partitionDescriptor.getTotalNumberOfPartitions();
+        checkState(isMapPartition || numResultPartitions > 0);
+
         CompletableFuture<RemoteShuffleDescriptor> future = new CompletableFuture<>();
         executor.execute(
                 () -> {
                     try {
-                        CommonUtils.checkState(!isClosed.get(), "ShuffleMaster has been closed.");
+                        checkState(!isClosed.get(), "ShuffleMaster has been closed.");
                         JobID shuffleJobID = IdMappingUtils.fromFlinkJobId(jobID);
                         ShuffleClient shuffleClient =
                                 CommonUtils.checkNotNull(shuffleClients.get(shuffleJobID));
@@ -164,13 +189,32 @@ public class RemoteShuffleMaster implements ShuffleMaster<RemoteShuffleDescripto
                         MapPartitionID mapPartitionId =
                                 IdMappingUtils.fromFlinkResultPartitionID(resultPartitionID);
 
+                        DataSetIDCoordinate dataSetIDCoordinate =
+                                new DataSetIDCoordinate(shuffleJobID, dataSetID);
+
+                        long consumerGroupID = generateRandomConsumerGroupID(dataSetIDCoordinate);
+                        ShuffleResource cachedShuffleResource =
+                                cacheShuffleResources.get(dataSetIDCoordinate);
+                        if (cachedShuffleResource != null) {
+                            future.complete(
+                                    new RemoteShuffleDescriptor(
+                                            resultPartitionID,
+                                            shuffleJobID,
+                                            cachedShuffleResource,
+                                            isMapPartition,
+                                            numResultPartitions));
+                            checkState(consumerGroupIDMap.containsKey(dataSetIDCoordinate));
+                            return;
+                        }
+
                         shuffleClient
                                 .getClient()
                                 .requestShuffleResource(
                                         dataSetID,
                                         mapPartitionId,
                                         partitionDescriptor.getNumberOfSubpartitions(),
-                                        partitionFactory,
+                                        consumerGroupID,
+                                        partitionFactoryName,
                                         producerDescriptor.getAddress().getHostName())
                                 .whenComplete(
                                         (shuffleResource, throwable) -> {
@@ -178,18 +222,20 @@ public class RemoteShuffleMaster implements ShuffleMaster<RemoteShuffleDescripto
                                                 future.completeExceptionally(throwable);
                                                 return;
                                             }
-                                            InstanceID workerID =
-                                                    shuffleResource
-                                                            .getMapPartitionLocation()
-                                                            .getWorkerId();
-                                            future.complete(
-                                                    new RemoteShuffleDescriptor(
-                                                            resultPartitionID,
-                                                            shuffleJobID,
-                                                            shuffleResource));
-                                            shuffleClient
-                                                    .getListener()
-                                                    .addPartition(workerID, resultPartitionID);
+                                            try {
+                                                addPartitionToWorker(
+                                                        future,
+                                                        shuffleJobID,
+                                                        shuffleClient,
+                                                        dataSetIDCoordinate,
+                                                        consumerGroupID,
+                                                        resultPartitionID,
+                                                        shuffleResource,
+                                                        numResultPartitions,
+                                                        isMapPartition);
+                                            } catch (Throwable th) {
+                                                future.completeExceptionally(th);
+                                            }
                                         });
                     } catch (Throwable throwable) {
                         LOG.error("Failed to allocate shuffle resource.", throwable);
@@ -197,6 +243,91 @@ public class RemoteShuffleMaster implements ShuffleMaster<RemoteShuffleDescripto
                     }
                 });
         return future;
+    }
+
+    private long generateRandomConsumerGroupID(DataSetIDCoordinate dataSetIDCoordinate) {
+        if (consumerGroupIDMap.containsKey(dataSetIDCoordinate)) {
+            return consumerGroupIDMap.get(dataSetIDCoordinate);
+        }
+
+        long consumerGroupID = Math.abs(RANDOM.nextLong());
+        consumerGroupIDMap.putIfAbsent(dataSetIDCoordinate, consumerGroupID);
+        return consumerGroupID;
+    }
+
+    private void addPartitionToWorker(
+            CompletableFuture<RemoteShuffleDescriptor> future,
+            JobID shuffleJobID,
+            ShuffleClient shuffleClient,
+            DataSetIDCoordinate dataSetIDCoordinate,
+            long consumerGroupID,
+            ResultPartitionID resultPartitionID,
+            ShuffleResource shuffleResource,
+            int numResultPartitions,
+            boolean isMapPartition) {
+        if (isMapPartition) {
+            InstanceID workerID = shuffleResource.getMapPartitionLocation().getWorkerId();
+            future.complete(
+                    new RemoteShuffleDescriptor(
+                            resultPartitionID,
+                            shuffleJobID,
+                            shuffleResource,
+                            isMapPartition,
+                            numResultPartitions));
+            shuffleClient.getListener().addPartition(workerID, resultPartitionID);
+        } else {
+            consumerGroupIDMap.putIfAbsent(dataSetIDCoordinate, consumerGroupID);
+            ShuffleResource cachedShuffleResource = cacheShuffleResources.get(dataSetIDCoordinate);
+            if (cachedShuffleResource == null) {
+                shuffleResource.setConsumerGroupID(consumerGroupID);
+                cacheShuffleResources.put(dataSetIDCoordinate, shuffleResource);
+                cachedShuffleResource = shuffleResource;
+            }
+
+            future.complete(
+                    new RemoteShuffleDescriptor(
+                            resultPartitionID,
+                            shuffleJobID,
+                            cachedShuffleResource,
+                            isMapPartition,
+                            numResultPartitions));
+            addPartitionToWorkerInternal(shuffleClient, resultPartitionID, cachedShuffleResource);
+        }
+    }
+
+    private void addPartitionToWorkerInternal(
+            ShuffleClient shuffleClient,
+            ResultPartitionID resultPartitionID,
+            ShuffleResource shuffleResource) {
+        executor.execute(
+                () -> {
+                    ShuffleWorkerDescriptor[] workerDescriptors =
+                            shuffleResource.getReducePartitionLocations();
+                    for (ShuffleWorkerDescriptor workerDescriptor : workerDescriptors) {
+                        InstanceID workerID = workerDescriptor.getWorkerId();
+                        shuffleClient.getListener().addPartition(workerID, resultPartitionID);
+                    }
+                });
+    }
+
+    private void removeCachedShuffleResource(JobID jobID) {
+        Set<DataSetIDCoordinate> toRemoveGroupCoordinates = new HashSet<>();
+        for (DataSetIDCoordinate dataSetIDCoordinate : cacheShuffleResources.keySet()) {
+            if (dataSetIDCoordinate.getShuffleJobID().equals(jobID)) {
+                toRemoveGroupCoordinates.add(dataSetIDCoordinate);
+            }
+        }
+        toRemoveGroupCoordinates.forEach(cacheShuffleResources::remove);
+    }
+
+    private void removeConsumerGroupIDs(JobID jobID) {
+        Set<DataSetIDCoordinate> toRemoveGroupCoordinates = new HashSet<>();
+        for (DataSetIDCoordinate dataSetIDCoordinate : consumerGroupIDMap.keySet()) {
+            if (dataSetIDCoordinate.getShuffleJobID().equals(jobID)) {
+                toRemoveGroupCoordinates.add(dataSetIDCoordinate);
+            }
+        }
+        toRemoveGroupCoordinates.forEach(consumerGroupIDMap::remove);
     }
 
     @Override
@@ -244,6 +375,8 @@ public class RemoteShuffleMaster implements ShuffleMaster<RemoteShuffleDescripto
                             }
                         }
                         shuffleClients.clear();
+                        cacheShuffleResources.clear();
+                        consumerGroupIDMap.clear();
 
                         try {
                             if (haServices != null) {
@@ -285,7 +418,7 @@ public class RemoteShuffleMaster implements ShuffleMaster<RemoteShuffleDescripto
 
                     try {
                         LOG.info("Registering job {}:{}", context.getJobId(), jobID);
-                        CommonUtils.checkState(!isClosed.get(), "ShuffleMaster has been closed.");
+                        checkState(!isClosed.get(), "ShuffleMaster has been closed.");
 
                         ShuffleManagerClientConfiguration shuffleManagerClientConfiguration =
                                 ShuffleManagerClientConfiguration.fromConfiguration(configuration);
@@ -331,6 +464,9 @@ public class RemoteShuffleMaster implements ShuffleMaster<RemoteShuffleDescripto
                         if (clientWithListener != null) {
                             clientWithListener.close();
                         }
+
+                        removeCachedShuffleResource(jobID);
+                        removeConsumerGroupIDs(jobID);
                     } catch (Throwable throwable) {
                         LOG.error(
                                 "Encounter an error when unregistering job {}:{}.",
@@ -602,6 +738,81 @@ public class RemoteShuffleMaster implements ShuffleMaster<RemoteShuffleDescripto
 
         public ShuffleWorkerStatusListenerImpl getListener() {
             return listener;
+        }
+    }
+
+    /**
+     * Only the distribution pattern of the result partition is ALL_TO_ALL, the ReducePartition mode
+     * will be used. Except for this situation, the MapPartition mode will be used.
+     */
+    private class PartitionTypeConverter {
+
+        private final boolean isMapPartition;
+
+        private final String partitionFactoryName;
+
+        PartitionTypeConverter(PartitionDescriptor partitionDescriptor) {
+            checkArgument(partitionDescriptor != null);
+
+            boolean isBroadcast = partitionDescriptor.isBroadcast();
+            boolean isAllToAllDistribution = partitionDescriptor.isAllToAllDistribution();
+            boolean isMapPartitionFactory = isMapPartitionFactory(partitionFactory);
+            this.isMapPartition = isMapPartitionFactory || isBroadcast || !isAllToAllDistribution;
+            this.partitionFactoryName =
+                    isMapPartition && !isMapPartitionFactory
+                            ? convertToMapPartitionFactory(partitionFactory)
+                            : partitionFactory;
+        }
+
+        boolean isMapPartition() {
+            return isMapPartition;
+        }
+
+        String getPartitionFactory() {
+            return partitionFactoryName;
+        }
+    }
+
+    private static class DataSetIDCoordinate {
+        private final JobID shuffleJobID;
+
+        private final DataSetID dataSetID;
+
+        public DataSetIDCoordinate(JobID shuffleJobID, DataSetID dataSetID) {
+            this.shuffleJobID = shuffleJobID;
+            this.dataSetID = dataSetID;
+        }
+
+        JobID getShuffleJobID() {
+            return shuffleJobID;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) {
+                return true;
+            }
+            if (o == null || getClass() != o.getClass()) {
+                return false;
+            }
+            DataSetIDCoordinate that = (DataSetIDCoordinate) o;
+            return Objects.equals(shuffleJobID, that.shuffleJobID)
+                    && Objects.equals(dataSetID, that.dataSetID);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(shuffleJobID, dataSetID);
+        }
+
+        @Override
+        public String toString() {
+            return "DataSetCoordinate{"
+                    + "shuffleJobID="
+                    + shuffleJobID
+                    + ", dataSetID="
+                    + dataSetID
+                    + '}';
         }
     }
 }

--- a/shuffle-plugin/src/main/java/com/alibaba/flink/shuffle/plugin/RemoteShuffleMaster.java
+++ b/shuffle-plugin/src/main/java/com/alibaba/flink/shuffle/plugin/RemoteShuffleMaster.java
@@ -496,7 +496,7 @@ public class RemoteShuffleMaster implements ShuffleMaster<RemoteShuffleDescripto
             TaskInputsOutputsDescriptor taskInputsOutputsDescriptor) {
         for (ResultPartitionType partitionType :
                 taskInputsOutputsDescriptor.getPartitionTypes().values()) {
-            if (!partitionType.isBlocking()) {
+            if (!partitionType.isBlockingOrBlockingPersistentResultPartition()) {
                 throw new ShuffleException(
                         "Blocking result partition type expected but found " + partitionType);
             }

--- a/shuffle-plugin/src/main/java/com/alibaba/flink/shuffle/plugin/config/PluginOptions.java
+++ b/shuffle-plugin/src/main/java/com/alibaba/flink/shuffle/plugin/config/PluginOptions.java
@@ -74,7 +74,7 @@ public class PluginOptions {
      */
     public static final ConfigOption<MemorySize> MEMORY_PER_INPUT_GATE =
             new ConfigOption<MemorySize>("remote-shuffle.job.memory-per-gate")
-                    .defaultValue(MemorySize.parse("32m"))
+                    .defaultValue(MemorySize.parse("64m"))
                     .description(
                             "The size of network buffers required per input gate. The minimum "
                                     + "valid value is 8m. Usually, several hundreds of megabytes "

--- a/shuffle-plugin/src/main/java/com/alibaba/flink/shuffle/plugin/transfer/BufferPacker.java
+++ b/shuffle-plugin/src/main/java/com/alibaba/flink/shuffle/plugin/transfer/BufferPacker.java
@@ -78,6 +78,20 @@ public class BufferPacker {
         }
     }
 
+    public void writeWithoutCache(Buffer buffer, int subIdx) throws InterruptedException {
+        drain();
+        if (buffer == null) {
+            return;
+        }
+
+        if (buffer.readableBytes() == 0) {
+            buffer.recycleBuffer();
+            return;
+        }
+
+        handleRipeBuffer(buffer, subIdx);
+    }
+
     public void drain() throws InterruptedException {
         if (cachedBuffer != null) {
             Buffer dumpedBuffer = cachedBuffer;
@@ -85,6 +99,10 @@ public class BufferPacker {
             handleRipeBuffer(dumpedBuffer, currentSubIdx);
         }
         currentSubIdx = -1;
+    }
+
+    protected boolean hasCachedBuffer() {
+        return cachedBuffer != null;
     }
 
     private void handleRipeBuffer(Buffer buffer, int subIdx) throws InterruptedException {

--- a/shuffle-plugin/src/main/java/com/alibaba/flink/shuffle/plugin/transfer/PartitionSortedBuffer.java
+++ b/shuffle-plugin/src/main/java/com/alibaba/flink/shuffle/plugin/transfer/PartitionSortedBuffer.java
@@ -58,6 +58,9 @@ public class PartitionSortedBuffer implements SortBuffer {
      */
     private static final int INDEX_ENTRY_SIZE = 4 + 4 + 8;
 
+    /** A flag to indicate the read process is finished. */
+    private static final int READ_CHANNEL_FINISHED = 1;
+
     private final Object lock;
     /** A buffer pool to request memory segments from. */
     private final BufferPool bufferPool;
@@ -87,6 +90,14 @@ public class PartitionSortedBuffer implements SortBuffer {
     private long numTotalBytesRead;
     /** Whether this sort buffer is finished. One can only read a finished sort buffer. */
     private boolean isFinished;
+    /** Total number of bytes for each sub partition. */
+    private final long[] numSubpartitionBytes;
+    /** Number of bytes already read from this sort buffer for each subpartition. */
+    private final long[] numSubpartitionBytesRead;
+    /** Whether this sort buffer for each subpartition is finished. */
+    private final int[] isChannelReadFinish;
+    /** Total number of events for each sub partition. */
+    private final int[] numEvents;
 
     // ---------------------------------------------------------------------------------------------
     // For writing
@@ -104,6 +115,10 @@ public class PartitionSortedBuffer implements SortBuffer {
     private int writeSegmentOffset;
     /** Index entry address of the current record or event to be read. */
     private long readIndexEntryAddress;
+    /** Index entry address of the current record or event to be read for each subpartition. */
+    private final long[] channelReadIndexAddress;
+    /** Record bytes remaining after last copy for each subpartition. */
+    private final int[] channelRemainingBytes;
 
     /** Record bytes remaining after last copy, which must be read first in next copy. */
     private int recordRemainingBytes;
@@ -123,10 +138,22 @@ public class PartitionSortedBuffer implements SortBuffer {
         this.bufferSize = bufferSize;
         this.firstIndexEntryAddresses = new long[numSubpartitions];
         this.lastIndexEntryAddresses = new long[numSubpartitions];
+        this.numSubpartitionBytes = new long[numSubpartitions];
+        this.numSubpartitionBytesRead = new long[numSubpartitions];
+        this.channelReadIndexAddress = new long[numSubpartitions];
+        this.channelRemainingBytes = new int[numSubpartitions];
+        this.isChannelReadFinish = new int[numSubpartitions];
+        this.numEvents = new int[numSubpartitions];
 
         // initialized with -1 means the corresponding channel has no data.
         Arrays.fill(firstIndexEntryAddresses, -1L);
         Arrays.fill(lastIndexEntryAddresses, -1L);
+        Arrays.fill(numSubpartitionBytes, 0L);
+        Arrays.fill(numSubpartitionBytesRead, 0L);
+        Arrays.fill(channelReadIndexAddress, -1L);
+        Arrays.fill(channelRemainingBytes, 0);
+        Arrays.fill(isChannelReadFinish, 0);
+        Arrays.fill(numEvents, 0);
 
         this.subpartitionReadOrder = new int[numSubpartitions];
         if (customReadOrder != null) {
@@ -159,6 +186,7 @@ public class PartitionSortedBuffer implements SortBuffer {
 
         ++numTotalRecords;
         numTotalBytes += totalBytes;
+        numSubpartitionBytes[targetChannel] += totalBytes;
 
         return true;
     }
@@ -186,6 +214,9 @@ public class PartitionSortedBuffer implements SortBuffer {
 
         // move the writer position forward to write the corresponding record
         updateWriteSegmentIndexAndOffset(INDEX_ENTRY_SIZE);
+        if (!dataType.isBuffer()) {
+            numEvents[channelIndex]++;
+        }
     }
 
     private void writeRecord(ByteBuffer source) {
@@ -281,6 +312,10 @@ public class PartitionSortedBuffer implements SortBuffer {
             DataType bufferDataType = DataType.DATA_BUFFER;
             int channelIndex = subpartitionReadOrder[readOrderIndex];
 
+            checkState(
+                    numSubpartitionBytesRead[channelIndex] < numSubpartitionBytes[channelIndex],
+                    "Bug, read too much data in sort buffer");
+
             do {
                 int sourceSegmentIndex = getSegmentIndexFromPointer(readIndexEntryAddress);
                 int sourceSegmentOffset = getSegmentOffsetFromPointer(readIndexEntryAddress);
@@ -318,6 +353,10 @@ public class PartitionSortedBuffer implements SortBuffer {
                 if (recordRemainingBytes == 0) {
                     // move to next channel if the current channel has been finished
                     if (readIndexEntryAddress == lastIndexEntryAddresses[channelIndex]) {
+                        checkState(
+                                numSubpartitionBytesRead[channelIndex] + numBytesCopied
+                                        == numSubpartitionBytes[channelIndex],
+                                "Read un-completely.");
                         updateReadChannelAndIndexEntryAddress();
                         break;
                     }
@@ -326,10 +365,179 @@ public class PartitionSortedBuffer implements SortBuffer {
             } while (numBytesCopied < target.size() - offset && bufferDataType.isBuffer());
 
             numTotalBytesRead += numBytesCopied;
+            numSubpartitionBytesRead[channelIndex] += numBytesCopied;
             Buffer buffer =
                     new NetworkBuffer(target, recycler, bufferDataType, numBytesCopied + offset);
             return new BufferWithChannel(buffer, channelIndex);
         }
+    }
+
+    public int getSubpartitionReadOrderIndex(int channelIndex) {
+        return subpartitionReadOrder[channelIndex];
+    }
+
+    @Nullable
+    @Override
+    public BufferWithChannel copyChannelBuffersIntoSegment(
+            MemorySegment target, int channelIndex, BufferRecycler recycler, int offset) {
+        synchronized (lock) {
+            checkState(hasRemaining(), "No data remaining.");
+            checkState(isFinished, "Should finish the sort buffer first before coping any data.");
+            checkState(!isReleased, "Sort buffer is already released.");
+            checkState(channelIndex >= 0, "Wrong channel index.");
+            int targetChannelIndex = subpartitionReadOrder[channelIndex];
+
+            int numBytesCopied = 0;
+            DataType bufferDataType = DataType.DATA_BUFFER;
+            if (channelReadIndexAddress[channelIndex] < 0 || hasChannelReadFinish(channelIndex)) {
+                recycler.recycle(target);
+                return null;
+            }
+
+            checkState(
+                    numSubpartitionBytesRead[targetChannelIndex]
+                            < numSubpartitionBytes[targetChannelIndex],
+                    "Bug: read too much data from sort buffer.");
+
+            do {
+                int sourceSegmentIndex =
+                        getSegmentIndexFromPointer(channelReadIndexAddress[channelIndex]);
+                int sourceSegmentOffset =
+                        getSegmentOffsetFromPointer(channelReadIndexAddress[channelIndex]);
+                MemorySegment sourceSegment = buffers.get(sourceSegmentIndex);
+
+                long lengthAndDataType = sourceSegment.getLong(sourceSegmentOffset);
+                int length = getSegmentIndexFromPointer(lengthAndDataType);
+                DataType dataType =
+                        DataType.values()[getSegmentOffsetFromPointer(lengthAndDataType)];
+
+                // return the data read directly if the next to read is an event
+                if (dataType.isEvent() && numBytesCopied > 0) {
+                    break;
+                }
+                bufferDataType = dataType;
+
+                // get the next index entry address and move the read position forward
+                long nextReadIndexEntryAddress = sourceSegment.getLong(sourceSegmentOffset + 8);
+                sourceSegmentOffset += INDEX_ENTRY_SIZE;
+
+                // throws if the event is too big to be accommodated by a buffer.
+                if (bufferDataType.isEvent() && target.size() < length) {
+                    throw new FlinkRuntimeException(
+                            "Event is too big to be accommodated by a buffer");
+                }
+
+                numBytesCopied +=
+                        copyChannelRecordOrEvent(
+                                target,
+                                numBytesCopied + offset,
+                                sourceSegmentIndex,
+                                sourceSegmentOffset,
+                                length,
+                                channelIndex);
+
+                if (isChannelReadFinished(
+                        channelIndex,
+                        targetChannelIndex,
+                        numBytesCopied,
+                        nextReadIndexEntryAddress)) {
+                    break;
+                }
+            } while (numBytesCopied < target.size() - offset && bufferDataType.isBuffer());
+
+            numSubpartitionBytesRead[targetChannelIndex] += numBytesCopied;
+            numTotalBytesRead += numBytesCopied;
+            Buffer buffer =
+                    new NetworkBuffer(target, recycler, bufferDataType, numBytesCopied + offset);
+            return new BufferWithChannel(buffer, targetChannelIndex);
+        }
+    }
+
+    private boolean isChannelReadFinished(
+            int channelIndex,
+            int targetChannelIndex,
+            int numBytesCopied,
+            long nextReadIndexEntryAddress) {
+        if (channelRemainingBytes[channelIndex] == 0) {
+            if (channelReadIndexAddress[channelIndex]
+                    == lastIndexEntryAddresses[targetChannelIndex]) {
+                checkState(
+                        numSubpartitionBytesRead[targetChannelIndex] + numBytesCopied
+                                == numSubpartitionBytes[targetChannelIndex],
+                        "Read un-completely.");
+                isChannelReadFinish[channelIndex] = READ_CHANNEL_FINISHED;
+                return true;
+            }
+            channelReadIndexAddress[channelIndex] = nextReadIndexEntryAddress;
+        }
+        return false;
+    }
+
+    private boolean hasChannelReadFinish(int channelIndex) {
+        return isChannelReadFinish[channelIndex] == READ_CHANNEL_FINISHED;
+    }
+
+    private int copyChannelRecordOrEvent(
+            MemorySegment targetSegment,
+            int targetSegmentOffset,
+            int sourceSegmentIndex,
+            int sourceSegmentOffset,
+            int recordLength,
+            int channelIndex) {
+        if (channelRemainingBytes[channelIndex] > 0) {
+            // skip the data already read if there is remaining partial record after the previous
+            // copy
+            long position =
+                    (long) sourceSegmentOffset
+                            + (recordLength - channelRemainingBytes[channelIndex]);
+            sourceSegmentIndex += (position / bufferSize);
+            sourceSegmentOffset = (int) (position % bufferSize);
+        } else {
+            channelRemainingBytes[channelIndex] = recordLength;
+        }
+
+        int targetSegmentSize = targetSegment.size();
+        int numBytesToCopy =
+                Math.min(
+                        targetSegmentSize - targetSegmentOffset,
+                        channelRemainingBytes[channelIndex]);
+        do {
+            // move to next data buffer if all data of the current buffer has been copied
+            if (sourceSegmentOffset == bufferSize) {
+                ++sourceSegmentIndex;
+                sourceSegmentOffset = 0;
+            }
+
+            int numBytes =
+                    copyToTargetSegment(
+                            targetSegment,
+                            targetSegmentOffset,
+                            sourceSegmentIndex,
+                            sourceSegmentOffset,
+                            targetSegmentSize,
+                            channelRemainingBytes[channelIndex]);
+
+            channelRemainingBytes[channelIndex] -= numBytes;
+            targetSegmentOffset += numBytes;
+            sourceSegmentOffset += numBytes;
+        } while (channelRemainingBytes[channelIndex] > 0
+                && targetSegmentOffset < targetSegmentSize);
+
+        return numBytesToCopy;
+    }
+
+    private int copyToTargetSegment(
+            MemorySegment targetSegment,
+            int targetSegmentOffset,
+            int sourceSegmentIndex,
+            int sourceSegmentOffset,
+            int targetSegmentSize,
+            int numRemainingBytes) {
+        int sourceRemainingBytes = Math.min(bufferSize - sourceSegmentOffset, numRemainingBytes);
+        int numBytes = Math.min(targetSegmentSize - targetSegmentOffset, sourceRemainingBytes);
+        MemorySegment sourceSegment = buffers.get(sourceSegmentIndex);
+        sourceSegment.copyTo(sourceSegmentOffset, targetSegment, targetSegmentOffset, numBytes);
+        return numBytes;
     }
 
     private int copyRecordOrEvent(
@@ -358,11 +566,14 @@ public class PartitionSortedBuffer implements SortBuffer {
                 sourceSegmentOffset = 0;
             }
 
-            int sourceRemainingBytes =
-                    Math.min(bufferSize - sourceSegmentOffset, recordRemainingBytes);
-            int numBytes = Math.min(targetSegmentSize - targetSegmentOffset, sourceRemainingBytes);
-            MemorySegment sourceSegment = buffers.get(sourceSegmentIndex);
-            sourceSegment.copyTo(sourceSegmentOffset, targetSegment, targetSegmentOffset, numBytes);
+            int numBytes =
+                    copyToTargetSegment(
+                            targetSegment,
+                            targetSegmentOffset,
+                            sourceSegmentIndex,
+                            sourceSegmentOffset,
+                            targetSegmentSize,
+                            recordRemainingBytes);
 
             recordRemainingBytes -= numBytes;
             targetSegmentOffset += numBytes;
@@ -379,6 +590,15 @@ public class PartitionSortedBuffer implements SortBuffer {
             if ((readIndexEntryAddress = firstIndexEntryAddresses[channelIndex]) >= 0) {
                 break;
             }
+        }
+    }
+
+    private void initChannelReadIndexEntryAddresses() {
+        int channelIndex = 0;
+        while (channelIndex < firstIndexEntryAddresses.length) {
+            channelReadIndexAddress[channelIndex] =
+                    firstIndexEntryAddresses[subpartitionReadOrder[channelIndex]];
+            channelIndex++;
         }
     }
 
@@ -401,6 +621,22 @@ public class PartitionSortedBuffer implements SortBuffer {
     }
 
     @Override
+    public long numSubpartitionBytes(int targetSubpartition) {
+        return numSubpartitionBytes[subpartitionReadOrder[targetSubpartition]];
+    }
+
+    @Override
+    public int numEvents(int targetSubpartition) {
+        return numEvents[targetSubpartition];
+    }
+
+    @Override
+    public boolean hasSubpartitionReadFinish(int targetSubpartition) {
+        return numSubpartitionBytesRead[targetSubpartition]
+                == numSubpartitionBytes[targetSubpartition];
+    }
+
+    @Override
     public boolean hasRemaining() {
         return numTotalBytesRead < numTotalBytes;
     }
@@ -415,6 +651,7 @@ public class PartitionSortedBuffer implements SortBuffer {
 
         // prepare for reading
         updateReadChannelAndIndexEntryAddress();
+        initChannelReadIndexEntryAddresses();
     }
 
     @Override
@@ -439,6 +676,7 @@ public class PartitionSortedBuffer implements SortBuffer {
 
             numTotalBytes = 0;
             numTotalRecords = 0;
+            Arrays.fill(numSubpartitionBytes, 0L);
         }
     }
 

--- a/shuffle-plugin/src/main/java/com/alibaba/flink/shuffle/plugin/transfer/RemoteShuffleInputGate.java
+++ b/shuffle-plugin/src/main/java/com/alibaba/flink/shuffle/plugin/transfer/RemoteShuffleInputGate.java
@@ -855,6 +855,14 @@ public class RemoteShuffleInputGate extends IndexedInputGate {
                 long cpId, ResultSubpartitionInfo info, int startSeqNum, Buffer... data) {}
 
         @Override
+        public void addOutputDataFuture(
+                long l,
+                ResultSubpartitionInfo resultSubpartitionInfo,
+                int i,
+                CompletableFuture<List<Buffer>> completableFuture)
+                throws IllegalArgumentException {}
+
+        @Override
         public void finishInput(long checkpointId) {}
 
         @Override

--- a/shuffle-plugin/src/main/java/com/alibaba/flink/shuffle/plugin/transfer/RemoteShuffleInputGate.java
+++ b/shuffle-plugin/src/main/java/com/alibaba/flink/shuffle/plugin/transfer/RemoteShuffleInputGate.java
@@ -21,6 +21,7 @@ import com.alibaba.flink.shuffle.common.utils.ExceptionUtils;
 import com.alibaba.flink.shuffle.coordinator.manager.ShuffleWorkerDescriptor;
 import com.alibaba.flink.shuffle.core.ids.DataSetID;
 import com.alibaba.flink.shuffle.core.ids.MapPartitionID;
+import com.alibaba.flink.shuffle.core.ids.ReducePartitionID;
 import com.alibaba.flink.shuffle.plugin.RemoteShuffleDescriptor;
 import com.alibaba.flink.shuffle.plugin.utils.BufferUtils;
 import com.alibaba.flink.shuffle.transfer.ConnectionManager;
@@ -86,6 +87,7 @@ import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
 import static com.alibaba.flink.shuffle.common.utils.CommonUtils.checkState;
+import static com.alibaba.flink.shuffle.plugin.utils.GateUtils.getSimplifiedShuffleDescriptors;
 
 /** A {@link IndexedInputGate} which ingest data from remote shuffle workers. */
 public class RemoteShuffleInputGate extends IndexedInputGate {
@@ -106,6 +108,9 @@ public class RemoteShuffleInputGate extends IndexedInputGate {
 
     /** Deployment descriptor for a single input gate instance. */
     private final InputGateDeploymentDescriptor gateDescriptor;
+
+    /** {@link ShuffleDescriptor}s pairs with channel indexes. */
+    List<Pair<Integer, ShuffleDescriptor>> shuffleDescriptorPairs;
 
     /** Number of concurrent readings. */
     private final int numConcurrentReading;
@@ -137,6 +142,9 @@ public class RemoteShuffleInputGate extends IndexedInputGate {
 
     /** The number of subpartitions that has not consumed per channel. */
     private final int[] numSubPartitionsHasNotConsumed;
+
+    /** Whether the data partition type is MapPartition. */
+    private final boolean isMapPartition;
 
     /** The overall number of subpartitions that has not been consumed. */
     private long numUnconsumedSubpartitions;
@@ -180,8 +188,10 @@ public class RemoteShuffleInputGate extends IndexedInputGate {
         this.connectionManager = connectionManager;
         this.bufferPoolFactory = bufferPoolFactory;
         this.bufferDecompressor = bufferDecompressor;
+        this.isMapPartition = isMapPartition(gateDescriptor);
 
-        int numChannels = gateDescriptor.getShuffleDescriptors().length;
+        this.shuffleDescriptorPairs = getShuffleDescriptorPairs();
+        int numChannels = shuffleDescriptorPairs.size();
         this.clientIndexMap = new int[numChannels];
         this.channelIndexMap = new int[numChannels];
         this.numSubPartitionsHasNotConsumed = new int[numChannels];
@@ -191,29 +201,49 @@ public class RemoteShuffleInputGate extends IndexedInputGate {
         this.pendingEndOfDataEvents = numUnconsumedSubpartitions;
     }
 
+    /**
+     * In the ReducePartition mode, before the {@link ShuffleDescriptor}s are simplified , all
+     * {@link ShuffleDescriptor}s in the list are the same. Use the first one as the {@link
+     * ShuffleDescriptor}s to be simplified. The specified number of simplified {@link
+     * ShuffleDescriptor}s are returned.
+     */
+    private List<Pair<Integer, ShuffleDescriptor>> getShuffleDescriptorPairs() {
+        int startSubIdx = gateDescriptor.getConsumedSubpartitionIndexRange().getStartIndex();
+        int endSubIdx = gateDescriptor.getConsumedSubpartitionIndexRange().getEndIndex();
+
+        checkState(endSubIdx >= startSubIdx);
+        checkState(gateDescriptor.getShuffleDescriptors().length > 0);
+
+        return isMapPartition
+                ? convertShuffleDescriptorToPairs(gateDescriptor.getShuffleDescriptors())
+                : getSimplifiedShuffleDescriptorPairs(
+                        (RemoteShuffleDescriptor) gateDescriptor.getShuffleDescriptors()[0],
+                        startSubIdx,
+                        endSubIdx);
+    }
+
     private long initShuffleReadClients(int bufferSize, boolean shuffleChannels) {
         int startSubIdx = gateDescriptor.getConsumedSubpartitionIndexRange().getStartIndex();
         int endSubIdx = gateDescriptor.getConsumedSubpartitionIndexRange().getEndIndex();
-        checkState(endSubIdx >= startSubIdx);
         int numSubpartitionsPerChannel = endSubIdx - startSubIdx + 1;
         long numUnconsumedSubpartitions = 0;
 
-        List<Pair<Integer, ShuffleDescriptor>> descriptors =
-                IntStream.range(0, gateDescriptor.getShuffleDescriptors().length)
-                        .mapToObj(i -> Pair.of(i, gateDescriptor.getShuffleDescriptors()[i]))
-                        .collect(Collectors.toList());
         if (shuffleChannels) {
-            Collections.shuffle(descriptors);
+            Collections.shuffle(shuffleDescriptorPairs);
         }
 
         int clientIndex = 0;
-        for (Pair<Integer, ShuffleDescriptor> descriptor : descriptors) {
+        for (Pair<Integer, ShuffleDescriptor> descriptor : shuffleDescriptorPairs) {
+            int subIdx = startSubIdx + descriptor.getLeft();
             RemoteShuffleDescriptor remoteDescriptor =
                     (RemoteShuffleDescriptor) descriptor.getRight();
-            ShuffleWorkerDescriptor swd =
-                    remoteDescriptor.getShuffleResource().getMapPartitionLocation();
+            checkState(
+                    isMapPartition == remoteDescriptor.isMapPartition(),
+                    "Inconsistent partition type.");
+            ShuffleWorkerDescriptor workerDescriptor = getWorkerDescriptor(remoteDescriptor);
             InetSocketAddress address =
-                    new InetSocketAddress(swd.getWorkerAddress(), swd.getDataPort());
+                    new InetSocketAddress(
+                            workerDescriptor.getWorkerAddress(), workerDescriptor.getDataPort());
             LOG.debug(
                     "Create DataPartitionReader [dataSetID: {}, resultPartitionID: {}, channelIdx: "
                             + "{}, mapID: {}, startSubIdx: {}, endSubIdx {}, address: {}]",
@@ -230,21 +260,73 @@ public class RemoteShuffleInputGate extends IndexedInputGate {
                             address,
                             remoteDescriptor.getDataSetId(),
                             (MapPartitionID) remoteDescriptor.getDataPartitionID(),
+                            getReducePartitionID(remoteDescriptor, subIdx),
+                            1,
                             startSubIdx,
                             endSubIdx,
                             bufferSize,
+                            isMapPartition,
                             transferBufferPool,
                             getDataListener(descriptor.getLeft()),
                             getFailureListener(remoteDescriptor.getResultPartitionID()));
-
             shuffleReadClients.add(shuffleReadClient);
-            numSubPartitionsHasNotConsumed[descriptor.getLeft()] = numSubpartitionsPerChannel;
-            numUnconsumedSubpartitions += numSubpartitionsPerChannel;
+            int numResultPartitionsPerChannel =
+                    isMapPartition ? numSubpartitionsPerChannel : remoteDescriptor.getNumMaps();
+            checkState(numResultPartitionsPerChannel > 0, "Wrong number of partitions.");
+            numSubPartitionsHasNotConsumed[descriptor.getLeft()] += numResultPartitionsPerChannel;
+            numUnconsumedSubpartitions += numResultPartitionsPerChannel;
             clientIndexMap[descriptor.getLeft()] = clientIndex;
-            channelIndexMap[clientIndex] = descriptor.getLeft();
-            ++clientIndex;
+            channelIndexMap[clientIndex++] = descriptor.getLeft();
         }
+        checkState(
+                isMapPartition || shuffleReadClients.size() == numSubpartitionsPerChannel,
+                "Wrong number of shuffle read clients.");
         return numUnconsumedSubpartitions;
+    }
+
+    private List<Pair<Integer, ShuffleDescriptor>> getSimplifiedShuffleDescriptorPairs(
+            RemoteShuffleDescriptor shuffleDescriptor, int startSubIdx, int endSubIdx) {
+        ShuffleDescriptor[] simplifiedDescriptors =
+                getSimplifiedShuffleDescriptors(shuffleDescriptor, startSubIdx, endSubIdx);
+        return convertShuffleDescriptorToPairs(simplifiedDescriptors);
+    }
+
+    private static List<Pair<Integer, ShuffleDescriptor>> convertShuffleDescriptorToPairs(
+            ShuffleDescriptor[] shuffleDescriptors) {
+        return IntStream.range(0, shuffleDescriptors.length)
+                .mapToObj(i -> Pair.of(i, shuffleDescriptors[i]))
+                .collect(Collectors.toList());
+    }
+
+    private ReducePartitionID getReducePartitionID(
+            RemoteShuffleDescriptor remoteDescriptor, int subPartitionIdx) {
+        return isMapPartition
+                ? new ReducePartitionID(0)
+                : new ReducePartitionID(
+                        subPartitionIdx,
+                        remoteDescriptor.getShuffleResource().getConsumerGroupID());
+    }
+
+    /**
+     * In the ReducePartition mode, the corresponding partition indexed {@link
+     * ShuffleWorkerDescriptor} is returned.
+     */
+    private ShuffleWorkerDescriptor getWorkerDescriptor(RemoteShuffleDescriptor remoteDescriptor) {
+        if (isMapPartition) {
+            return remoteDescriptor.getShuffleResource().getMapPartitionLocation();
+        } else {
+            ShuffleWorkerDescriptor[] shuffleWorkerDescriptors =
+                    remoteDescriptor.getShuffleResource().getReducePartitionLocations();
+            checkState(shuffleWorkerDescriptors.length > 0);
+            return shuffleWorkerDescriptors[0];
+        }
+    }
+
+    private static boolean isMapPartition(InputGateDeploymentDescriptor gateDescriptor) {
+        checkState(gateDescriptor != null && gateDescriptor.getShuffleDescriptors().length > 0);
+        RemoteShuffleDescriptor remoteDescriptor =
+                (RemoteShuffleDescriptor) gateDescriptor.getShuffleDescriptors()[0];
+        return remoteDescriptor.isMapPartition();
     }
 
     /** Setup gate and build network connections. */
@@ -257,8 +339,8 @@ public class RemoteShuffleInputGate extends IndexedInputGate {
                 bufferPool, RemoteShuffleInputGateFactory.MIN_BUFFERS_PER_GATE);
 
         try {
-            for (int i = 0; i < gateDescriptor.getShuffleDescriptors().length; i++) {
-                shuffleReadClients.get(i).connect();
+            for (ShuffleReadClient shuffleReadClient : shuffleReadClients) {
+                shuffleReadClient.connect();
             }
         } catch (Throwable throwable) {
             LOG.error("Failed to setup remote input gate.", throwable);
@@ -391,7 +473,7 @@ public class RemoteShuffleInputGate extends IndexedInputGate {
     }
 
     private List<InputChannelInfo> createChannelInfos() {
-        return IntStream.range(0, gateDescriptor.getShuffleDescriptors().length)
+        return IntStream.range(0, shuffleDescriptorPairs.size())
                 .mapToObj(i -> new InputChannelInfo(gateIndex, i))
                 .collect(Collectors.toList());
     }
@@ -401,9 +483,12 @@ public class RemoteShuffleInputGate extends IndexedInputGate {
             InetSocketAddress address,
             DataSetID dataSetID,
             MapPartitionID mapID,
+            ReducePartitionID reduceID,
+            int numSubs,
             int startSubIdx,
             int endSubIdx,
             int bufferSize,
+            boolean isMapPartition,
             TransferBufferPool bufferPool,
             Consumer<ByteBuf> dataListener,
             Consumer<Throwable> failureListener) {
@@ -411,9 +496,12 @@ public class RemoteShuffleInputGate extends IndexedInputGate {
                 address,
                 dataSetID,
                 mapID,
+                reduceID,
+                numSubs,
                 startSubIdx,
                 endSubIdx,
                 bufferSize,
+                isMapPartition,
                 bufferPool,
                 connectionManager,
                 dataListener,
@@ -428,15 +516,9 @@ public class RemoteShuffleInputGate extends IndexedInputGate {
                 throw new IOException("Input gate already closed.");
             }
 
-            LOG.debug("Try open some partition readers.");
             int numOnGoing = 0;
             for (int i = 0; i < shuffleReadClients.size(); i++) {
                 ShuffleReadClient shuffleReadClient = shuffleReadClients.get(i);
-                LOG.debug(
-                        "Trying reader: {}, isOpened={}, numSubPartitionsHasNotConsumed={}.",
-                        shuffleReadClient,
-                        shuffleReadClient.isOpened(),
-                        numSubPartitionsHasNotConsumed[channelIndexMap[i]]);
                 if (numOnGoing >= numConcurrentReading) {
                     break;
                 }
@@ -484,6 +566,7 @@ public class RemoteShuffleInputGate extends IndexedInputGate {
             try {
                 boolean wasEmpty = receivedBuffers.isEmpty();
                 InputChannelInfo channelInfo = channelsInfo.get(channelIdx);
+                checkState(channelInfo != null, "Empty channel info for channel " + channelIdx);
                 checkState(
                         channelInfo.getInputChannelIdx() == channelIdx, "Illegal channel index.");
                 receivedBuffers.add(Pair.of(buffer, channelInfo));
@@ -590,17 +673,21 @@ public class RemoteShuffleInputGate extends IndexedInputGate {
         }
 
         if (event.getClass() == EndOfPartitionEvent.class) {
+            int channelIdx = channelInfo.getInputChannelIdx();
             checkState(
-                    numSubPartitionsHasNotConsumed[channelInfo.getInputChannelIdx()] > 0,
+                    numSubPartitionsHasNotConsumed[channelIdx] > 0,
+                    "BUG -- EndOfPartitionEvent in channel received repeatedly.");
+            numSubPartitionsHasNotConsumed[channelIdx]--;
+            checkState(
+                    numUnconsumedSubpartitions > 0,
                     "BUG -- EndOfPartitionEvent received repeatedly.");
-            numSubPartitionsHasNotConsumed[channelInfo.getInputChannelIdx()]--;
             numUnconsumedSubpartitions--;
             // not the real end.
-            if (numSubPartitionsHasNotConsumed[channelInfo.getInputChannelIdx()] != 0) {
+            if (numSubPartitionsHasNotConsumed[channelIdx] != 0) {
                 return Optional.empty();
             } else {
                 // the real end.
-                shuffleReadClients.get(clientIndexMap[channelInfo.getInputChannelIdx()]).close();
+                shuffleReadClients.get(clientIndexMap[channelIdx]).close();
                 tryOpenSomeChannels();
                 if (allReadersEOF()) {
                     availabilityHelper.getUnavailableToResetAvailable().complete(null);

--- a/shuffle-plugin/src/main/java/com/alibaba/flink/shuffle/plugin/transfer/RemoteShuffleOutputGate.java
+++ b/shuffle-plugin/src/main/java/com/alibaba/flink/shuffle/plugin/transfer/RemoteShuffleOutputGate.java
@@ -18,27 +18,39 @@ package com.alibaba.flink.shuffle.plugin.transfer;
 
 import com.alibaba.flink.shuffle.common.utils.CommonUtils;
 import com.alibaba.flink.shuffle.common.utils.ExceptionUtils;
-import com.alibaba.flink.shuffle.coordinator.manager.DefaultShuffleResource;
 import com.alibaba.flink.shuffle.coordinator.manager.ShuffleWorkerDescriptor;
 import com.alibaba.flink.shuffle.core.ids.DataSetID;
 import com.alibaba.flink.shuffle.core.ids.JobID;
 import com.alibaba.flink.shuffle.core.ids.MapPartitionID;
+import com.alibaba.flink.shuffle.core.ids.ReducePartitionID;
+import com.alibaba.flink.shuffle.core.storage.MapPartition;
 import com.alibaba.flink.shuffle.plugin.RemoteShuffleDescriptor;
 import com.alibaba.flink.shuffle.plugin.utils.BufferUtils;
+import com.alibaba.flink.shuffle.plugin.utils.GateUtils;
 import com.alibaba.flink.shuffle.transfer.ConnectionManager;
 import com.alibaba.flink.shuffle.transfer.ShuffleWriteClient;
 
 import org.apache.flink.runtime.io.network.api.writer.ResultPartitionWriter;
 import org.apache.flink.runtime.io.network.buffer.Buffer;
 import org.apache.flink.runtime.io.network.buffer.BufferPool;
+import org.apache.flink.runtime.scheduler.strategy.ConsumedPartitionGroup;
 import org.apache.flink.runtime.shuffle.ShuffleDescriptor;
 import org.apache.flink.util.function.SupplierWithException;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import javax.annotation.concurrent.GuardedBy;
+
 import java.io.IOException;
 import java.net.InetSocketAddress;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.LinkedBlockingQueue;
+
+import static com.alibaba.flink.shuffle.common.utils.CommonUtils.checkNotNull;
+import static com.alibaba.flink.shuffle.common.utils.CommonUtils.checkState;
 
 /**
  * A transportation gate used to spill buffers from {@link ResultPartitionWriter} to remote shuffle
@@ -54,17 +66,50 @@ public class RemoteShuffleOutputGate {
     /** Number of subpartitions of the corresponding {@link ResultPartitionWriter}. */
     protected final int numSubs;
 
+    /** Whether the data partition type is {@link MapPartition}. */
+    private final boolean isMapPartition;
+
+    /** Number of partitions in a {@link ConsumedPartitionGroup}. */
+    private final int numMapsInGroup;
+
     /** Used to transport data to a shuffle worker. */
-    private final ShuffleWriteClient shuffleWriteClient;
+    private final Map<Integer, ShuffleWriteClient> shuffleWriteClients = new HashMap<>();
 
     /** Used to consolidate buffers. */
-    private final BufferPacker bufferPacker;
+    private final Map<Integer, BufferPacker> bufferPackers = new HashMap<>();
 
     /** {@link BufferPool} provider. */
     protected final SupplierWithException<BufferPool, IOException> bufferPoolFactory;
 
+    /** Lock to wait the writing finish commitments of all the {@link ShuffleWriteClient}s. */
+    protected final Object lock = new Object();
+
     /** Provides buffers to hold data to send online by Netty layer. */
     protected BufferPool bufferPool;
+
+    /**
+     * A queue to store the {@link ShuffleWriteClient} to send buffers in a {@link SortBuffer}, and
+     * the data in the sort buffer is ready. When receiving credits from the server side, the
+     * corresponding {@link ShuffleWriteClient} is polled to write data.
+     */
+    private final BlockingQueue<ShuffleWriteClient> writingClients = new LinkedBlockingQueue<>();
+
+    /**
+     * Number of waiting finish commitments from server side. When all finish commitments are
+     * received, the {@link RemoteShuffleOutputGate} can be finished safely.
+     */
+    @GuardedBy("lock")
+    private int numWaitingFinishCommit;
+
+    /**
+     * Whether the {@link RemoteShuffleOutputGate} is waiting finish commitments from server side.
+     */
+    @GuardedBy("lock")
+    private boolean isWaitingFinishCommit;
+
+    /** Whether the {@link RemoteShuffleOutputGate} is released. */
+    @GuardedBy("lock")
+    private boolean isReleased;
 
     /**
      * @param shuffleDesc Describes shuffle meta and shuffle worker address.
@@ -83,22 +128,31 @@ public class RemoteShuffleOutputGate {
         this.shuffleDesc = shuffleDesc;
         this.numSubs = numSubs;
         this.bufferPoolFactory = bufferPoolFactory;
-        this.shuffleWriteClient =
-                createWriteClient(bufferSize, dataPartitionFactoryName, connectionManager);
-        this.bufferPacker = new BufferPacker(shuffleWriteClient::write);
+        this.isMapPartition = shuffleDesc.isMapPartition();
+        this.numMapsInGroup = shuffleDesc.getNumMaps();
+        initShuffleWriteClients(bufferSize, dataPartitionFactoryName, connectionManager);
+    }
+
+    boolean isMapPartition() {
+        return isMapPartition;
+    }
+
+    ShuffleWriteClient takeWritingClient() throws InterruptedException {
+        return writingClients.take();
     }
 
     /** Initialize transportation gate. */
     public void setup() throws IOException, InterruptedException {
-        bufferPool = CommonUtils.checkNotNull(bufferPoolFactory.get());
+        bufferPool = checkNotNull(bufferPoolFactory.get());
         CommonUtils.checkArgument(
                 bufferPool.getNumberOfRequiredMemorySegments() >= 2,
                 "Too few buffers for transfer, the minimum valid required size is 2.");
 
         // guarantee that we have at least one buffer
         BufferUtils.reserveNumRequiredBuffers(bufferPool, 1);
-
-        shuffleWriteClient.open();
+        for (ShuffleWriteClient writeClient : shuffleWriteClients.values()) {
+            writeClient.open();
+        }
     }
 
     /** Get transportation buffer pool. */
@@ -106,9 +160,28 @@ public class RemoteShuffleOutputGate {
         return bufferPool;
     }
 
+    public Map<Integer, ShuffleWriteClient> getShuffleWriteClients() {
+        return shuffleWriteClients;
+    }
+
     /** Writes a {@link Buffer} to a subpartition. */
     public void write(Buffer buffer, int subIdx) throws InterruptedException {
-        bufferPacker.process(buffer, subIdx);
+        if (isMapPartition) {
+            checkState(bufferPackers.size() == 1, "Wrong buffer packer size.");
+            for (BufferPacker bufferPacker : bufferPackers.values()) {
+                bufferPacker.process(buffer, subIdx);
+            }
+        } else {
+            BufferPacker bufferPacker = bufferPackers.get(subIdx);
+            checkState(bufferPacker != null, "Buffer packer must not be null.");
+            if ((shuffleWriteClients.get(subIdx).needMoreThanOneBuffer()
+                            && !shuffleWriteClients.get(subIdx).needMoreCredits())
+                    || bufferPacker.hasCachedBuffer()) {
+                bufferPacker.process(buffer, subIdx);
+            } else {
+                bufferPacker.writeWithoutCache(buffer, subIdx);
+            }
+        }
     }
 
     /**
@@ -117,8 +190,42 @@ public class RemoteShuffleOutputGate {
      *
      * @param isBroadcast Whether it's a broadcast region.
      */
-    public void regionStart(boolean isBroadcast) {
-        shuffleWriteClient.regionStart(isBroadcast);
+    public void regionStart(boolean isBroadcast, SortBuffer sortBuffer, int bufferSize) {
+        for (Map.Entry<Integer, ShuffleWriteClient> clientEntry : shuffleWriteClients.entrySet()) {
+            int subPartitionIndex = clientEntry.getKey();
+            ShuffleWriteClient shuffleWriteClient = clientEntry.getValue();
+            long numSubpartitionBytes =
+                    isMapPartition() ? 0 : sortBuffer.numSubpartitionBytes(subPartitionIndex);
+            int numEvents = isMapPartition() ? 0 : sortBuffer.numEvents(subPartitionIndex);
+            if (isEmptyDataInRegion(shuffleWriteClient, numSubpartitionBytes, numEvents)) {
+                continue;
+            }
+
+            int requireCredit =
+                    BufferUtils.calculateSubpartitionCredit(
+                            numSubpartitionBytes, numEvents, bufferSize);
+            boolean needMoreThanOneBuffer =
+                    BufferUtils.needMoreThanOneBuffer(numSubpartitionBytes, bufferSize);
+            shuffleWriteClient.regionStart(
+                    isBroadcast, numMapsInGroup, requireCredit, needMoreThanOneBuffer);
+        }
+    }
+
+    private boolean isEmptyDataInRegion(
+            ShuffleWriteClient shuffleWriteClient, long numSubpartitionBytes, int numEvents) {
+        boolean isEmptyDataInRegion =
+                !isMapPartition() && numSubpartitionBytes == 0 && numEvents == 0;
+        shuffleWriteClient.setIsEmptyDataInRegion(isEmptyDataInRegion);
+        return isEmptyDataInRegion;
+    }
+
+    public void regionStart(
+            boolean isBroadcast,
+            int targetSubpartition,
+            int requireCredit,
+            boolean needMoreThanOneBuffer) {
+        checkNotNull(shuffleWriteClients.get(targetSubpartition))
+                .regionStart(isBroadcast, numMapsInGroup, requireCredit, needMoreThanOneBuffer);
     }
 
     /**
@@ -126,13 +233,61 @@ public class RemoteShuffleOutputGate {
      * region-finish.
      */
     public void regionFinish() throws InterruptedException {
-        bufferPacker.drain();
-        shuffleWriteClient.regionFinish();
+        for (BufferPacker bufferPacker : bufferPackers.values()) {
+            bufferPacker.drain();
+        }
+
+        for (ShuffleWriteClient shuffleWriteClient : shuffleWriteClients.values()) {
+            if (shuffleWriteClient.isEmptyDataInRegion()) {
+                continue;
+            }
+            shuffleWriteClient.regionFinish();
+        }
+    }
+
+    public void regionFinish(int targetSubpartition) throws InterruptedException {
+        if (shuffleWriteClients.get(targetSubpartition).isEmptyDataInRegion()) {
+            return;
+        }
+        bufferPackers.get(targetSubpartition).drain();
+        shuffleWriteClients.get(targetSubpartition).regionFinish();
     }
 
     /** Indicates the writing/spilling is finished. */
     public void finish() throws InterruptedException {
-        shuffleWriteClient.finish();
+        numWaitingFinishCommit = shuffleWriteClients.size();
+        for (ShuffleWriteClient writeClient : shuffleWriteClients.values()) {
+            writeClient.finish(this::decWaitingFinishCommitListener);
+        }
+        synchronized (lock) {
+            if (numWaitingFinishCommit > 0 && !isReleased) {
+                isWaitingFinishCommit = true;
+                lock.wait();
+            }
+        }
+        writingClients.clear();
+    }
+
+    public void decWaitingFinishCommitListener() {
+        synchronized (lock) {
+            numWaitingFinishCommit--;
+            if (numWaitingFinishCommit == 0) {
+                lock.notifyAll();
+                isWaitingFinishCommit = false;
+            }
+        }
+        checkState(numWaitingFinishCommit >= 0, "Wrong number of waiting clients.");
+    }
+
+    void release() {
+        synchronized (lock) {
+            isReleased = true;
+            if (isWaitingFinishCommit) {
+                lock.notifyAll();
+                isWaitingFinishCommit = false;
+            }
+        }
+        writingClients.add(GateUtils.POISON);
     }
 
     /** Close the transportation gate. */
@@ -148,17 +303,35 @@ public class RemoteShuffleOutputGate {
         }
 
         try {
-            bufferPacker.close();
+            for (BufferPacker bufferPacker : bufferPackers.values()) {
+                bufferPacker.close();
+            }
+            bufferPackers.clear();
         } catch (Throwable throwable) {
             closeException = closeException == null ? throwable : closeException;
             LOG.error("Failed to close buffer packer.", throwable);
         }
 
         try {
-            shuffleWriteClient.close();
+            for (ShuffleWriteClient shuffleWriteClient : shuffleWriteClients.values()) {
+                shuffleWriteClient.close();
+            }
+            shuffleWriteClients.clear();
         } catch (Throwable throwable) {
             closeException = closeException == null ? throwable : closeException;
             LOG.error("Failed to close shuffle write client.", throwable);
+        }
+
+        try {
+            while (!writingClients.isEmpty()) {
+                ShuffleWriteClient shuffleWriteClient = writingClients.poll();
+                if (shuffleWriteClient != null) {
+                    shuffleWriteClient.close();
+                }
+            }
+        } catch (Throwable throwable) {
+            closeException = closeException == null ? throwable : closeException;
+            LOG.error("Failed to close writing shuffle write client.", throwable);
         }
 
         if (closeException != null) {
@@ -171,24 +344,59 @@ public class RemoteShuffleOutputGate {
         return shuffleDesc;
     }
 
-    private ShuffleWriteClient createWriteClient(
+    private void initShuffleWriteClients(
             int bufferSize, String dataPartitionFactoryName, ConnectionManager connectionManager) {
         JobID jobID = shuffleDesc.getJobId();
         DataSetID dataSetID = shuffleDesc.getDataSetId();
         MapPartitionID mapID = (MapPartitionID) shuffleDesc.getDataPartitionID();
-        ShuffleWorkerDescriptor swd =
-                ((DefaultShuffleResource) shuffleDesc.getShuffleResource())
-                        .getMapPartitionLocation();
-        InetSocketAddress address =
-                new InetSocketAddress(swd.getWorkerAddress(), swd.getDataPort());
-        return new ShuffleWriteClient(
-                address,
-                jobID,
-                dataSetID,
-                mapID,
-                numSubs,
-                bufferSize,
-                dataPartitionFactoryName,
-                connectionManager);
+        ShuffleWorkerDescriptor[] workerDescriptors = getShuffleWorkerDescriptors();
+        long consumerGroupID = shuffleDesc.getShuffleResource().getConsumerGroupID();
+        checkState(
+                isMapPartition || numSubs == workerDescriptors.length,
+                "Wrong number of workers, " + workerDescriptors.length + " " + numSubs);
+        for (int i = 0; i < workerDescriptors.length; i++) {
+            InetSocketAddress address =
+                    new InetSocketAddress(
+                            workerDescriptors[i].getWorkerAddress(),
+                            workerDescriptors[i].getDataPort());
+            if (shuffleWriteClients.containsKey(i)) {
+                continue;
+            }
+            ReducePartitionID reducePartitionID = new ReducePartitionID(i, consumerGroupID);
+            shuffleWriteClients.put(
+                    i,
+                    new ShuffleWriteClient(
+                            address,
+                            jobID,
+                            dataSetID,
+                            mapID,
+                            reducePartitionID,
+                            numMapsInGroup,
+                            numSubs,
+                            bufferSize,
+                            isMapPartition,
+                            dataPartitionFactoryName,
+                            connectionManager,
+                            writingClients::add));
+        }
+        checkState(
+                shuffleWriteClients.size() == workerDescriptors.length, "Wrong write client count");
+        initBufferPackers();
+    }
+
+    private ShuffleWorkerDescriptor[] getShuffleWorkerDescriptors() {
+        return isMapPartition
+                ? new ShuffleWorkerDescriptor[] {
+                    shuffleDesc.getShuffleResource().getMapPartitionLocation()
+                }
+                : shuffleDesc.getShuffleResource().getReducePartitionLocations();
+    }
+
+    private void initBufferPackers() {
+        shuffleWriteClients.forEach(
+                (subPartitionIndex, shuffleWriteClient) -> {
+                    bufferPackers.put(
+                            subPartitionIndex, new BufferPacker(shuffleWriteClient::write));
+                });
     }
 }

--- a/shuffle-plugin/src/main/java/com/alibaba/flink/shuffle/plugin/transfer/RemoteShuffleResultPartition.java
+++ b/shuffle-plugin/src/main/java/com/alibaba/flink/shuffle/plugin/transfer/RemoteShuffleResultPartition.java
@@ -19,6 +19,8 @@ package com.alibaba.flink.shuffle.plugin.transfer;
 import com.alibaba.flink.shuffle.common.exception.ShuffleException;
 import com.alibaba.flink.shuffle.common.utils.ExceptionUtils;
 import com.alibaba.flink.shuffle.plugin.utils.BufferUtils;
+import com.alibaba.flink.shuffle.plugin.utils.GateUtils;
+import com.alibaba.flink.shuffle.transfer.ShuffleWriteClient;
 
 import org.apache.flink.core.memory.MemorySegment;
 import org.apache.flink.runtime.event.AbstractEvent;
@@ -48,6 +50,9 @@ import javax.annotation.Nullable;
 
 import java.io.IOException;
 import java.nio.ByteBuffer;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 
 import static com.alibaba.flink.shuffle.common.utils.CommonUtils.checkNotNull;
@@ -108,7 +113,7 @@ public class RemoteShuffleResultPartition extends ResultPartition {
 
     @Override
     public void setup() throws IOException {
-        LOG.info("Setup {}", this);
+        LOG.debug("Setup {}", this);
         super.setup();
         BufferUtils.reserveNumRequiredBuffers(bufferPool, 1);
         try {
@@ -141,7 +146,14 @@ public class RemoteShuffleResultPartition extends ResultPartition {
     }
 
     private void broadcast(ByteBuffer record, DataType dataType) throws IOException {
-        emit(record, 0, dataType, true);
+        if (outputGate.isMapPartition()) {
+            emit(record, 0, dataType, true);
+        } else {
+            for (int i = 0; i < numSubpartitions; i++) {
+                ByteBuffer copyRecord = i < numSubpartitions - 1 ? record.duplicate() : record;
+                emit(copyRecord, i, dataType, false);
+            }
+        }
     }
 
     private void emit(
@@ -221,34 +233,123 @@ public class RemoteShuffleResultPartition extends ResultPartition {
         sortBuffer.finish();
         if (sortBuffer.hasRemaining()) {
             try {
-                outputGate.regionStart(isBroadcast);
+                outputGate.regionStart(isBroadcast, sortBuffer, networkBufferSize);
+                Set<ShuffleWriteClient> readFinishClients = new HashSet<>();
                 while (sortBuffer.hasRemaining()) {
-                    MemorySegment segment =
-                            outputGate.getBufferPool().requestMemorySegmentBlocking();
-                    SortBuffer.BufferWithChannel bufferWithChannel;
-                    try {
-                        bufferWithChannel =
-                                sortBuffer.copyIntoSegment(
-                                        segment,
-                                        outputGate.getBufferPool(),
-                                        BufferUtils.HEADER_LENGTH);
-                    } catch (Throwable t) {
-                        outputGate.getBufferPool().recycle(segment);
-                        throw new FlinkRuntimeException("Shuffle write failure.", t);
+                    if (outputGate.isMapPartition()) {
+                        writeDataForMapPartition(sortBuffer, isBroadcast);
+                    } else {
+                        writeDataForReducePartition(sortBuffer, readFinishClients, isBroadcast);
                     }
 
-                    Buffer buffer = bufferWithChannel.getBuffer();
-                    int subpartitionIndex = bufferWithChannel.getChannelIndex();
-                    updateStatistics(bufferWithChannel.getBuffer(), isBroadcast);
-                    writeCompressedBufferIfPossible(buffer, subpartitionIndex);
+                    if (isReleased()) {
+                        break;
+                    }
                 }
-                outputGate.regionFinish();
+                sendRegionFinishIfNeeded();
             } catch (InterruptedException e) {
                 throw new IOException(
                         "Failed to flush the sort buffer, broadcast=" + isBroadcast, e);
             }
         }
         releaseSortBuffer(sortBuffer);
+    }
+
+    private void writeDataForMapPartition(SortBuffer sortBuffer, boolean isBroadcast)
+            throws InterruptedException {
+        MemorySegment segment = outputGate.getBufferPool().requestMemorySegmentBlocking();
+        SortBuffer.BufferWithChannel bufferWithChannel;
+        try {
+            bufferWithChannel =
+                    sortBuffer.copyIntoSegment(
+                            segment, outputGate.getBufferPool(), BufferUtils.HEADER_LENGTH);
+        } catch (Throwable t) {
+            outputGate.getBufferPool().recycle(segment);
+            throw new FlinkRuntimeException("Shuffle write failure.", t);
+        }
+
+        Buffer buffer = bufferWithChannel.getBuffer();
+        int subpartitionIndex = bufferWithChannel.getChannelIndex();
+        updateStatistics(buffer, isBroadcast);
+        writeCompressedBufferIfPossible(buffer, subpartitionIndex);
+    }
+
+    private void writeDataForReducePartition(
+            SortBuffer sortBuffer, Set<ShuffleWriteClient> readFinishClients, boolean isBroadcast)
+            throws InterruptedException {
+        ShuffleWriteClient writeClient = outputGate.takeWritingClient();
+
+        if (writeClient == GateUtils.POISON) {
+            return;
+        }
+
+        if (writeClient.getCurrentCredit() <= 0) {
+            return;
+        }
+
+        while (writeClient.getCurrentCredit() > 0) {
+            int channelIndex = writeClient.getReduceID().getPartitionIndex();
+            MemorySegment segment = outputGate.getBufferPool().requestMemorySegmentBlocking();
+            SortBuffer.BufferWithChannel bufferWithChannel;
+            try {
+                bufferWithChannel =
+                        sortBuffer.copyChannelBuffersIntoSegment(
+                                segment,
+                                channelIndex,
+                                outputGate.getBufferPool(),
+                                BufferUtils.HEADER_LENGTH);
+            } catch (Throwable t) {
+                outputGate.getBufferPool().recycle(segment);
+                throw new FlinkRuntimeException("Shuffle write failure.", t);
+            }
+
+            if (bufferWithChannel != null) {
+                Buffer buffer = bufferWithChannel.getBuffer();
+                int subpartitionIndex = bufferWithChannel.getChannelIndex();
+                checkChannelIndex(sortBuffer, writeClient, bufferWithChannel);
+                updateStatistics(buffer, isBroadcast);
+                writeCompressedBufferIfPossible(buffer, subpartitionIndex);
+
+                if (sortBuffer.hasSubpartitionReadFinish(channelIndex)) {
+                    regionFinish(readFinishClients, writeClient, sortBuffer, channelIndex);
+                    break;
+                }
+            } else {
+                regionFinish(readFinishClients, writeClient, sortBuffer, channelIndex);
+                break;
+            }
+        }
+    }
+
+    private void regionFinish(
+            Set<ShuffleWriteClient> readFinishClients,
+            ShuffleWriteClient writeClient,
+            SortBuffer sortBuffer,
+            int channelIndex)
+            throws InterruptedException {
+        if (!readFinishClients.contains(writeClient)) {
+            readFinishClients.add(writeClient);
+            outputGate.regionFinish(sortBuffer.getSubpartitionReadOrderIndex(channelIndex));
+        }
+    }
+
+    private void sendRegionFinishIfNeeded() throws InterruptedException {
+        if (isReleased()) {
+            return;
+        }
+
+        if (outputGate.isMapPartition()) {
+            outputGate.regionFinish();
+            return;
+        }
+        for (Map.Entry<Integer, ShuffleWriteClient> writeClientEntry :
+                outputGate.getShuffleWriteClients().entrySet()) {
+            int channelIndex = writeClientEntry.getKey();
+            ShuffleWriteClient writeClient = writeClientEntry.getValue();
+            if (!writeClient.sentRegionFinish()) {
+                outputGate.regionFinish(channelIndex);
+            }
+        }
     }
 
     private void writeCompressedBufferIfPossible(Buffer buffer, int targetSubpartition)
@@ -287,8 +388,13 @@ public class RemoteShuffleResultPartition extends ResultPartition {
     private void writeLargeRecord(
             ByteBuffer record, int targetSubpartition, DataType dataType, boolean isBroadcast)
             throws InterruptedException {
-
-        outputGate.regionStart(isBroadcast);
+        int requireCredit =
+                BufferUtils.calculateSubpartitionCredit(
+                        record.remaining(), dataType.isEvent() ? 1 : 0, networkBufferSize);
+        boolean needMoreThanOneBuffer =
+                BufferUtils.needMoreThanOneBuffer(record.remaining(), networkBufferSize);
+        outputGate.regionStart(
+                isBroadcast, targetSubpartition, requireCredit, needMoreThanOneBuffer);
         while (record.hasRemaining()) {
             MemorySegment writeBuffer = outputGate.getBufferPool().requestMemorySegmentBlocking();
             int toCopy =
@@ -304,13 +410,14 @@ public class RemoteShuffleResultPartition extends ResultPartition {
             updateStatistics(buffer, isBroadcast);
             writeCompressedBufferIfPossible(buffer, targetSubpartition);
         }
-        outputGate.regionFinish();
+        outputGate.regionFinish(targetSubpartition);
     }
 
     @Override
     public void finish() throws IOException {
         checkState(!isReleased(), "Result partition is already released.");
         broadcastEvent(EndOfPartitionEvent.INSTANCE, false);
+        flushUnicastSortBuffer();
         checkState(
                 unicastSortBuffer == null || unicastSortBuffer.isReleased(),
                 "The unicast sort buffer should be either null or released.");
@@ -354,6 +461,13 @@ public class RemoteShuffleResultPartition extends ResultPartition {
             LOG.error("Failed to close remote shuffle output gate.", throwable);
         }
 
+        try {
+            partitionManager.releasePartition(this.partitionId, null);
+        } catch (Throwable throwable) {
+            closeException = closeException == null ? throwable : closeException;
+            LOG.error("Failed to release result partition.", throwable);
+        }
+
         if (closeException != null) {
             ExceptionUtils.rethrowAsRuntimeException(closeException);
         }
@@ -361,7 +475,7 @@ public class RemoteShuffleResultPartition extends ResultPartition {
 
     @Override
     protected void releaseInternal() {
-        // no-op
+        outputGate.release();
     }
 
     @Override
@@ -430,5 +544,15 @@ public class RemoteShuffleResultPartition extends ResultPartition {
                 + " subpartitions, shuffle-descriptor: "
                 + outputGate.getShuffleDesc()
                 + "]";
+    }
+
+    private static void checkChannelIndex(
+            SortBuffer sortBuffer,
+            ShuffleWriteClient writeClient,
+            SortBuffer.BufferWithChannel bufferWithChannel) {
+        checkState(
+                sortBuffer.getSubpartitionReadOrderIndex(
+                                writeClient.getReduceID().getPartitionIndex())
+                        == bufferWithChannel.getChannelIndex());
     }
 }

--- a/shuffle-plugin/src/main/java/com/alibaba/flink/shuffle/plugin/transfer/RemoteShuffleResultPartition.java
+++ b/shuffle-plugin/src/main/java/com/alibaba/flink/shuffle/plugin/transfer/RemoteShuffleResultPartition.java
@@ -23,6 +23,7 @@ import com.alibaba.flink.shuffle.plugin.utils.GateUtils;
 import com.alibaba.flink.shuffle.transfer.ShuffleWriteClient;
 
 import org.apache.flink.core.memory.MemorySegment;
+import org.apache.flink.runtime.checkpoint.CheckpointException;
 import org.apache.flink.runtime.event.AbstractEvent;
 import org.apache.flink.runtime.io.network.api.EndOfData;
 import org.apache.flink.runtime.io.network.api.EndOfPartitionEvent;
@@ -513,6 +514,15 @@ public class RemoteShuffleResultPartition extends ResultPartition {
     public int getNumberOfQueuedBuffers(int targetSubpartition) {
         return 0;
     }
+
+    @Override
+    public void alignedBarrierTimeout(long l) {}
+
+    @Override
+    public void abortCheckpoint(long l, CheckpointException e) {}
+
+    @Override
+    protected void setupInternal() {}
 
     @Override
     public ResultSubpartitionView createSubpartitionView(

--- a/shuffle-plugin/src/main/java/com/alibaba/flink/shuffle/plugin/transfer/RemoteShuffleResultPartitionFactory.java
+++ b/shuffle-plugin/src/main/java/com/alibaba/flink/shuffle/plugin/transfer/RemoteShuffleResultPartitionFactory.java
@@ -42,6 +42,8 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 
+import static com.alibaba.flink.shuffle.plugin.utils.GateUtils.getDataPartitionFactoryName;
+
 /** Factory class to create {@link RemoteShuffleResultPartition}. */
 public class RemoteShuffleResultPartitionFactory {
 
@@ -153,6 +155,7 @@ public class RemoteShuffleResultPartitionFactory {
             bufferCompressor = null;
         }
         RemoteShuffleDescriptor rsd = (RemoteShuffleDescriptor) shuffleDescriptor;
+        String factoryName = getDataPartitionFactoryName(rsd);
         ResultPartition partition =
                 new RemoteShuffleResultPartition(
                         taskNameWithSubtaskAndId,
@@ -169,7 +172,7 @@ public class RemoteShuffleResultPartitionFactory {
                                 rsd,
                                 numSubpartitions,
                                 networkBufferSize,
-                                dataPartitionFactoryName,
+                                factoryName,
                                 bufferPoolFactories.get(1),
                                 connectionManager));
         LOG.debug("{}: Initialized {}", taskNameWithSubtaskAndId, this);

--- a/shuffle-plugin/src/main/java/com/alibaba/flink/shuffle/plugin/transfer/SortBuffer.java
+++ b/shuffle-plugin/src/main/java/com/alibaba/flink/shuffle/plugin/transfer/SortBuffer.java
@@ -46,11 +46,31 @@ public interface SortBuffer {
      */
     BufferWithChannel copyIntoSegment(MemorySegment target, BufferRecycler recycler, int offset);
 
+    /**
+     * Copies data from this {@link SortBuffer} to the target {@link MemorySegment} of specific
+     * channel index and returns {@link BufferWithChannel} which contains the copied data and the
+     * corresponding channel index.
+     */
+    BufferWithChannel copyChannelBuffersIntoSegment(
+            MemorySegment target, int targetChannelIndex, BufferRecycler recycler, int offset);
+
+    /** Returns the sub partition read index of this {@link SortBuffer}. */
+    int getSubpartitionReadOrderIndex(int channelIndex);
+
     /** Returns the number of records written to this {@link SortBuffer}. */
     long numRecords();
 
     /** Returns the number of bytes written to this {@link SortBuffer}. */
     long numBytes();
+
+    /** Returns the number of bytes for the specific target subpartition. */
+    long numSubpartitionBytes(int targetSubpartition);
+
+    /** Returns the number of events for the specific target subpartition. */
+    int numEvents(int targetSubpartition);
+
+    /** Returns true if there is no data can be consumed for the specific target subpartition. */
+    boolean hasSubpartitionReadFinish(int targetSubpartition);
 
     /** Returns true if there is still data can be consumed in this {@link SortBuffer}. */
     boolean hasRemaining();

--- a/shuffle-plugin/src/main/java/com/alibaba/flink/shuffle/plugin/utils/GateUtils.java
+++ b/shuffle-plugin/src/main/java/com/alibaba/flink/shuffle/plugin/utils/GateUtils.java
@@ -1,0 +1,143 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.flink.shuffle.plugin.utils;
+
+import com.alibaba.flink.shuffle.common.exception.ShuffleException;
+import com.alibaba.flink.shuffle.coordinator.manager.DefaultShuffleResource;
+import com.alibaba.flink.shuffle.coordinator.manager.ShuffleResource;
+import com.alibaba.flink.shuffle.coordinator.manager.ShuffleWorkerDescriptor;
+import com.alibaba.flink.shuffle.core.ids.DataSetID;
+import com.alibaba.flink.shuffle.core.ids.JobID;
+import com.alibaba.flink.shuffle.core.ids.MapPartitionID;
+import com.alibaba.flink.shuffle.core.ids.ReducePartitionID;
+import com.alibaba.flink.shuffle.plugin.RemoteShuffleDescriptor;
+import com.alibaba.flink.shuffle.plugin.transfer.RemoteShuffleOutputGate;
+import com.alibaba.flink.shuffle.transfer.ConnectionManager;
+import com.alibaba.flink.shuffle.transfer.ShuffleWriteClient;
+
+import org.apache.flink.runtime.shuffle.ShuffleDescriptor;
+
+import java.net.InetSocketAddress;
+import java.time.Duration;
+import java.util.ArrayList;
+
+import static com.alibaba.flink.shuffle.common.utils.CommonUtils.checkState;
+import static com.alibaba.flink.shuffle.core.utils.PartitionUtils.HDD_MAP_PARTITION_FACTORY;
+import static com.alibaba.flink.shuffle.core.utils.PartitionUtils.HDD_REDUCE_PARTITION_FACTORY;
+import static com.alibaba.flink.shuffle.core.utils.PartitionUtils.MAP_PARTITION_FACTORY;
+import static com.alibaba.flink.shuffle.core.utils.PartitionUtils.REDUCE_PARTITION_FACTORY;
+import static com.alibaba.flink.shuffle.core.utils.PartitionUtils.SSD_MAP_PARTITION_FACTORY;
+import static com.alibaba.flink.shuffle.core.utils.PartitionUtils.SSD_REDUCE_PARTITION_FACTORY;
+
+/** Utils for intput gate or output gate. */
+public class GateUtils {
+
+    public static final String EMPTY_WRITE_CLIENT = "emptyClient";
+
+    /**
+     * Marker object used to signal the queue that the result partition is released or failed. This
+     * is added to notify the queue that the result partition has been released or failed so that
+     * the output gate will not be hanged when taking {@link ShuffleWriteClient} from the queue
+     * writingClients of {@link RemoteShuffleOutputGate}.
+     *
+     * <p>Invariant: This is never on queue unless the result partition is released or failed.
+     */
+    public static final ShuffleWriteClient POISON =
+            new ShuffleWriteClient(
+                    InetSocketAddress.createUnresolved("localhost", 9999),
+                    new JobID(EMPTY_WRITE_CLIENT.getBytes()),
+                    new DataSetID(EMPTY_WRITE_CLIENT.getBytes()),
+                    new MapPartitionID(EMPTY_WRITE_CLIENT.getBytes()),
+                    new ReducePartitionID(0),
+                    1,
+                    1,
+                    1,
+                    false,
+                    EMPTY_WRITE_CLIENT,
+                    new ConnectionManager(null, null, 0, Duration.ofMillis(1)),
+                    new ArrayList<ShuffleWriteClient>()::add);
+
+    public static String getDataPartitionFactoryName(RemoteShuffleDescriptor rsd) {
+        boolean isMapPartition = rsd.isMapPartition();
+        ShuffleResource shuffleResource = rsd.getShuffleResource();
+        String factoryName;
+        if (isMapPartition) {
+            switch (shuffleResource.getDiskType()) {
+                case HDD_ONLY:
+                    factoryName = HDD_MAP_PARTITION_FACTORY;
+                    break;
+                case SSD_ONLY:
+                    factoryName = SSD_MAP_PARTITION_FACTORY;
+                    break;
+                case ANY_TYPE:
+                    factoryName = MAP_PARTITION_FACTORY;
+                    break;
+                default:
+                    throw new ShuffleException("No such disk type.");
+            }
+        } else {
+            switch (shuffleResource.getDiskType()) {
+                case HDD_ONLY:
+                    factoryName = HDD_REDUCE_PARTITION_FACTORY;
+                    break;
+                case SSD_ONLY:
+                    factoryName = SSD_REDUCE_PARTITION_FACTORY;
+                    break;
+                case ANY_TYPE:
+                    factoryName = REDUCE_PARTITION_FACTORY;
+                    break;
+                default:
+                    throw new ShuffleException("No such disk type.");
+            }
+        }
+        return factoryName;
+    }
+
+    /**
+     * Returns the simplified {@link ShuffleDescriptor}s according to the input shuffle descriptor
+     * and the sub partition range.
+     */
+    public static ShuffleDescriptor[] getSimplifiedShuffleDescriptors(
+            RemoteShuffleDescriptor shuffleDescriptor, int startSubIdx, int endSubIdx) {
+        int numSubs = endSubIdx - startSubIdx + 1;
+        ShuffleResource shuffleResource = shuffleDescriptor.getShuffleResource();
+        ShuffleWorkerDescriptor[] shuffleWorkerDescriptors =
+                shuffleResource.getReducePartitionLocations();
+        checkState(shuffleWorkerDescriptors.length >= numSubs);
+        ShuffleDescriptor[] simplifiedDescriptors = new ShuffleDescriptor[numSubs];
+
+        for (int i = 0; i < numSubs; i++) {
+            ShuffleWorkerDescriptor workerDescriptor = shuffleWorkerDescriptors[startSubIdx + i];
+            DefaultShuffleResource simplifiedShuffleResource =
+                    new DefaultShuffleResource(
+                            new ShuffleWorkerDescriptor[] {workerDescriptor},
+                            shuffleResource.getDataPartitionType(),
+                            shuffleResource.getDiskType());
+            simplifiedShuffleResource.setConsumerGroupID(shuffleResource.getConsumerGroupID());
+            simplifiedDescriptors[i] =
+                    new RemoteShuffleDescriptor(
+                            shuffleDescriptor.getResultPartitionID(),
+                            shuffleDescriptor.getJobId(),
+                            simplifiedShuffleResource,
+                            shuffleDescriptor.isMapPartition(),
+                            shuffleDescriptor.getNumMaps());
+        }
+        return simplifiedDescriptors;
+    }
+}

--- a/shuffle-plugin/src/test/java/com/alibaba/flink/shuffle/plugin/RemoteShuffleMasterTest.java
+++ b/shuffle-plugin/src/test/java/com/alibaba/flink/shuffle/plugin/RemoteShuffleMasterTest.java
@@ -36,11 +36,13 @@ import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.MemorySize;
 import org.apache.flink.runtime.clusterframework.types.ResourceID;
 import org.apache.flink.runtime.executiongraph.ExecutionAttemptID;
+import org.apache.flink.runtime.executiongraph.ExecutionGraphID;
 import org.apache.flink.runtime.io.network.partition.ResultPartitionID;
 import org.apache.flink.runtime.io.network.partition.ResultPartitionType;
 import org.apache.flink.runtime.jobgraph.IntermediateDataSetID;
 import org.apache.flink.runtime.jobgraph.IntermediateResultPartitionID;
-import org.apache.flink.runtime.scheduler.strategy.ConsumedPartitionGroup;
+import org.apache.flink.runtime.jobgraph.JobVertexID;
+import org.apache.flink.runtime.scheduler.strategy.ExecutionVertexID;
 import org.apache.flink.runtime.shuffle.JobShuffleContext;
 import org.apache.flink.runtime.shuffle.PartitionDescriptor;
 import org.apache.flink.runtime.shuffle.ProducerDescriptor;
@@ -52,9 +54,7 @@ import org.junit.Test;
 
 import java.net.InetAddress;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
 import java.util.Random;
 import java.util.concurrent.CompletableFuture;
@@ -97,7 +97,9 @@ public class RemoteShuffleMasterTest extends RemoteShuffleShuffleTestBase {
         IntermediateDataSetID intermediateDataSetId = new IntermediateDataSetID();
         IntermediateResultPartitionID intermediateResultPartitionId =
                 new IntermediateResultPartitionID(intermediateDataSetId, 0);
-        ExecutionAttemptID executionAttemptId = new ExecutionAttemptID();
+        ExecutionAttemptID executionAttemptId =
+                new ExecutionAttemptID(
+                        new ExecutionGraphID(), new ExecutionVertexID(new JobVertexID(), 0), 0);
         ResultPartitionID resultPartitionId =
                 new ResultPartitionID(intermediateResultPartitionId, executionAttemptId);
         PartitionDescriptor partitionDescriptor =
@@ -116,9 +118,6 @@ public class RemoteShuffleMasterTest extends RemoteShuffleShuffleTestBase {
                         executionAttemptId,
                         InetAddress.getLocalHost(),
                         50000);
-        List<ConsumedPartitionGroup> consumedPartitionGroups =
-                Collections.singletonList(
-                        ConsumedPartitionGroup.fromSinglePartition(intermediateResultPartitionId));
         try (RemoteShuffleMaster shuffleMaster = createAndInitializeShuffleMaster(jobID)) {
             CompletableFuture<RemoteShuffleDescriptor> shuffleDescriptorFuture =
                     shuffleMaster.registerPartitionWithProducer(

--- a/shuffle-plugin/src/test/java/com/alibaba/flink/shuffle/plugin/itcase/AdaptiveBatchJobWithReducePartitionITCase.java
+++ b/shuffle-plugin/src/test/java/com/alibaba/flink/shuffle/plugin/itcase/AdaptiveBatchJobWithReducePartitionITCase.java
@@ -1,0 +1,161 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.flink.shuffle.plugin.itcase;
+
+import com.alibaba.flink.shuffle.storage.partition.LocalFileReducePartitionFactory;
+
+import org.apache.flink.api.common.JobID;
+import org.apache.flink.api.common.RuntimeExecutionMode;
+import org.apache.flink.configuration.JobManagerOptions;
+import org.apache.flink.configuration.MemorySize;
+import org.apache.flink.runtime.jobgraph.JobGraph;
+import org.apache.flink.runtime.jobgraph.JobType;
+import org.apache.flink.runtime.jobmaster.JobResult;
+import org.apache.flink.streaming.api.datastream.DataStream;
+import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
+import org.apache.flink.streaming.api.functions.sink.SinkFunction;
+import org.apache.flink.streaming.api.graph.GlobalStreamExchangeMode;
+import org.apache.flink.streaming.api.graph.StreamGraph;
+import org.apache.flink.streaming.api.graph.StreamingJobGraphGenerator;
+
+import org.junit.Test;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import java.util.stream.LongStream;
+
+import static com.alibaba.flink.shuffle.plugin.config.PluginOptions.DATA_PARTITION_FACTORY_NAME;
+import static org.junit.Assert.assertEquals;
+
+/** IT case for adaptive batch scheduler which covers cases with ReducePartition mode. */
+public class AdaptiveBatchJobWithReducePartitionITCase extends BatchJobITCaseBase {
+
+    private static final int DEFAULT_MAX_PARALLELISM = 100;
+    private static final int SOURCE_PARALLELISM_1 = 8;
+    private static final int SOURCE_PARALLELISM_2 = 12;
+    private static final int NUMBERS_TO_PRODUCE = 10000;
+
+    @Override
+    void setup() {
+        CountSink.countResults.clear();
+
+        // adaptive batch job scheduler config.
+        flinkConfiguration.set(
+                JobManagerOptions.SCHEDULER, JobManagerOptions.SchedulerType.AdaptiveBatch);
+        flinkConfiguration.setInteger(
+                JobManagerOptions.ADAPTIVE_BATCH_SCHEDULER_MAX_PARALLELISM,
+                DEFAULT_MAX_PARALLELISM);
+        flinkConfiguration.set(
+                JobManagerOptions.ADAPTIVE_BATCH_SCHEDULER_AVG_DATA_VOLUME_PER_TASK,
+                MemorySize.parse("128k"));
+        flinkConfiguration.setString(
+                DATA_PARTITION_FACTORY_NAME.key(), LocalFileReducePartitionFactory.class.getName());
+        numTaskManagers = 5;
+        numSlotsPerTaskManager = 2;
+    }
+
+    @Test
+    public void testAdaptiveBatchJobSchedulerWithForwardEdge() throws Exception {
+        final StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
+        env.setParallelism(-1);
+        env.setBufferTimeout(-1);
+        env.setRuntimeMode(RuntimeExecutionMode.BATCH);
+
+        JobGraph jobGraph = createJobGraph(env);
+
+        JobID jobID = flinkCluster.submitJob(jobGraph).get().getJobID();
+        JobResult jobResult = flinkCluster.requestJobResult(jobID).get();
+        if (jobResult.getSerializedThrowable().isPresent()) {
+            throw new AssertionError(jobResult.getSerializedThrowable().get());
+        }
+        checkCountResults();
+    }
+
+    private static void checkCountResults() {
+        Map<Long, Long> countResults = CountSink.countResults;
+
+        Map<Long, Long> expectedResults =
+                LongStream.range(0, NUMBERS_TO_PRODUCE)
+                        .boxed()
+                        .collect(Collectors.toMap(Function.identity(), i -> 2L));
+
+        assertEquals(countResults.size(), NUMBERS_TO_PRODUCE);
+        assertEquals(countResults, expectedResults);
+    }
+
+    /**
+     * Create job vertices and connect them as the following JobGraph:
+     *
+     * <pre>
+     *             hash               forward
+     * 	source1 ----------> middle -----------> sink
+     * 	                                        /
+     * 	                    hash               /
+     *  source2 ----------------------------->/
+     *
+     * </pre>
+     *
+     * <p>All edges are BLOCKING. Edge (source1 --> middle) is hash. Edge (middle --> sink) is
+     * forward. Edge (source2 --> sink) is hash.
+     */
+    private JobGraph createJobGraph(StreamExecutionEnvironment env) throws Exception {
+
+        final DataStream<Long> source1 =
+                env.fromSequence(0, NUMBERS_TO_PRODUCE - 1)
+                        .setParallelism(SOURCE_PARALLELISM_1)
+                        .name("source1")
+                        .slotSharingGroup("group1");
+
+        final DataStream<Long> source2 =
+                env.fromSequence(0, NUMBERS_TO_PRODUCE - 1)
+                        .setParallelism(SOURCE_PARALLELISM_2)
+                        .name("source2")
+                        .slotSharingGroup("group2");
+
+        source1.map(number -> number)
+                .name("middle")
+                .slotSharingGroup("group3")
+                .forward()
+                .union(source2)
+                .addSink(new CountSink())
+                .name("sink")
+                .slotSharingGroup("group4");
+
+        StreamGraph streamGraph = env.getStreamGraph();
+        streamGraph.setGlobalStreamExchangeMode(GlobalStreamExchangeMode.ALL_EDGES_BLOCKING);
+        streamGraph.setJobType(JobType.BATCH);
+        return StreamingJobGraphGenerator.createJobGraph(streamGraph);
+    }
+
+    private static class CountSink implements SinkFunction<Long> {
+
+        private static final long serialVersionUID = -3245115847208949264L;
+
+        private static final Map<Long, Long> countResults = new ConcurrentHashMap<>();
+
+        @Override
+        public void invoke(Long value, Context context) throws Exception {
+            synchronized (countResults) {
+                countResults.put(value, countResults.getOrDefault(value, 0L) + 1L);
+            }
+        }
+    }
+}

--- a/shuffle-plugin/src/test/java/com/alibaba/flink/shuffle/plugin/transfer/ReadingIntegrationTest.java
+++ b/shuffle-plugin/src/test/java/com/alibaba/flink/shuffle/plugin/transfer/ReadingIntegrationTest.java
@@ -25,6 +25,7 @@ import com.alibaba.flink.shuffle.core.config.TransferOptions;
 import com.alibaba.flink.shuffle.core.ids.JobID;
 import com.alibaba.flink.shuffle.core.storage.DataPartition;
 import com.alibaba.flink.shuffle.core.storage.DataPartitionReadingView;
+import com.alibaba.flink.shuffle.core.storage.DiskType;
 import com.alibaba.flink.shuffle.core.storage.ReadingViewContext;
 import com.alibaba.flink.shuffle.plugin.RemoteShuffleDescriptor;
 import com.alibaba.flink.shuffle.plugin.utils.BufferUtils;
@@ -345,8 +346,9 @@ public class ReadingIntegrationTest {
             ShuffleResource shuffleResource =
                     new DefaultShuffleResource(
                             new ShuffleWorkerDescriptor[] {descs.get(randIdx)},
-                            DataPartition.DataPartitionType.MAP_PARTITION);
-            ret[i] = new RemoteShuffleDescriptor(rID, jobID, shuffleResource);
+                            DataPartition.DataPartitionType.MAP_PARTITION,
+                            DiskType.ANY_TYPE);
+            ret[i] = new RemoteShuffleDescriptor(rID, jobID, shuffleResource, true, 1);
         }
         return ret;
     }

--- a/shuffle-plugin/src/test/java/com/alibaba/flink/shuffle/plugin/transfer/RemoteShuffleInputGateFactoryTest.java
+++ b/shuffle-plugin/src/test/java/com/alibaba/flink/shuffle/plugin/transfer/RemoteShuffleInputGateFactoryTest.java
@@ -24,7 +24,9 @@ import com.alibaba.flink.shuffle.coordinator.manager.ShuffleWorkerDescriptor;
 import com.alibaba.flink.shuffle.core.ids.DataSetID;
 import com.alibaba.flink.shuffle.core.ids.JobID;
 import com.alibaba.flink.shuffle.core.ids.MapPartitionID;
+import com.alibaba.flink.shuffle.core.ids.ReducePartitionID;
 import com.alibaba.flink.shuffle.core.storage.DataPartition;
+import com.alibaba.flink.shuffle.core.storage.DiskType;
 import com.alibaba.flink.shuffle.plugin.RemoteShuffleDescriptor;
 import com.alibaba.flink.shuffle.plugin.config.PluginOptions;
 import com.alibaba.flink.shuffle.plugin.utils.ConfigurationUtils;
@@ -131,8 +133,9 @@ public class RemoteShuffleInputGateFactoryTest {
                                 new ShuffleWorkerDescriptor(
                                         null, InetAddress.getLocalHost().getHostAddress(), 0)
                             },
-                            DataPartition.DataPartitionType.MAP_PARTITION);
-            ret[i] = new RemoteShuffleDescriptor(rID, jID, resource);
+                            DataPartition.DataPartitionType.MAP_PARTITION,
+                            DiskType.ANY_TYPE);
+            ret[i] = new RemoteShuffleDescriptor(rID, jID, resource, true, 1);
         }
         return ret;
     }
@@ -206,9 +209,12 @@ public class RemoteShuffleInputGateFactoryTest {
                 InetSocketAddress address,
                 DataSetID dataSetID,
                 MapPartitionID mapID,
+                ReducePartitionID reduceID,
+                int numSubs,
                 int startSubIdx,
                 int endSubIdx,
                 int bufferSize,
+                boolean isMapPartition,
                 TransferBufferPool bufferPool,
                 Consumer<ByteBuf> dataListener,
                 Consumer<Throwable> failureListener) {

--- a/shuffle-plugin/src/test/java/com/alibaba/flink/shuffle/plugin/transfer/RemoteShuffleInputGateTest.java
+++ b/shuffle-plugin/src/test/java/com/alibaba/flink/shuffle/plugin/transfer/RemoteShuffleInputGateTest.java
@@ -25,7 +25,9 @@ import com.alibaba.flink.shuffle.core.exception.PartitionNotFoundException;
 import com.alibaba.flink.shuffle.core.ids.DataSetID;
 import com.alibaba.flink.shuffle.core.ids.JobID;
 import com.alibaba.flink.shuffle.core.ids.MapPartitionID;
+import com.alibaba.flink.shuffle.core.ids.ReducePartitionID;
 import com.alibaba.flink.shuffle.core.storage.DataPartition;
+import com.alibaba.flink.shuffle.core.storage.DiskType;
 import com.alibaba.flink.shuffle.plugin.RemoteShuffleDescriptor;
 import com.alibaba.flink.shuffle.plugin.utils.BufferUtils;
 import com.alibaba.flink.shuffle.transfer.ConnectionManager;
@@ -255,8 +257,9 @@ public class RemoteShuffleInputGateTest {
                                 new ShuffleWorkerDescriptor(
                                         null, InetAddress.getLocalHost().getHostAddress(), 0)
                             },
-                            DataPartition.DataPartitionType.MAP_PARTITION);
-            ret[i] = new RemoteShuffleDescriptor(rID, jID, resource);
+                            DataPartition.DataPartitionType.MAP_PARTITION,
+                            DiskType.ANY_TYPE);
+            ret[i] = new RemoteShuffleDescriptor(rID, jID, resource, true, 1);
         }
         return ret;
     }
@@ -306,9 +309,12 @@ public class RemoteShuffleInputGateTest {
                 InetSocketAddress address,
                 DataSetID dataSetID,
                 MapPartitionID mapID,
+                ReducePartitionID reduceID,
+                int numSubs,
                 int startSubIdx,
                 int endSubIdx,
                 int bufferSize,
+                boolean isMapPartition,
                 TransferBufferPool bufferPool,
                 Consumer<ByteBuf> dataListener,
                 Consumer<Throwable> failureListener) {
@@ -347,9 +353,12 @@ public class RemoteShuffleInputGateTest {
                     new InetSocketAddress(1),
                     new DataSetID(CommonUtils.randomBytes(1)),
                     new MapPartitionID(CommonUtils.randomBytes(1)),
+                    new ReducePartitionID(0),
+                    1,
                     0,
                     0,
                     Integer.MAX_VALUE,
+                    true,
                     bufferPool,
                     new ConnectionManager(null, null, 3, Duration.ofMillis(1)),
                     dataListener,

--- a/shuffle-plugin/src/test/java/com/alibaba/flink/shuffle/plugin/transfer/WritingIntegrationTest.java
+++ b/shuffle-plugin/src/test/java/com/alibaba/flink/shuffle/plugin/transfer/WritingIntegrationTest.java
@@ -26,6 +26,7 @@ import com.alibaba.flink.shuffle.core.ids.JobID;
 import com.alibaba.flink.shuffle.core.memory.Buffer;
 import com.alibaba.flink.shuffle.core.storage.DataPartition;
 import com.alibaba.flink.shuffle.core.storage.DataPartitionWritingView;
+import com.alibaba.flink.shuffle.core.storage.DiskType;
 import com.alibaba.flink.shuffle.core.storage.WritingViewContext;
 import com.alibaba.flink.shuffle.plugin.RemoteShuffleDescriptor;
 import com.alibaba.flink.shuffle.transfer.AbstractNettyTest;
@@ -243,7 +244,7 @@ public class WritingIntegrationTest {
                     if (i % regionSize == 0) {
                         // No need to test broadcast which doesn't have effect on credit-based
                         // transportation.
-                        gate.regionStart(false);
+                        gate.regionStart(false, 0, 0, true);
                     }
                     gate.write(buffer, random.nextInt(numSubs));
                     if (i % regionSize == regionSize - 1) {
@@ -291,9 +292,10 @@ public class WritingIntegrationTest {
                             new ShuffleWorkerDescriptor(
                                     null, localhost, nettyConfig.getServerPort())
                         },
-                        DataPartition.DataPartitionType.MAP_PARTITION);
+                        DataPartition.DataPartitionType.MAP_PARTITION,
+                        DiskType.ANY_TYPE);
         RemoteShuffleDescriptor shuffleDescriptor =
-                new RemoteShuffleDescriptor(resultPartitionID, jobID, shuffleResource);
+                new RemoteShuffleDescriptor(resultPartitionID, jobID, shuffleResource, true, 1);
         return new RemoteShuffleOutputGate(
                 shuffleDescriptor,
                 numSubs,

--- a/shuffle-storage/src/main/java/com/alibaba/flink/shuffle/storage/datastore/PartitionWritingViewImpl.java
+++ b/shuffle-storage/src/main/java/com/alibaba/flink/shuffle/storage/datastore/PartitionWritingViewImpl.java
@@ -51,7 +51,7 @@ public class PartitionWritingViewImpl implements DataPartitionWritingView {
     }
 
     @Override
-    public void onBuffer(Buffer buffer, ReducePartitionID reducePartitionID) {
+    public void onBuffer(Buffer buffer, int dataRegionIndex, ReducePartitionID reducePartitionID) {
         CommonUtils.checkArgument(buffer != null, "Must be not null.");
 
         try {
@@ -64,11 +64,17 @@ public class PartitionWritingViewImpl implements DataPartitionWritingView {
             throw throwable;
         }
 
-        partitionWriter.addBuffer(reducePartitionID, buffer);
+        partitionWriter.addBuffer(reducePartitionID, dataRegionIndex, buffer);
     }
 
     @Override
     public void regionStarted(int dataRegionIndex, boolean isBroadcastRegion) {
+        regionStarted(dataRegionIndex, 1, 0, isBroadcastRegion);
+    }
+
+    @Override
+    public void regionStarted(
+            int dataRegionIndex, int numMaps, int requireCredit, boolean isBroadcastRegion) {
         CommonUtils.checkArgument(dataRegionIndex >= 0, "Must be non-negative.");
 
         checkNotInErrorState();
@@ -76,17 +82,17 @@ public class PartitionWritingViewImpl implements DataPartitionWritingView {
         checkRegionFinished();
 
         isRegionStarted = true;
-        partitionWriter.startRegion(dataRegionIndex, isBroadcastRegion);
+        partitionWriter.startRegion(dataRegionIndex, numMaps, requireCredit, isBroadcastRegion);
     }
 
     @Override
-    public void regionFinished() {
+    public void regionFinished(int dataRegionIndex) {
         checkNotInErrorState();
         checkInputNotFinished();
         checkRegionStarted();
 
         isRegionStarted = false;
-        partitionWriter.finishRegion();
+        partitionWriter.finishRegion(dataRegionIndex);
     }
 
     @Override

--- a/shuffle-storage/src/main/java/com/alibaba/flink/shuffle/storage/partition/BaseMapPartitionWriter.java
+++ b/shuffle-storage/src/main/java/com/alibaba/flink/shuffle/storage/partition/BaseMapPartitionWriter.java
@@ -70,7 +70,7 @@ public abstract class BaseMapPartitionWriter extends BaseDataPartitionWriter {
         if (triggerWriting) {
             DataPartitionWritingTask writingTask =
                     CommonUtils.checkNotNull(dataPartition.getPartitionWritingTask());
-            writingTask.triggerWriting();
+            writingTask.triggerWriting(this);
         }
     }
 }

--- a/shuffle-storage/src/main/java/com/alibaba/flink/shuffle/storage/partition/BaseReducePartitionWriter.java
+++ b/shuffle-storage/src/main/java/com/alibaba/flink/shuffle/storage/partition/BaseReducePartitionWriter.java
@@ -1,0 +1,38 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.flink.shuffle.storage.partition;
+
+import com.alibaba.flink.shuffle.core.ids.MapPartitionID;
+import com.alibaba.flink.shuffle.core.listener.DataRegionCreditListener;
+import com.alibaba.flink.shuffle.core.listener.FailureListener;
+import com.alibaba.flink.shuffle.core.storage.ReducePartition;
+
+/**
+ * {@link BaseReducePartitionWriter} implements some basic logic for data writing of {@link
+ * ReducePartition}s.
+ */
+public abstract class BaseReducePartitionWriter extends BaseDataPartitionWriter {
+    public BaseReducePartitionWriter(
+            MapPartitionID mapPartitionID,
+            BaseDataPartition dataPartition,
+            DataRegionCreditListener dataRegionCreditListener,
+            FailureListener failureListener) {
+        super(dataPartition, mapPartitionID, dataRegionCreditListener, failureListener);
+    }
+}

--- a/shuffle-storage/src/main/java/com/alibaba/flink/shuffle/storage/partition/BufferOrMarker.java
+++ b/shuffle-storage/src/main/java/com/alibaba/flink/shuffle/storage/partition/BufferOrMarker.java
@@ -133,17 +133,25 @@ public abstract class BufferOrMarker {
         /** Target reduce partition of the data. */
         private final ReducePartitionID reducePartitionID;
 
+        /** Region index of the data. */
+        private final int dataRegionIndex;
+
         /** Buffer containing data to be written. */
         private final Buffer buffer;
 
         public DataBuffer(
-                MapPartitionID mapPartitionID, ReducePartitionID reducePartitionID, Buffer buffer) {
+                MapPartitionID mapPartitionID,
+                int dataRegionIndex,
+                ReducePartitionID reducePartitionID,
+                Buffer buffer) {
             super(mapPartitionID);
 
             CommonUtils.checkArgument(reducePartitionID != null, "Must be not null.");
             CommonUtils.checkArgument(buffer != null, "Must be not null.");
+            CommonUtils.checkArgument(dataRegionIndex >= 0, "Must be non-negative.");
 
             this.reducePartitionID = reducePartitionID;
+            this.dataRegionIndex = dataRegionIndex;
             this.buffer = buffer;
         }
 
@@ -154,6 +162,10 @@ public abstract class BufferOrMarker {
 
         public void release() {
             buffer.release();
+        }
+
+        public int getDataRegionIndex() {
+            return dataRegionIndex;
         }
 
         public ReducePartitionID getReducePartitionID() {
@@ -171,6 +183,8 @@ public abstract class BufferOrMarker {
         /** Data region index (started from 0) of the new region. */
         private final int dataRegionIndex;
 
+        private final int requireCredit;
+
         /**
          * Whether the new data region is a broadcast region. In a broadcast region, each piece of
          * data will be written to all reduce partitions.
@@ -178,12 +192,16 @@ public abstract class BufferOrMarker {
         private final boolean isBroadcastRegion;
 
         public RegionStartedMarker(
-                MapPartitionID mapPartitionID, int dataRegionIndex, boolean isBroadcastRegion) {
+                MapPartitionID mapPartitionID,
+                int dataRegionIndex,
+                int requireCredit,
+                boolean isBroadcastRegion) {
             super(mapPartitionID);
 
             CommonUtils.checkArgument(dataRegionIndex >= 0, "Must be non-negative.");
 
             this.dataRegionIndex = dataRegionIndex;
+            this.requireCredit = requireCredit;
             this.isBroadcastRegion = isBroadcastRegion;
         }
 
@@ -196,6 +214,10 @@ public abstract class BufferOrMarker {
             return dataRegionIndex;
         }
 
+        public int getRequireCredit() {
+            return requireCredit;
+        }
+
         public boolean isBroadcastRegion() {
             return isBroadcastRegion;
         }
@@ -204,13 +226,24 @@ public abstract class BufferOrMarker {
     /** Definition of {@link Type#REGION_FINISHED_MARKER}. */
     public static class RegionFinishedMarker extends BufferOrMarker {
 
-        public RegionFinishedMarker(MapPartitionID mapPartitionID) {
+        /** Data region index (started from 0) of the new region. */
+        private final int dataRegionIndex;
+
+        public RegionFinishedMarker(MapPartitionID mapPartitionID, int dataRegionIndex) {
             super(mapPartitionID);
+
+            CommonUtils.checkArgument(dataRegionIndex >= 0, "Must be non-negative.");
+
+            this.dataRegionIndex = dataRegionIndex;
         }
 
         @Override
         public Type getType() {
             return Type.REGION_FINISHED_MARKER;
+        }
+
+        public int getDataRegionIndex() {
+            return dataRegionIndex;
         }
     }
 

--- a/shuffle-storage/src/main/java/com/alibaba/flink/shuffle/storage/partition/DataPartitionWritingTask.java
+++ b/shuffle-storage/src/main/java/com/alibaba/flink/shuffle/storage/partition/DataPartitionWritingTask.java
@@ -16,6 +16,8 @@
 
 package com.alibaba.flink.shuffle.storage.partition;
 
+import com.alibaba.flink.shuffle.core.storage.DataPartitionWriter;
+
 import javax.annotation.Nullable;
 
 /**
@@ -25,10 +27,34 @@ import javax.annotation.Nullable;
 public interface DataPartitionWritingTask extends PartitionProcessingTask {
 
     /** Allocates resources for data writing, will be called on the first data writing request. */
-    void allocateResources() throws Exception;
+    void allocateResources();
 
     /** Triggers running of this writing task which will write data to data partition. */
-    void triggerWriting();
+    void triggerWriting(DataPartitionWriter writer);
+
+    /**
+     * Returns the maximum number of available writing buffers of this {@link
+     * DataPartitionWritingTask}.
+     */
+    int numAvailableBuffers();
+
+    /**
+     * Returns the occupied number of available writing buffers of this {@link
+     * DataPartitionWritingTask}.
+     */
+    int numOccupiedBuffers();
+
+    /**
+     * Whether the number of occupied buffers of this {@link DataPartitionWritingTask} equals with
+     * maximum writing buffers.
+     */
+    boolean hasAllocatedMaxWritingBuffers();
+
+    /**
+     * Recycles the buffers of this {@link DataPartitionWritingTask}. When no more writers, it will
+     * actively release the allocated resources.
+     */
+    void recycleResources();
 
     /** Releases this {@link DataPartitionWritingTask} which releases all allocated resources. */
     void release(@Nullable Throwable throwable) throws Exception;

--- a/shuffle-storage/src/main/java/com/alibaba/flink/shuffle/storage/partition/HDDOnlyLocalFileReducePartitionFactory.java
+++ b/shuffle-storage/src/main/java/com/alibaba/flink/shuffle/storage/partition/HDDOnlyLocalFileReducePartitionFactory.java
@@ -1,11 +1,13 @@
 /*
- * Copyright 2021 The Flink Remote Shuffle Project
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *  	http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -28,9 +30,10 @@ import com.alibaba.flink.shuffle.core.storage.StorageType;
 import java.util.List;
 
 /**
- * A {@link LocalFileMapPartitionFactory} variant which only uses HDD to store data partition data.
+ * A {@link LocalFileReducePartitionFactory} variant which only uses HDD to store data partition
+ * data.
  */
-public class HDDOnlyLocalFileMapPartitionFactory extends LocalFileMapPartitionFactory {
+public class HDDOnlyLocalFileReducePartitionFactory extends LocalFileReducePartitionFactory {
 
     @Override
     public void initialize(Configuration configuration) {

--- a/shuffle-storage/src/main/java/com/alibaba/flink/shuffle/storage/partition/LocalFileMapPartitionWriter.java
+++ b/shuffle-storage/src/main/java/com/alibaba/flink/shuffle/storage/partition/LocalFileMapPartitionWriter.java
@@ -58,7 +58,8 @@ public class LocalFileMapPartitionWriter extends BaseMapPartitionWriter {
     }
 
     @Override
-    protected void processDataBuffer(BufferOrMarker.DataBuffer buffer) throws Exception {
+    protected void processDataBuffer(BufferOrMarker.DataBuffer buffer, boolean isLastBufferOrMarker)
+            throws Exception {
         if (!fileWriter.isOpened()) {
             fileWriter.open();
         }

--- a/shuffle-storage/src/main/java/com/alibaba/flink/shuffle/storage/partition/LocalFileReducePartition.java
+++ b/shuffle-storage/src/main/java/com/alibaba/flink/shuffle/storage/partition/LocalFileReducePartition.java
@@ -1,0 +1,224 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.flink.shuffle.storage.partition;
+
+import com.alibaba.flink.shuffle.common.config.ConfigOption;
+import com.alibaba.flink.shuffle.common.config.Configuration;
+import com.alibaba.flink.shuffle.common.exception.ShuffleException;
+import com.alibaba.flink.shuffle.common.utils.CommonUtils;
+import com.alibaba.flink.shuffle.common.utils.ExceptionUtils;
+import com.alibaba.flink.shuffle.core.config.StorageOptions;
+import com.alibaba.flink.shuffle.core.executor.SingleThreadExecutor;
+import com.alibaba.flink.shuffle.core.ids.DataSetID;
+import com.alibaba.flink.shuffle.core.ids.JobID;
+import com.alibaba.flink.shuffle.core.ids.MapPartitionID;
+import com.alibaba.flink.shuffle.core.ids.ReducePartitionID;
+import com.alibaba.flink.shuffle.core.listener.BacklogListener;
+import com.alibaba.flink.shuffle.core.listener.DataListener;
+import com.alibaba.flink.shuffle.core.listener.DataRegionCreditListener;
+import com.alibaba.flink.shuffle.core.listener.FailureListener;
+import com.alibaba.flink.shuffle.core.storage.DataPartition;
+import com.alibaba.flink.shuffle.core.storage.DataPartitionMeta;
+import com.alibaba.flink.shuffle.core.storage.DataPartitionReader;
+import com.alibaba.flink.shuffle.core.storage.DataPartitionStatistics;
+import com.alibaba.flink.shuffle.core.storage.DataPartitionWriter;
+import com.alibaba.flink.shuffle.core.storage.PartitionedDataStore;
+import com.alibaba.flink.shuffle.core.storage.StorageMeta;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.File;
+
+/**
+ * A reduce {@link DataPartition} implementation which writes data to and read data from local file.
+ */
+public class LocalFileReducePartition extends BaseReducePartition {
+    private static final Logger LOG = LoggerFactory.getLogger(LocalFileReducePartition.class);
+
+    /** {@link DataPartitionMeta} of this data partition. */
+    private final LocalFileReducePartitionMeta partitionMeta;
+
+    /** Local file storing all data of this data partition. */
+    private final LocalReducePartitionFile partitionFile;
+
+    /** File writer used to write data to local file. */
+    private final LocalReducePartitionFileWriter fileWriter;
+
+    public LocalFileReducePartition(
+            StorageMeta storageMeta,
+            PartitionedDataStore dataStore,
+            JobID jobID,
+            DataSetID dataSetID,
+            ReducePartitionID partitionID,
+            int numMapPartitions) {
+        super(dataStore, getSingleThreadExecutor(dataStore, storageMeta));
+
+        String storagePath = storageMeta.getStoragePath();
+        File storageDir = new File(storagePath);
+        CommonUtils.checkArgument(storagePath.endsWith("/"), "Illegal storage path.");
+        CommonUtils.checkArgument(storageDir.exists(), "Storage path does not exist.");
+        CommonUtils.checkArgument(storageDir.isDirectory(), "Storage path is not a directory.");
+
+        Configuration configuration = dataStore.getConfiguration();
+        ConfigOption<Integer> configOption = StorageOptions.STORAGE_FILE_TOLERABLE_FAILURES;
+        int tolerableFailures = CommonUtils.checkNotNull(configuration.getInteger(configOption));
+
+        String fileName = CommonUtils.randomHexString(32);
+        LocalReducePartitionFileMeta fileMeta =
+                new LocalReducePartitionFileMeta(
+                        storagePath + fileName,
+                        numMapPartitions,
+                        LocalReducePartitionFile.LATEST_STORAGE_VERSION);
+        this.partitionFile = new LocalReducePartitionFile(fileMeta, tolerableFailures, true);
+        this.partitionMeta =
+                new LocalFileReducePartitionMeta(
+                        jobID, dataSetID, partitionID, fileMeta, storageMeta);
+
+        boolean dataChecksumEnabled =
+                dataStore
+                        .getConfiguration()
+                        .getBoolean(StorageOptions.STORAGE_ENABLE_DATA_CHECKSUM);
+
+        this.fileWriter =
+                new LocalReducePartitionFileWriter(
+                        partitionFile,
+                        getPartitionWritingTask().minBuffersToWrite / 4,
+                        dataChecksumEnabled);
+    }
+
+    /**
+     * Used to construct data partition instances when adding a finished external data partition or
+     * recovering after failure.
+     */
+    public LocalFileReducePartition(
+            PartitionedDataStore dataStore, LocalFileReducePartitionMeta partitionMeta) {
+        super(dataStore, getSingleThreadExecutor(dataStore, partitionMeta.getStorageMeta()));
+
+        this.partitionMeta = partitionMeta;
+        LocalReducePartitionFileMeta fileMeta = partitionMeta.getPartitionFileMeta();
+        this.partitionFile = fileMeta.createPersistentFile(dataStore.getConfiguration());
+
+        if (!partitionFile.isConsumable()) {
+            partitionFile.setConsumable(false);
+            throw new ShuffleException("Partition data is not consumable.");
+        }
+
+        boolean dataChecksumEnabled =
+                dataStore
+                        .getConfiguration()
+                        .getBoolean(StorageOptions.STORAGE_ENABLE_DATA_CHECKSUM);
+
+        this.fileWriter =
+                new LocalReducePartitionFileWriter(
+                        partitionFile,
+                        getPartitionWritingTask().minBuffersToWrite / 4,
+                        dataChecksumEnabled);
+    }
+
+    private static SingleThreadExecutor getSingleThreadExecutor(
+            PartitionedDataStore dataStore, StorageMeta storageMeta) {
+        CommonUtils.checkArgument(dataStore != null, "Must be not null.");
+        CommonUtils.checkArgument(storageMeta != null, "Must be not null.");
+
+        return dataStore.getExecutorPool(storageMeta).getSingleThreadExecutor();
+    }
+
+    @Override
+    public boolean isConsumable() {
+        return partitionFile.isConsumable();
+    }
+
+    @Override
+    public DataPartitionStatistics getDataPartitionStatistics() {
+        PersistentFileStatistics fileStatistics = partitionFile.getPersistentFileStatistics();
+        return new DataPartitionStatistics(
+                fileStatistics.getNumDataRegions(),
+                fileStatistics.getIndexFileBytes(),
+                fileStatistics.getDataFileBytes());
+    }
+
+    @Override
+    protected DataPartitionReader getDataPartitionReader(
+            int startPartitionIndex,
+            int endPartitionIndex,
+            DataListener dataListener,
+            BacklogListener backlogListener,
+            FailureListener failureListener) {
+        // for different storage versions and formats, different file reader implementations are
+        // needed for backward compatibility, we must keep backward compatibility when upgrading
+        int storageVersion = partitionFile.getFileMeta().getStorageVersion();
+        if (storageVersion <= 1) {
+            boolean dataChecksumEnabled =
+                    dataStore
+                            .getConfiguration()
+                            .getBoolean(StorageOptions.STORAGE_ENABLE_DATA_CHECKSUM);
+            LocalReducePartitionFileReader fileReader =
+                    new LocalReducePartitionFileReader(
+                            dataChecksumEnabled,
+                            startPartitionIndex,
+                            endPartitionIndex,
+                            partitionFile);
+            return new LocalFileReducePartitionReader(
+                    fileReader, dataListener, backlogListener, failureListener);
+        }
+
+        throw new ShuffleException(
+                String.format(
+                        "Illegal storage version, current: %d, supported: %d.",
+                        storageVersion, partitionFile.getLatestStorageVersion()));
+    }
+
+    @Override
+    protected DataPartitionWriter getDataPartitionWriter(
+            MapPartitionID mapPartitionID,
+            DataRegionCreditListener dataRegionCreditListener,
+            FailureListener failureListener) {
+        return new LocalFileReducePartitionWriter(
+                mapPartitionID, this, dataRegionCreditListener, failureListener, fileWriter);
+    }
+
+    @Override
+    protected void releaseInternal(Throwable releaseCause) throws Exception {
+        Throwable exception = null;
+
+        try {
+            super.releaseInternal(releaseCause);
+        } catch (Throwable throwable) {
+            exception = throwable;
+            LOG.error("Fatal: failed to release base map partition.", throwable);
+        }
+
+        try {
+            partitionFile.deleteFile();
+        } catch (Throwable throwable) {
+            exception = throwable;
+            LOG.error("Fatal: failed to delete the partition file.", throwable);
+        }
+
+        if (exception != null) {
+            ExceptionUtils.rethrowException(exception);
+        }
+    }
+
+    @Override
+    public LocalFileReducePartitionMeta getPartitionMeta() {
+        return partitionMeta;
+    }
+}

--- a/shuffle-storage/src/main/java/com/alibaba/flink/shuffle/storage/partition/LocalFileReducePartitionMeta.java
+++ b/shuffle-storage/src/main/java/com/alibaba/flink/shuffle/storage/partition/LocalFileReducePartitionMeta.java
@@ -1,0 +1,127 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.flink.shuffle.storage.partition;
+
+import com.alibaba.flink.shuffle.common.utils.CommonUtils;
+import com.alibaba.flink.shuffle.core.ids.DataSetID;
+import com.alibaba.flink.shuffle.core.ids.JobID;
+import com.alibaba.flink.shuffle.core.ids.ReducePartitionID;
+import com.alibaba.flink.shuffle.core.storage.DataPartitionFactory;
+import com.alibaba.flink.shuffle.core.storage.DataPartitionMeta;
+import com.alibaba.flink.shuffle.core.storage.ReducePartitionMeta;
+import com.alibaba.flink.shuffle.core.storage.StorageMeta;
+
+import java.io.DataInput;
+import java.io.DataOutput;
+import java.io.IOException;
+import java.util.Objects;
+
+/** {@link DataPartitionMeta} of {@link LocalFileReducePartition}. */
+public class LocalFileReducePartitionMeta extends ReducePartitionMeta {
+    private static final long serialVersionUID = -2329943525903450813L;
+
+    /** Meta of the corresponding {@link LocalReducePartitionFile}. */
+    private final LocalReducePartitionFileMeta fileMeta;
+
+    public LocalFileReducePartitionMeta(
+            JobID jobID,
+            DataSetID dataSetID,
+            ReducePartitionID partitionID,
+            LocalReducePartitionFileMeta fileMeta,
+            StorageMeta storageMeta) {
+        super(jobID, dataSetID, partitionID, storageMeta);
+
+        CommonUtils.checkArgument(fileMeta != null, "Must be not null.");
+        this.fileMeta = fileMeta;
+    }
+
+    /**
+     * Reconstructs the {@link DataPartitionMeta} from {@link DataInput} when recovering from
+     * failure.
+     */
+    public static LocalFileReducePartitionMeta readFrom(
+            DataInput dataInput, DataPartitionFactory partitionFactory) throws IOException {
+        JobID jobID = JobID.readFrom(dataInput);
+        DataSetID dataSetID = DataSetID.readFrom(dataInput);
+        ReducePartitionID partitionID = ReducePartitionID.readFrom(dataInput);
+
+        StorageMeta storageMeta = StorageMeta.readFrom(dataInput, partitionFactory);
+        LocalReducePartitionFileMeta fileMeta = LocalReducePartitionFileMeta.readFrom(dataInput);
+
+        return new LocalFileReducePartitionMeta(
+                jobID, dataSetID, partitionID, fileMeta, storageMeta);
+    }
+
+    @Override
+    public String getPartitionFactoryClassName() {
+        return LocalFileReducePartitionFactory.class.getName();
+    }
+
+    public LocalReducePartitionFileMeta getPartitionFileMeta() {
+        return fileMeta;
+    }
+
+    @Override
+    public void writeTo(DataOutput dataOutput) throws Exception {
+        jobID.writeTo(dataOutput);
+        dataSetID.writeTo(dataOutput);
+        partitionID.writeTo(dataOutput);
+        storageMeta.writeTo(dataOutput);
+        fileMeta.writeTo(dataOutput);
+    }
+
+    @Override
+    public boolean equals(Object that) {
+        if (this == that) {
+            return true;
+        }
+
+        if (!(that instanceof LocalFileReducePartitionMeta)) {
+            return false;
+        }
+
+        LocalFileReducePartitionMeta partitionMeta = (LocalFileReducePartitionMeta) that;
+        return Objects.equals(jobID, partitionMeta.jobID)
+                && Objects.equals(dataSetID, partitionMeta.dataSetID)
+                && Objects.equals(partitionID, partitionMeta.partitionID)
+                && Objects.equals(storageMeta, partitionMeta.storageMeta)
+                && Objects.equals(fileMeta, partitionMeta.fileMeta);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(jobID, dataSetID, partitionID, storageMeta, fileMeta);
+    }
+
+    @Override
+    public String toString() {
+        return "LocalFileReducePartitionMeta{"
+                + "JobID="
+                + jobID
+                + ", DataSetID="
+                + dataSetID
+                + ", PartitionID="
+                + partitionID
+                + ", StorageMeta="
+                + storageMeta
+                + ", FileMeta="
+                + fileMeta
+                + '}';
+    }
+}

--- a/shuffle-storage/src/main/java/com/alibaba/flink/shuffle/storage/partition/LocalFileReducePartitionReader.java
+++ b/shuffle-storage/src/main/java/com/alibaba/flink/shuffle/storage/partition/LocalFileReducePartitionReader.java
@@ -1,0 +1,160 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.flink.shuffle.storage.partition;
+
+import com.alibaba.flink.shuffle.common.utils.CommonUtils;
+import com.alibaba.flink.shuffle.common.utils.ExceptionUtils;
+import com.alibaba.flink.shuffle.core.listener.BacklogListener;
+import com.alibaba.flink.shuffle.core.listener.DataListener;
+import com.alibaba.flink.shuffle.core.listener.FailureListener;
+import com.alibaba.flink.shuffle.core.memory.Buffer;
+import com.alibaba.flink.shuffle.core.memory.BufferRecycler;
+import com.alibaba.flink.shuffle.core.storage.BufferQueue;
+import com.alibaba.flink.shuffle.core.storage.DataPartitionReader;
+import com.alibaba.flink.shuffle.core.utils.BufferUtils;
+import com.alibaba.flink.shuffle.core.utils.ListenerUtils;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.nio.ByteBuffer;
+
+/** {@link DataPartitionReader} for {@link LocalFileReducePartition}. */
+public class LocalFileReducePartitionReader extends BaseDataPartitionReader {
+    private static final Logger LOG = LoggerFactory.getLogger(LocalFileReducePartitionReader.class);
+
+    /** File reader responsible for reading data from partition file. */
+    private final LocalReducePartitionFileReader fileReader;
+
+    /** Whether this {@link DataPartitionReader} has been opened or not. */
+    private boolean isOpened;
+
+    public LocalFileReducePartitionReader(
+            LocalReducePartitionFileReader fileReader,
+            DataListener dataListener,
+            BacklogListener backlogListener,
+            FailureListener failureListener) {
+        super(dataListener, backlogListener, failureListener);
+
+        CommonUtils.checkArgument(fileReader != null, "Must be not null.");
+        this.fileReader = fileReader;
+    }
+
+    @Override
+    public void open() throws Exception {
+        CommonUtils.checkState(!isOpened, "Partition reader has been opened.");
+
+        isOpened = true;
+        fileReader.open();
+    }
+
+    /**
+     * Reads data through the corresponding {@link LocalReducePartitionFileReader} and returns true
+     * if there is remaining data to be read with this data partition reader.
+     */
+    @Override
+    public boolean readData(BufferQueue buffers, BufferRecycler recycler) throws Exception {
+        CommonUtils.checkArgument(buffers != null, "Must be not null.");
+        CommonUtils.checkArgument(recycler != null, "Must be not null.");
+
+        CommonUtils.checkState(isOpened, "Partition reader is not opened.");
+
+        boolean hasReaming = fileReader.hasRemaining();
+        boolean continueReading = hasReaming;
+        int numDataBuffers = 0;
+        while (continueReading) {
+            ByteBuffer buffer = buffers.poll();
+            if (buffer == null) {
+                break;
+            }
+
+            try {
+                continueReading = fileReader.readBuffer(buffer);
+            } catch (Throwable throwable) {
+                BufferUtils.recycleBuffer(buffer, recycler);
+                throw throwable;
+            }
+
+            hasReaming = fileReader.hasRemaining();
+            addBuffer(new Buffer(buffer, recycler, buffer.remaining()), hasReaming);
+            ++numDataBuffers;
+        }
+
+        if (numDataBuffers > 0) {
+            notifyBacklog(numDataBuffers);
+        }
+
+        if (!hasReaming) {
+            closeReader();
+        }
+
+        return hasReaming;
+    }
+
+    @Override
+    public long getPriority() {
+        CommonUtils.checkState(isOpened, "Partition reader is not opened.");
+
+        // small file offset has high reading priority, it means when reading the partition file,
+        // the reader always reads data in file offset order which can reduce random IO and lead to
+        // more sequential reading thus is better for IO performance
+        return fileReader.geConsumingOffset();
+    }
+
+    @Override
+    public boolean isOpened() {
+        return isOpened;
+    }
+
+    @Override
+    public void release(Throwable releaseCause) throws Exception {
+        Throwable exception = null;
+
+        try {
+            super.release(releaseCause);
+        } catch (Throwable throwable) {
+            exception = throwable;
+            LOG.error("Failed to release base partition reader.", throwable);
+        }
+
+        try {
+            fileReader.close();
+        } catch (Throwable throwable) {
+            exception = exception != null ? exception : throwable;
+            LOG.error("Failed to release file reader.", throwable);
+        }
+
+        if (exception != null) {
+            ExceptionUtils.rethrowException(exception);
+        }
+    }
+
+    @Override
+    protected void closeReader() throws Exception {
+        try {
+            fileReader.finishReading();
+
+            // mark the reader as finished after closing succeeded
+            super.closeReader();
+        } catch (Throwable throwable) {
+            ListenerUtils.notifyFailure(failureListener, throwable);
+            ExceptionUtils.rethrowException(throwable);
+        }
+    }
+}

--- a/shuffle-storage/src/main/java/com/alibaba/flink/shuffle/storage/partition/LocalFileReducePartitionWriter.java
+++ b/shuffle-storage/src/main/java/com/alibaba/flink/shuffle/storage/partition/LocalFileReducePartitionWriter.java
@@ -1,0 +1,310 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.flink.shuffle.storage.partition;
+
+import com.alibaba.flink.shuffle.common.exception.ShuffleException;
+import com.alibaba.flink.shuffle.common.utils.CommonUtils;
+import com.alibaba.flink.shuffle.common.utils.ExceptionUtils;
+import com.alibaba.flink.shuffle.core.ids.MapPartitionID;
+import com.alibaba.flink.shuffle.core.listener.DataCommitListener;
+import com.alibaba.flink.shuffle.core.listener.DataRegionCreditListener;
+import com.alibaba.flink.shuffle.core.listener.FailureListener;
+import com.alibaba.flink.shuffle.core.memory.Buffer;
+import com.alibaba.flink.shuffle.core.memory.BufferRecycler;
+import com.alibaba.flink.shuffle.core.storage.BufferQueue;
+import com.alibaba.flink.shuffle.core.storage.DataPartitionWriter;
+import com.alibaba.flink.shuffle.core.storage.ReducePartition;
+import com.alibaba.flink.shuffle.core.utils.ListenerUtils;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+
+import static com.alibaba.flink.shuffle.common.utils.CommonUtils.checkState;
+
+/** {@link DataPartitionWriter} for {@link LocalFileReducePartition}. */
+public class LocalFileReducePartitionWriter extends BaseReducePartitionWriter {
+    private static final Logger LOG = LoggerFactory.getLogger(LocalFileReducePartitionWriter.class);
+
+    /**
+     * The number of credits required. The value is from the client when starting a region, it will
+     * not be changed.
+     */
+    protected int requiredCredit;
+
+    /**
+     * The number of credits that have been satisfied. The value should not be greater than {@link
+     * #requiredCredit}.
+     */
+    protected int fulfilledCredit;
+
+    /** The number of map partitions corresponding to the current {@link ReducePartition}. */
+    private volatile int numMaps;
+
+    /** File writer used to write data to local file. */
+    private final LocalReducePartitionFileWriter fileWriter;
+
+    public LocalFileReducePartitionWriter(
+            MapPartitionID mapPartitionID,
+            BaseReducePartition dataPartition,
+            DataRegionCreditListener dataRegionCreditListener,
+            FailureListener failureListener,
+            LocalReducePartitionFileWriter fileWriter) {
+        super(mapPartitionID, dataPartition, dataRegionCreditListener, failureListener);
+        this.fileWriter = fileWriter;
+    }
+
+    @Override
+    public void startRegion(
+            int dataRegionIndex, int numMaps, int requireCredit, boolean isBroadcastRegion) {
+        super.startRegion(dataRegionIndex, numMaps, requireCredit, isBroadcastRegion);
+        checkState(this.numMaps == 0 || this.numMaps == numMaps);
+        this.numMaps = numMaps;
+        triggerWriting();
+    }
+
+    @Override
+    public void finishRegion(int dataRegionIndex) {
+        super.finishRegion(dataRegionIndex);
+        triggerWriting();
+    }
+
+    @Override
+    public void finishDataInput(DataCommitListener commitListener) {
+        super.finishDataInput(commitListener);
+        triggerWriting();
+    }
+
+    @Override
+    protected void processRegionStartedMarker(BufferOrMarker.RegionStartedMarker marker)
+            throws Exception {
+        super.processRegionStartedMarker(marker);
+        isRegionFinished = false;
+        requiredCredit = marker.getRequireCredit();
+        fulfilledCredit = 0;
+        isWritingPartial = false;
+
+        dataPartition.incWritingCounter();
+        dataPartition.addPendingBufferWriter(this);
+        tryAllocatingResources();
+        fileWriter.startRegion(marker.isBroadcastRegion(), marker.getMapPartitionID());
+    }
+
+    @Override
+    protected void processDataBuffer(BufferOrMarker.DataBuffer buffer, boolean isLastBufferOrMarker)
+            throws Exception {
+        if (!fileWriter.isOpened()) {
+            fileWriter.open();
+        }
+        checkState(dataPartition.writers.size() <= numMaps);
+
+        isWritingPartial = true;
+        tryAllocatingResources();
+        // the file writer is responsible for releasing the target buffer
+        fileWriter.writeBuffer(buffer, isLastBufferOrMarker);
+    }
+
+    private void tryAllocatingResources() {
+        DataPartitionWritingTask writingTask =
+                CommonUtils.checkNotNull(dataPartition.getPartitionWritingTask());
+        writingTask.allocateResources();
+    }
+
+    @Override
+    protected void processRegionFinishedMarker(BufferOrMarker.RegionFinishedMarker marker)
+            throws Exception {
+        isRegionFinished = true;
+        isWritingPartial = false;
+        dataPartition.decWritingCounter();
+        checkState(dataPartition.numWritingCounter() >= 0, "Wrong number of writing writers.");
+        super.processRegionFinishedMarker(marker);
+
+        fileWriter.finishRegion(marker.getMapPartitionID());
+        dataPartition.removePendingBufferWriter(this);
+    }
+
+    @Override
+    protected void processInputFinishedMarker(BufferOrMarker.InputFinishedMarker marker)
+            throws Exception {
+        checkState(availableCredits.isEmpty(), "Bug: leaking buffers.");
+        checkState(isRegionFinished, "The region should be finished firstly.");
+        checkState(!isWritingPartial, "The writer is writing a partial record.");
+
+        dataPartition.incNumInputFinishWriter();
+        fileWriter.prepareFinishWriting(marker);
+        if (areAllWritersFinished()) {
+            fileWriter.closeWriting();
+            dataPartition.finishInput();
+        }
+        super.processInputFinishedMarker(marker);
+
+        DataPartitionWriter removedWriter = dataPartition.writers.remove(mapPartitionID);
+        checkState(removedWriter == this, "Remove a wrong writer.");
+        if (dataPartition.writers.isEmpty()) {
+            DataPartitionWritingTask writingTask =
+                    CommonUtils.checkNotNull(dataPartition.getPartitionWritingTask());
+            writingTask.recycleResources();
+        }
+    }
+
+    @Override
+    protected void addBufferOrMarker(BufferOrMarker bufferOrMarker) {
+        boolean recycleBuffer;
+        boolean triggerWriting = false;
+
+        synchronized (lock) {
+            if (numPendingCredit() <= 0 && bufferOrMarkers.isEmpty()) {
+                triggerWriting = true;
+            }
+            if (!(recycleBuffer = isReleased)) {
+                bufferOrMarkers.add(bufferOrMarker);
+            }
+
+            DataPartitionWritingTask writingTask =
+                    CommonUtils.checkNotNull(dataPartition.getPartitionWritingTask());
+            if (writingTask.hasAllocatedMaxWritingBuffers()
+                    && bufferOrMarkers.size()
+                                    + availableCredits.size()
+                                    + fileWriter.numCacheDataBuffers()
+                            == writingTask.numOccupiedBuffers()
+                    && dataPartition.numWritingCounter() == dataPartition.numPendingBufferWriters()
+                    && bufferOrMarkers.size() >= fileWriter.numDataBufferCacheSize() / 2) {
+                triggerWriting = true;
+            }
+        }
+
+        if (recycleBuffer) {
+            BufferOrMarker.releaseBuffer(bufferOrMarker);
+            throw new ShuffleException("Partition writer has been released.");
+        }
+
+        if (triggerWriting) {
+            triggerWriting();
+        }
+    }
+
+    @Override
+    public void onError(Throwable throwable) {
+        super.onError(throwable);
+        triggerWriting();
+    }
+
+    @Override
+    public boolean assignCredits(BufferQueue credits, BufferRecycler recycler) {
+        CommonUtils.checkArgument(credits != null, "Must be not null.");
+        CommonUtils.checkArgument(recycler != null, "Must be not null.");
+
+        needMoreCredits = hasNotFulfilledCredit() && !isRegionFinished;
+        if (isReleased || !needMoreCredits) {
+            return false;
+        }
+
+        int numBuffers = Math.min(credits.size(), requiredCredit - fulfilledCredit);
+        int numLeftBuffers = numBuffers;
+        synchronized (lock) {
+            if (isError) {
+                return false;
+            }
+
+            while (numLeftBuffers-- > 0) {
+                availableCredits.add(new Buffer(credits.poll(), recycler, 0));
+            }
+        }
+
+        fulfilledCredit += numBuffers;
+        checkState(fulfilledCredit >= 0 && fulfilledCredit <= requiredCredit);
+        needMoreCredits = hasNotFulfilledCredit() && !isRegionFinished;
+
+        ListenerUtils.notifyAvailableCredits(
+                numBuffers, currentDataRegionIndex, dataRegionCreditListener);
+        return needMoreCredits;
+    }
+
+    private boolean hasNotFulfilledCredit() {
+        return fulfilledCredit < requiredCredit;
+    }
+
+    @Override
+    public boolean isInProcessQueue() {
+        return isInProcessQueue;
+    }
+
+    @Override
+    public void setInProcessQueue(boolean isInProcessQueue) {
+        this.isInProcessQueue = isInProcessQueue;
+    }
+
+    @Override
+    public boolean isWritingPartial() {
+        return isWritingPartial;
+    }
+
+    @Override
+    public void triggerFlushFileDataBuffers() throws IOException {
+        if (fileWriter.isOpened() && !fileWriter.isClosed()) {
+            fileWriter.flushDataBuffers();
+        }
+    }
+
+    @Override
+    public int numPendingCredit() {
+        return requiredCredit - fulfilledCredit;
+    }
+
+    private boolean areAllWritersFinished() {
+        checkState(dataPartition.numInputFinishWriter() <= numMaps);
+        return dataPartition.numInputFinishWriter() == numMaps;
+    }
+
+    @Override
+    public void release(Throwable throwable) throws Exception {
+        Throwable error = null;
+
+        try {
+            super.release(throwable);
+        } catch (Throwable exception) {
+            error = exception;
+            LOG.error("Failed to release base partition writer.", exception);
+        }
+
+        try {
+            fileWriter.close();
+        } catch (Throwable exception) {
+            error = error == null ? exception : error;
+            LOG.error("Failed to release file writer.", exception);
+        }
+
+        if (error != null) {
+            ExceptionUtils.rethrowException(error);
+        }
+    }
+
+    private void triggerWriting() {
+        synchronized (lock) {
+            if (hasTriggeredWriting) {
+                return;
+            }
+            DataPartitionWritingTask writingTask =
+                    CommonUtils.checkNotNull(dataPartition.getPartitionWritingTask());
+            writingTask.triggerWriting(this);
+            hasTriggeredWriting = true;
+        }
+    }
+}

--- a/shuffle-storage/src/main/java/com/alibaba/flink/shuffle/storage/partition/LocalReducePartitionFile.java
+++ b/shuffle-storage/src/main/java/com/alibaba/flink/shuffle/storage/partition/LocalReducePartitionFile.java
@@ -1,0 +1,405 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.flink.shuffle.storage.partition;
+
+import com.alibaba.flink.shuffle.common.utils.CommonUtils;
+import com.alibaba.flink.shuffle.common.utils.ExceptionUtils;
+import com.alibaba.flink.shuffle.storage.exception.FileCorruptedException;
+import com.alibaba.flink.shuffle.storage.utils.IOUtils;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.annotation.Nullable;
+import javax.annotation.concurrent.NotThreadSafe;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.channels.ClosedChannelException;
+import java.nio.channels.FileChannel;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.zip.CRC32;
+import java.util.zip.Checksum;
+
+/**
+ * Local file based {@link PersistentFile} implementation which is used to store data partition data
+ * to and read data partition data from local file. It consists of two files, the data file is used
+ * to store data and the index file is used to store index information of the data file for reading.
+ */
+@NotThreadSafe
+public class LocalReducePartitionFile implements PersistentFile {
+
+    private static final Logger LOG = LoggerFactory.getLogger(LocalReducePartitionFile.class);
+
+    /**
+     * Latest storage version used. One need to increase this version after changing the storage
+     * format.
+     */
+    public static final int LATEST_STORAGE_VERSION = 1;
+
+    /**
+     * Size of each index entry in the index file: 8 for file offset, 8 for number of bytes and 4
+     * bytes for magic number.
+     */
+    public static final int INDEX_ENTRY_SIZE = 8 + 8 + 4;
+
+    /**
+     * Size of index data checksum, 8 for the number of data regions and 8 for magic number. The
+     * index data checksum sits at the tail the index data file.
+     */
+    public static final int INDEX_DATA_CHECKSUM_SIZE = 8 + 8;
+
+    /** Name suffix of the data file. */
+    public static final String DATA_FILE_SUFFIX = ".data";
+
+    /** Name suffix of the index file. */
+    public static final String INDEX_FILE_SUFFIX = ".index";
+
+    /** Name suffix of the in-progressing partial data file. */
+    public static final String PARTIAL_DATA_FILE_SUFFIX = ".data.partial";
+
+    /** Name suffix of the in-progressing partial index file. */
+    public static final String PARTIAL_INDEX_FILE_SUFFIX = ".index.partial";
+
+    /** Meta information of this data partition file. */
+    private final LocalReducePartitionFileMeta fileMeta;
+
+    /**
+     * Maximum number of {@link IOException}s can be tolerated before marking this partition file as
+     * corrupted.
+     */
+    private final int tolerableFailures;
+
+    /** All data readers that have opened and are reading data from the file. */
+    private final Set<Object> readers = new HashSet<>();
+
+    /** Opened data file channel shared by all data readers for data reading. */
+    @Nullable private FileChannel dataReadingChannel;
+
+    /** Opened index file channel shared by all data readers for data reading. */
+    @Nullable private FileChannel indexReadingChannel;
+
+    /** Counter recording all data reading failures. */
+    private int failureCounter;
+
+    /** Whether this persistent file is consumable and ready for data reading. */
+    private volatile boolean isConsumable;
+
+    /** Statistics information of this persistent file. */
+    private volatile PersistentFileStatistics statistics;
+
+    /** Whether the checksum of the corresponding index data is verified or not. */
+    private volatile boolean indexDataChecksumVerified;
+
+    public LocalReducePartitionFile(
+            LocalReducePartitionFileMeta fileMeta,
+            int tolerableFailures,
+            boolean indexDataChecksumVerified) {
+        this(
+                fileMeta,
+                tolerableFailures,
+                indexDataChecksumVerified,
+                new PersistentFileStatistics(0, 0, 0));
+    }
+
+    public LocalReducePartitionFile(
+            LocalReducePartitionFileMeta fileMeta,
+            int tolerableFailures,
+            boolean indexDataChecksumVerified,
+            PersistentFileStatistics statistics) {
+        CommonUtils.checkArgument(fileMeta != null, "Must be not null.");
+        CommonUtils.checkArgument(tolerableFailures >= 0, "Must be non-negative.");
+        CommonUtils.checkArgument(statistics != null, "Must be not null.");
+
+        this.fileMeta = fileMeta;
+        this.tolerableFailures = tolerableFailures;
+        this.indexDataChecksumVerified = indexDataChecksumVerified;
+        this.statistics = statistics;
+    }
+
+    @Override
+    public int getLatestStorageVersion() {
+        return LATEST_STORAGE_VERSION;
+    }
+
+    @Override
+    public boolean isConsumable() {
+        LOG.info(
+                "isConsumable? {}, data file {} is readable? {}, index file {} is readable? {}",
+                isConsumable,
+                fileMeta.getDataFilePath(),
+                Files.isReadable(fileMeta.getDataFilePath()),
+                fileMeta.getIndexFilePath(),
+                Files.isReadable(fileMeta.getIndexFilePath()));
+        return isConsumable
+                && Files.isReadable(fileMeta.getDataFilePath())
+                && Files.isReadable(fileMeta.getIndexFilePath());
+    }
+
+    @Override
+    public void updatePersistentFileStatistics(PersistentFileStatistics statistics) {
+        this.statistics = statistics;
+    }
+
+    @Override
+    public PersistentFileStatistics getPersistentFileStatistics() {
+        return statistics;
+    }
+
+    @Override
+    public LocalReducePartitionFileMeta getFileMeta() {
+        return fileMeta;
+    }
+
+    /**
+     * Opens this file for reading. This method maintains the reader set and will only open the new
+     * file channels when the first reader is registered. It guarantees that all opened resources
+     * will be released if any exception occurs.
+     */
+    public void openFile(Object reader) throws Exception {
+        CommonUtils.checkArgument(reader != null, "Must be not null.");
+        CommonUtils.checkState(fileMeta.getStorageVersion() <= 1, "Illegal storage version.");
+
+        if (!readers.isEmpty()) {
+            readers.add(reader);
+            return;
+        }
+
+        if (!indexDataChecksumVerified) {
+            verifyIndexDataChecksum();
+            indexDataChecksumVerified = true;
+        }
+
+        try {
+            Path dataFilePath = fileMeta.getDataFilePath();
+            dataReadingChannel = IOUtils.openReadableFileChannel(dataFilePath);
+            Path indexFilePath = fileMeta.getIndexFilePath();
+            indexReadingChannel = IOUtils.openReadableFileChannel(indexFilePath);
+
+            readers.add(reader);
+        } catch (Throwable throwable) {
+            CommonUtils.runQuietly(this::closeFileChannels);
+            LOG.error("Failed to open the partition for reading: {}.", fileMeta.getFilePath());
+            throw throwable;
+        }
+    }
+
+    /**
+     * Marks the given file reader as closed. This method maintains the reader set and will only
+     * close the opened file channels when all file readers have been closed.
+     */
+    public void closeFile(Object reader) throws Exception {
+        CommonUtils.checkArgument(reader != null, "Must be not null.");
+
+        readers.remove(reader);
+        if (readers.isEmpty()) {
+            closeFileChannels();
+        }
+    }
+
+    @Override
+    public void deleteFile() throws Exception {
+        LOG.info("Deleting the partition file: {}.", fileMeta.getFilePath());
+        Throwable exception = null;
+
+        try {
+            // close file channel first if opened
+            closeFileChannels();
+        } catch (Throwable throwable) {
+            exception = throwable;
+        }
+
+        Path filePath = fileMeta.getDataFilePath();
+        try {
+            CommonUtils.deleteFileWithRetry(filePath);
+        } catch (Throwable throwable) {
+            exception = exception != null ? exception : throwable;
+            LOG.error("Failed to delete data file: {}.", filePath, throwable);
+        }
+
+        filePath = fileMeta.getIndexFilePath();
+        try {
+            CommonUtils.deleteFileWithRetry(filePath);
+        } catch (Throwable throwable) {
+            exception = exception != null ? exception : throwable;
+            LOG.error("Failed to delete index file: {}.", filePath, throwable);
+        }
+
+        filePath = fileMeta.getPartialDataFilePath();
+        try {
+            CommonUtils.deleteFileWithRetry(filePath);
+        } catch (Throwable throwable) {
+            exception = exception != null ? exception : throwable;
+            LOG.error("Failed to delete data file: {}.", filePath, throwable);
+        }
+
+        filePath = fileMeta.getPartialIndexFilePath();
+        try {
+            CommonUtils.deleteFileWithRetry(filePath);
+        } catch (Throwable throwable) {
+            exception = exception != null ? exception : throwable;
+            LOG.error("Failed to delete index file: {}.", filePath, throwable);
+        }
+
+        if (exception != null) {
+            ExceptionUtils.rethrowException(exception);
+        }
+    }
+
+    @Override
+    public void onError(Throwable throwable) {
+        if (throwable instanceof ClosedChannelException) {
+            return;
+        }
+
+        if (throwable instanceof FileCorruptedException
+                || (throwable instanceof IOException && ++failureCounter > tolerableFailures)) {
+            // to trigger partition not found exception
+            setConsumable(false);
+            LOG.error("Corrupted partition file: {}.", fileMeta.getFilePath(), throwable);
+        }
+    }
+
+    @Override
+    public void setConsumable(boolean isConsumable) {
+        this.isConsumable = isConsumable;
+
+        // delete the physical files eagerly
+        if (!isConsumable) {
+            CommonUtils.runQuietly(this::closeFileChannels);
+            CommonUtils.runQuietly(this::deleteFile);
+        }
+    }
+
+    @Nullable
+    public FileChannel getDataReadingChannel() {
+        return dataReadingChannel;
+    }
+
+    @Nullable
+    public FileChannel getIndexReadingChannel() {
+        return indexReadingChannel;
+    }
+
+    /** Returns the total size of all index entries for a data region. */
+    public long getIndexRegionSize() {
+        //        return fileMeta.getNumMapPartitions() * (long) INDEX_ENTRY_SIZE;
+        // Only one region
+        return (long) INDEX_ENTRY_SIZE;
+    }
+
+    /** Returns the offset in the index file of the target index entry. */
+    public long getIndexEntryOffset(int regionIndex, int targetPartitionIndex) {
+        return regionIndex * getIndexRegionSize() + targetPartitionIndex * (long) INDEX_ENTRY_SIZE;
+    }
+
+    public static Path getDataFilePath(String baseFilePath) {
+        CommonUtils.checkArgument(baseFilePath != null, "Must be not null.");
+
+        return new File(baseFilePath + DATA_FILE_SUFFIX).toPath();
+    }
+
+    public static Path getIndexFilePath(String baseFilePath) {
+        CommonUtils.checkArgument(baseFilePath != null, "Must be not null.");
+
+        return new File(baseFilePath + INDEX_FILE_SUFFIX).toPath();
+    }
+
+    public static Path getPartialDataFilePath(String baseFilePath) {
+        CommonUtils.checkArgument(baseFilePath != null, "Must be not null.");
+
+        return new File(baseFilePath + PARTIAL_DATA_FILE_SUFFIX).toPath();
+    }
+
+    public static Path getPartialIndexFilePath(String baseFilePath) {
+        CommonUtils.checkArgument(baseFilePath != null, "Must be not null.");
+
+        return new File(baseFilePath + PARTIAL_INDEX_FILE_SUFFIX).toPath();
+    }
+
+    /** Closes the opened data file channel and index file channel. */
+    private void closeFileChannels() throws Exception {
+        Throwable exception = null;
+        try {
+            CommonUtils.closeWithRetry(dataReadingChannel);
+            dataReadingChannel = null;
+        } catch (Throwable throwable) {
+            exception = throwable;
+            LOG.error(
+                    "Failed to close data file channel: {}.",
+                    fileMeta.getDataFilePath(),
+                    throwable);
+        }
+
+        try {
+            CommonUtils.closeWithRetry(indexReadingChannel);
+            indexReadingChannel = null;
+        } catch (Throwable throwable) {
+            exception = exception != null ? exception : throwable;
+            LOG.error(
+                    "Failed to close index file channel: {}.",
+                    fileMeta.getIndexFilePath(),
+                    throwable);
+        }
+
+        if (exception != null) {
+            ExceptionUtils.rethrowException(exception);
+        }
+    }
+
+    private void verifyIndexDataChecksum() throws Exception {
+        FileChannel fileChannel = null;
+        try {
+            fileChannel = IOUtils.openReadableFileChannel(fileMeta.getIndexFilePath());
+            int numPartitions = fileMeta.getNumMapPartitions();
+            int indexRegionSize = IOUtils.calculateIndexRegionSize(1);
+
+            long remainingDataSize = fileChannel.size() - INDEX_DATA_CHECKSUM_SIZE;
+            if (remainingDataSize % indexRegionSize != 0) {
+                throw new FileCorruptedException();
+            }
+
+            Checksum checksum = new CRC32();
+            CommonUtils.checkState(
+                    CommonUtils.checkedDownCast(remainingDataSize / indexRegionSize) == 1);
+            ByteBuffer indexBuffer = IOUtils.allocateIndexBuffer(numPartitions);
+
+            while (remainingDataSize > 0) {
+                long length = Math.min(remainingDataSize, indexBuffer.capacity());
+                IOUtils.readBuffer(fileChannel, indexBuffer, CommonUtils.checkedDownCast(length));
+                remainingDataSize -= length;
+                while (indexBuffer.hasRemaining()) {
+                    checksum.update(indexBuffer.get());
+                }
+            }
+
+            IOUtils.readBuffer(fileChannel, indexBuffer, INDEX_DATA_CHECKSUM_SIZE);
+        } catch (Throwable throwable) {
+            setConsumable(false);
+            LOG.error("Failed to verify index data checksum, releasing partition data.", throwable);
+            throw throwable;
+        } finally {
+            CommonUtils.closeWithRetry(fileChannel);
+        }
+    }
+}

--- a/shuffle-storage/src/main/java/com/alibaba/flink/shuffle/storage/partition/LocalReducePartitionFileMeta.java
+++ b/shuffle-storage/src/main/java/com/alibaba/flink/shuffle/storage/partition/LocalReducePartitionFileMeta.java
@@ -1,0 +1,177 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.flink.shuffle.storage.partition;
+
+import com.alibaba.flink.shuffle.common.config.ConfigOption;
+import com.alibaba.flink.shuffle.common.config.Configuration;
+import com.alibaba.flink.shuffle.common.exception.ShuffleException;
+import com.alibaba.flink.shuffle.common.utils.CommonUtils;
+import com.alibaba.flink.shuffle.core.config.StorageOptions;
+
+import java.io.DataInput;
+import java.io.DataOutput;
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.Objects;
+
+/** {@link PersistentFileMeta} of {@link LocalReducePartitionFile}. */
+public class LocalReducePartitionFileMeta implements PersistentFileMeta {
+    private static final long serialVersionUID = -3499083473292011948L;
+
+    /** File name (without suffix) of both the data file and index file. */
+    private final String filePath;
+
+    /** Number of map partitions in the corresponding partition file. */
+    private final int numMapPartitions;
+
+    /** Path of the data file. */
+    private final Path dataFilePath;
+
+    /** Path of the index file. */
+    private final Path indexFilePath;
+
+    /** Path of the in-progressing partial data file. */
+    private final Path partialDataFilePath;
+
+    /** Path of the in-progressing partial index file. */
+    private final Path partialIndexFilePath;
+
+    /**
+     * Storage version of the target {@link PersistentFile}. Different versions may need different
+     * processing logics.
+     */
+    private final int storageVersion;
+
+    public LocalReducePartitionFileMeta(String filePath, int numMapPartitions, int storageVersion) {
+        CommonUtils.checkArgument(filePath != null, "Must be not null.");
+        CommonUtils.checkArgument(numMapPartitions > 0, "Must be positive.");
+
+        this.filePath = filePath;
+        this.numMapPartitions = numMapPartitions;
+        this.storageVersion = storageVersion;
+
+        this.partialDataFilePath = LocalReducePartitionFile.getPartialDataFilePath(filePath);
+        this.partialIndexFilePath = LocalReducePartitionFile.getPartialIndexFilePath(filePath);
+        this.dataFilePath = LocalReducePartitionFile.getDataFilePath(filePath);
+        this.indexFilePath = LocalReducePartitionFile.getIndexFilePath(filePath);
+    }
+
+    @Override
+    public int getStorageVersion() {
+        return storageVersion;
+    }
+
+    /**
+     * Reconstructs the {@link LocalReducePartitionFileMeta} instance from the {@link DataInput}
+     * when recovering from failure.
+     */
+    public static LocalReducePartitionFileMeta readFrom(DataInput dataInput) throws IOException {
+        int storageVersion = dataInput.readInt();
+        return readFrom(dataInput, storageVersion);
+    }
+
+    private static LocalReducePartitionFileMeta readFrom(DataInput dataInput, int storageVersion)
+            throws IOException {
+        if (storageVersion <= 1) {
+            int numReducePartitions = dataInput.readInt();
+            String filePath = dataInput.readUTF();
+            return new LocalReducePartitionFileMeta(filePath, numReducePartitions, storageVersion);
+        }
+
+        throw new ShuffleException(
+                String.format(
+                        "Illegal storage version, data format version: %d, supported version: %d.",
+                        storageVersion, LocalReducePartitionFile.LATEST_STORAGE_VERSION));
+    }
+
+    public String getFilePath() {
+        return filePath;
+    }
+
+    public Path getDataFilePath() {
+        return dataFilePath;
+    }
+
+    public Path getIndexFilePath() {
+        return indexFilePath;
+    }
+
+    public Path getPartialDataFilePath() {
+        return partialDataFilePath;
+    }
+
+    public Path getPartialIndexFilePath() {
+        return partialIndexFilePath;
+    }
+
+    public int getNumMapPartitions() {
+        return numMapPartitions;
+    }
+
+    @Override
+    public LocalReducePartitionFile createPersistentFile(Configuration configuration) {
+        ConfigOption<Integer> configOption = StorageOptions.STORAGE_FILE_TOLERABLE_FAILURES;
+        int tolerableFailures = CommonUtils.checkNotNull(configuration.getInteger(configOption));
+
+        LocalReducePartitionFile partitionFile =
+                new LocalReducePartitionFile(this, tolerableFailures, false);
+        partitionFile.setConsumable(true);
+        return partitionFile;
+    }
+
+    @Override
+    public void writeTo(DataOutput dataOutput) throws Exception {
+        dataOutput.writeInt(storageVersion);
+        dataOutput.writeInt(numMapPartitions);
+        dataOutput.writeUTF(filePath);
+    }
+
+    @Override
+    public boolean equals(Object that) {
+        if (this == that) {
+            return true;
+        }
+
+        if (!(that instanceof LocalReducePartitionFileMeta)) {
+            return false;
+        }
+
+        LocalReducePartitionFileMeta fileMeta = (LocalReducePartitionFileMeta) that;
+        return numMapPartitions == fileMeta.numMapPartitions
+                && storageVersion == fileMeta.storageVersion
+                && Objects.equals(filePath, fileMeta.filePath);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(filePath, numMapPartitions, storageVersion);
+    }
+
+    @Override
+    public String toString() {
+        return "LocalReducePartitionFileMeta{"
+                + "FilePath="
+                + filePath
+                + ", NumReducePartitions="
+                + numMapPartitions
+                + ", StorageVersion="
+                + storageVersion
+                + '}';
+    }
+}

--- a/shuffle-storage/src/main/java/com/alibaba/flink/shuffle/storage/partition/LocalReducePartitionFileReader.java
+++ b/shuffle-storage/src/main/java/com/alibaba/flink/shuffle/storage/partition/LocalReducePartitionFileReader.java
@@ -1,0 +1,237 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.flink.shuffle.storage.partition;
+
+import com.alibaba.flink.shuffle.common.utils.CommonUtils;
+import com.alibaba.flink.shuffle.storage.exception.FileCorruptedException;
+import com.alibaba.flink.shuffle.storage.utils.IOUtils;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.channels.FileChannel;
+import java.nio.file.Files;
+
+/** File reader for the {@link LocalReducePartitionFile}. */
+public class LocalReducePartitionFileReader {
+    private static final Logger LOG = LoggerFactory.getLogger(LocalReducePartitionFileReader.class);
+
+    /** Buffer for reading an index entry to memory. */
+    private final ByteBuffer indexBuffer;
+
+    /** Buffer for reading buffer header to memory. */
+    private final ByteBuffer headerBuffer;
+
+    /** Target partition file to be read data from. */
+    private final LocalReducePartitionFile partitionFile;
+
+    /** First index (inclusive) of the target reduce partitions to be read. */
+    private final int startPartitionIndex;
+
+    /** Last index (inclusive) of the target reduce partitions to be read. */
+    private final int endPartitionIndex;
+
+    /** Whether to enable data checksum or not. */
+    private final boolean dataChecksumEnabled;
+
+    /** Number of data regions in the target file. */
+    private int numRegions;
+
+    /** Opened data file channel to read data from. */
+    private FileChannel dataFileChannel;
+
+    /** Opened index file channel to read index from. */
+    private FileChannel indexFileChannel;
+
+    /** Number of remaining reduce partitions to read in the current data region. */
+    private int numRemainingPartitions;
+
+    /** Current data region index to read data from. */
+    private int currentDataRegion = -1;
+
+    /** File offset in data file to read data from. */
+    private long dataConsumingOffset;
+
+    /** Number of remaining bytes to read from the current reduce partition. */
+    private long currentPartitionRemainingBytes;
+
+    /** Whether this file reader is closed or not. A closed file reader can not read any data. */
+    private boolean isClosed;
+
+    /** Whether this file reader is opened or not. */
+    private boolean isOpened;
+
+    public LocalReducePartitionFileReader(
+            boolean dataChecksumEnabled,
+            int startPartitionIndex,
+            int endPartitionIndex,
+            LocalReducePartitionFile partitionFile) {
+        CommonUtils.checkArgument(partitionFile != null, "Must be not null.");
+        CommonUtils.checkArgument(startPartitionIndex >= 0, "Must be non-negative.");
+        CommonUtils.checkArgument(
+                endPartitionIndex >= startPartitionIndex,
+                "Ending partition index must be no smaller than starting partition index.");
+
+        this.partitionFile = partitionFile;
+        this.startPartitionIndex = startPartitionIndex;
+        this.endPartitionIndex = endPartitionIndex;
+        this.dataChecksumEnabled = dataChecksumEnabled;
+
+        int indexBufferSize =
+                LocalReducePartitionFile.INDEX_ENTRY_SIZE
+                        * (endPartitionIndex - startPartitionIndex + 1);
+        this.indexBuffer = CommonUtils.allocateDirectByteBuffer(indexBufferSize);
+        this.headerBuffer =
+                CommonUtils.allocateDirectByteBuffer(
+                        IOUtils.getHeaderBufferSizeOfLocalReducePartitionFile(
+                                partitionFile.getFileMeta().getStorageVersion()));
+    }
+
+    public void open() throws Exception {
+        CommonUtils.checkState(!isOpened, "Partition file reader has been opened.");
+        CommonUtils.checkState(!isClosed, "Partition file reader has been closed.");
+
+        try {
+            isOpened = true;
+            partitionFile.openFile(this);
+            dataFileChannel = CommonUtils.checkNotNull(partitionFile.getDataReadingChannel());
+            indexFileChannel = CommonUtils.checkNotNull(partitionFile.getIndexReadingChannel());
+
+            long indexFileSize = indexFileChannel.size();
+            long indexRegionSize = partitionFile.getIndexRegionSize();
+
+            // if this checks fail, the partition file must be corrupted
+            if (indexFileSize % indexRegionSize
+                    != LocalReducePartitionFile.INDEX_DATA_CHECKSUM_SIZE) {
+                throw new FileCorruptedException();
+            }
+
+            numRegions = CommonUtils.checkedDownCast(indexFileChannel.size() / indexRegionSize);
+            updateConsumingOffset();
+        } catch (Throwable throwable) {
+            CommonUtils.runQuietly(this::close);
+            partitionFile.onError(throwable);
+
+            LOG.error("Failed to open partition file.", throwable);
+            throw throwable;
+        }
+    }
+
+    /**
+     * Reads data to the target buffer and returns true if there is remaining data in current data
+     * region. The caller is responsible for recycling the target buffer if any exception occurs.
+     */
+    public boolean readBuffer(ByteBuffer buffer) throws Exception {
+        CommonUtils.checkArgument(buffer != null, "Must be not null.");
+
+        CommonUtils.checkState(isOpened, "Partition file reader is not opened.");
+        CommonUtils.checkState(!isClosed, "Partition file reader has been closed.");
+        // one must check remaining before reading
+        CommonUtils.checkState(hasRemaining(), "No remaining data to read.");
+
+        try {
+            dataFileChannel.position(dataConsumingOffset);
+            currentPartitionRemainingBytes -=
+                    IOUtils.readBuffer(
+                            dataFileChannel,
+                            headerBuffer,
+                            buffer,
+                            headerBuffer.capacity(),
+                            dataChecksumEnabled);
+
+            // if this check fails, the partition file must be corrupted
+            if (currentPartitionRemainingBytes < 0) {
+                throw new FileCorruptedException();
+            } else if (currentPartitionRemainingBytes == 0) {
+                int prevDataRegion = currentDataRegion;
+                updateConsumingOffset();
+                return prevDataRegion == currentDataRegion && currentPartitionRemainingBytes > 0;
+            }
+
+            dataConsumingOffset = dataFileChannel.position();
+            return true;
+        } catch (Throwable throwable) {
+            partitionFile.onError(throwable);
+            LOG.error("Failed to read partition file.", throwable);
+            throw throwable;
+        }
+    }
+
+    /** Returns true if there is remaining bytes in the target partition file. */
+    public boolean hasRemaining() {
+        return currentPartitionRemainingBytes > 0;
+    }
+
+    /** Returns the next data reading offset in the target data partition file. */
+    public long geConsumingOffset() {
+        return dataConsumingOffset;
+    }
+
+    /** Updates to next data reading offset in the target data partition file. */
+    private void updateConsumingOffset() throws IOException {
+        while (currentPartitionRemainingBytes == 0
+                && (currentDataRegion < numRegions - 1 || numRemainingPartitions > 0)) {
+            if (numRemainingPartitions <= 0) {
+                ++currentDataRegion;
+                numRemainingPartitions = endPartitionIndex - startPartitionIndex + 1;
+
+                // read the target index entry to the target index buffer
+                long seekPosition = partitionFile.getIndexEntryOffset(currentDataRegion, 0);
+                indexFileChannel.position(seekPosition);
+                IOUtils.readBuffer(indexFileChannel, indexBuffer, indexBuffer.capacity());
+            }
+
+            // get the data file offset and the data size
+            dataConsumingOffset = indexBuffer.getLong();
+            currentPartitionRemainingBytes = indexBuffer.getLong();
+            int magicNumber = indexBuffer.getInt();
+            --numRemainingPartitions;
+
+            // if these checks fail, the partition file must be corrupted
+            if (dataConsumingOffset < 0
+                    || dataConsumingOffset + currentPartitionRemainingBytes > dataFileChannel.size()
+                    || currentPartitionRemainingBytes < 0
+                    || magicNumber != IOUtils.MAGIC_NUMBER) {
+                throw new FileCorruptedException();
+            }
+        }
+    }
+
+    public void finishReading() throws Exception {
+        close();
+
+        LocalReducePartitionFileMeta fileMeta = partitionFile.getFileMeta();
+        CommonUtils.checkState(
+                Files.exists(fileMeta.getDataFilePath()), "Data file has been deleted.");
+        CommonUtils.checkState(
+                Files.exists(fileMeta.getIndexFilePath()), "Index file has been deleted.");
+    }
+
+    /** Closes this partition file reader. After closed, no data can be read any more. */
+    public void close() throws Exception {
+        isClosed = true;
+        partitionFile.closeFile(this);
+    }
+
+    public boolean isOpened() {
+        return isOpened;
+    }
+}

--- a/shuffle-storage/src/main/java/com/alibaba/flink/shuffle/storage/partition/LocalReducePartitionFileWriter.java
+++ b/shuffle-storage/src/main/java/com/alibaba/flink/shuffle/storage/partition/LocalReducePartitionFileWriter.java
@@ -1,0 +1,369 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.flink.shuffle.storage.partition;
+
+import com.alibaba.flink.shuffle.common.utils.CommonUtils;
+import com.alibaba.flink.shuffle.common.utils.ExceptionUtils;
+import com.alibaba.flink.shuffle.core.ids.MapPartitionID;
+import com.alibaba.flink.shuffle.storage.utils.IOUtils;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.channels.FileChannel;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.zip.CRC32;
+import java.util.zip.Checksum;
+
+import static com.alibaba.flink.shuffle.common.utils.CommonUtils.checkState;
+
+/** File writer for the {@link LocalReducePartitionFile}. */
+public class LocalReducePartitionFileWriter {
+
+    private static final Logger LOG = LoggerFactory.getLogger(LocalReducePartitionFileWriter.class);
+
+    /** Maximum number of data buffers can be cached in {@link #dataBuffers} before flushing. */
+    private final int dataBufferCacheSize;
+
+    /**
+     * All pending {@link BufferOrMarker.DataBuffer}s to be written. This list is for batch writing
+     * which can be better for IO performance.
+     */
+    protected final List<BufferOrMarker.DataBuffer> dataBuffers;
+
+    protected final Set<MapPartitionID> regionStartMapIDs;
+
+    /** Target {@link LocalReducePartitionFile} to write data to. */
+    private final LocalReducePartitionFile partitionFile;
+
+    /** Caches the index data before flushing the data to target index file. */
+    private final ByteBuffer indexBuffer;
+
+    /** Opened data file channel to write data buffers to. */
+    private FileChannel dataFileChannel;
+
+    /** Opened index file channel to write index info to. */
+    private FileChannel indexFileChannel;
+
+    /** Current reduce partition index to which the data buffer is written. */
+    private int currentReducePartition;
+
+    /** Total bytes of data have been written to the target partition file. */
+    private long totalBytes;
+
+    /**
+     * Whether current data region is a broadcast region or not. If true, buffers added to this
+     * region will be written to all reduce partitions.
+     */
+    private boolean isBroadcastRegion;
+
+    /** Whether this file writer has been closed or not. */
+    private boolean isClosed;
+
+    /** Whether this file writer has been opened or not. */
+    private boolean isOpened;
+
+    /** Number of finished data regions in the target {@link LocalMapPartitionFile} currently. */
+    private long numDataRegions;
+
+    private boolean isCachingData;
+
+    /**
+     * Checksum util to calculate the checksum value the index data. The completeness of index data
+     * is important because it is used to index the real data. The lost of index data just means the
+     * lost of the real data.
+     */
+    private final Checksum checksum = new CRC32();
+
+    /** Whether to enable data checksum or not. */
+    private final boolean dataChecksumEnabled;
+
+    public LocalReducePartitionFileWriter(
+            LocalReducePartitionFile partitionFile,
+            int dataBufferCacheSize,
+            boolean dataChecksumEnabled) {
+        CommonUtils.checkArgument(partitionFile != null, "Must be not null.");
+        CommonUtils.checkArgument(dataBufferCacheSize > 0, "Must be positive.");
+
+        this.partitionFile = partitionFile;
+        this.dataBufferCacheSize = dataBufferCacheSize;
+        this.dataBuffers = new ArrayList<>(2 * dataBufferCacheSize);
+        this.regionStartMapIDs = new HashSet<>();
+        this.dataChecksumEnabled = dataChecksumEnabled;
+
+        this.indexBuffer = IOUtils.allocateIndexBuffer(1);
+        LOG.debug("dataBufferCacheSize={}", dataBufferCacheSize);
+    }
+
+    public void open() throws Exception {
+        checkState(!isOpened, "Partition file writer has been opened.");
+        checkState(!isClosed, "Partition file writer has been closed.");
+
+        try {
+            isOpened = true;
+            Path dataFilePath = partitionFile.getFileMeta().getPartialDataFilePath();
+            dataFileChannel = IOUtils.createWritableFileChannel(dataFilePath);
+
+            Path indexFilePath = partitionFile.getFileMeta().getPartialIndexFilePath();
+            indexFileChannel = IOUtils.createWritableFileChannel(indexFilePath);
+        } catch (Throwable throwable) {
+            CommonUtils.runQuietly(this::close);
+            throw throwable;
+        }
+    }
+
+    /**
+     * Writes the given data buffer of the corresponding reduce partition to the target {@link
+     * LocalReducePartitionFile}.
+     */
+    public void writeBuffer(BufferOrMarker.DataBuffer dataBuffer, boolean isLastBufferOrMarker)
+            throws IOException {
+        CommonUtils.checkArgument(dataBuffer != null, "Must be not null.");
+
+        checkState(isOpened, "Partition file writer is not opened.");
+        checkState(!isClosed, "Partition file writer has been closed.");
+
+        if (!dataBuffer.getBuffer().isReadable()) {
+            dataBuffer.release();
+            return;
+        }
+
+        dataBuffers.add(dataBuffer);
+
+        if (dataBuffers.size() >= dataBufferCacheSize) {
+            flushDataBuffers();
+            CommonUtils.checkState(
+                    dataBuffers.isEmpty(),
+                    "Leaking buffers, some buffers are not released after flush.");
+        }
+    }
+
+    void flushDataBuffers() throws IOException {
+        try {
+            checkNotClosed();
+            isCachingData = false;
+
+            if (!dataBuffers.isEmpty()) {
+                ByteBuffer[] bufferWithHeaders = collectBufferWithHeaders();
+                IOUtils.writeBuffers(dataFileChannel, bufferWithHeaders);
+            }
+        } finally {
+            releaseAllDataBuffers();
+        }
+    }
+
+    private ByteBuffer[] collectBufferWithHeaders() {
+        int index = 0;
+        ByteBuffer[] bufferWithHeaders = new ByteBuffer[2 * dataBuffers.size()];
+
+        for (BufferOrMarker.DataBuffer dataBuffer : dataBuffers) {
+            int reducePartitionIndex = dataBuffer.getReducePartitionID().getPartitionIndex();
+            checkState(
+                    reducePartitionIndex >= currentReducePartition,
+                    "Must writing data in reduce partition index order.");
+            checkState(
+                    !isBroadcastRegion || reducePartitionIndex == 0,
+                    "Reduce partition index must be 0 for broadcast region.");
+
+            if (reducePartitionIndex > currentReducePartition) {
+                currentReducePartition = reducePartitionIndex;
+            }
+
+            ByteBuffer data = dataBuffer.getBuffer().nioBuffer();
+            ByteBuffer header = IOUtils.getHeaderBuffer(data, dataChecksumEnabled);
+
+            long length = data.remaining() + header.remaining();
+            totalBytes += length;
+
+            bufferWithHeaders[index] = header;
+            bufferWithHeaders[index + 1] = data;
+            index += 2;
+        }
+        return bufferWithHeaders;
+    }
+
+    /**
+     * Marks that a new data region has been started. If the new data region is a broadcast region,
+     * buffers added to this region will be written to all reduce partitions.
+     */
+    public void startRegion(boolean isBroadcastRegion, MapPartitionID mapPartitionID) {
+        checkNotClosed();
+        currentReducePartition = Math.max(currentReducePartition, 0);
+        this.isBroadcastRegion = isBroadcastRegion;
+        regionStartMapIDs.add(mapPartitionID);
+    }
+
+    /**
+     * Marks that the current data region has been finished and flushes the index region to the
+     * index file.
+     */
+    public void finishRegion(MapPartitionID mapPartitionID) throws IOException {
+        checkNotClosed();
+        checkState(
+                regionStartMapIDs.contains(mapPartitionID),
+                "No region start message was received for " + mapPartitionID);
+
+        if (dataBuffers.size() >= dataBufferCacheSize) {
+            flushDataBuffers();
+        } else {
+            isCachingData = true;
+        }
+
+        ++numDataRegions;
+        regionStartMapIDs.remove(mapPartitionID);
+    }
+
+    private void flushIndexBuffer() throws IOException {
+        indexBuffer.flip();
+        if (indexBuffer.hasRemaining()) {
+            for (int index = 0; index < indexBuffer.limit(); ++index) {
+                checksum.update(indexBuffer.get(index));
+            }
+            IOUtils.writeBuffer(indexFileChannel, indexBuffer);
+        }
+        indexBuffer.clear();
+    }
+
+    boolean isCachingData() {
+        return isCachingData;
+    }
+
+    public void prepareFinishWriting(BufferOrMarker.InputFinishedMarker marker) throws Exception {
+        if (!isOpened()) {
+            open();
+        }
+
+        checkNotClosed();
+        flushDataBuffers();
+    }
+
+    /**
+     * Closes this partition file writer and marks the target {@link LocalReducePartitionFile} as
+     * consumable after finishing data writing.
+     */
+    public void closeWriting() throws Exception {
+        checkState(regionStartMapIDs.size() == 0, "Wrong region finish marker count. ");
+        checkState(dataBuffers.size() == 0, "Must flush cached data firstly. ");
+
+        indexBuffer.putLong(0);
+        indexBuffer.putLong(totalBytes);
+        indexBuffer.putInt(IOUtils.MAGIC_NUMBER);
+
+        flushIndexBuffer();
+
+        // flush the number of data regions and the index data checksum for integrity checking
+        indexBuffer.putLong(numDataRegions);
+        indexBuffer.putLong(checksum.getValue());
+        indexBuffer.flip();
+        IOUtils.writeBuffer(indexFileChannel, indexBuffer);
+
+        close();
+
+        LocalReducePartitionFileMeta fileMeta = partitionFile.getFileMeta();
+        File dataFile = fileMeta.getDataFilePath().toFile();
+        renameFile(fileMeta.getPartialDataFilePath().toFile(), dataFile);
+
+        File indexFile = fileMeta.getIndexFilePath().toFile();
+        renameFile(fileMeta.getPartialIndexFilePath().toFile(), indexFile);
+
+        checkState(dataFile.exists(), "Data file has been deleted.");
+        checkState(indexFile.exists(), "Index file has been deleted.");
+        partitionFile.setConsumable(true);
+        LOG.info("Closed file for {} and {}, total {} bytes", dataFile, indexFile, totalBytes);
+    }
+
+    private void renameFile(File sourceFile, File targetFile) throws IOException {
+        CommonUtils.checkArgument(sourceFile != null, "Must be not null.");
+        CommonUtils.checkArgument(targetFile != null, "Must be not null.");
+
+        if (!sourceFile.renameTo(targetFile)) {
+            throw new IOException(
+                    String.format(
+                            "Failed to rename file %s to file %s.",
+                            sourceFile.getAbsolutePath(), targetFile.getAbsolutePath()));
+        }
+    }
+
+    /** Releases this partition file writer when any exception occurs. */
+    public void close() throws Exception {
+        isClosed = true;
+        Throwable exception = null;
+
+        try {
+            CommonUtils.closeWithRetry(dataFileChannel);
+        } catch (Throwable throwable) {
+            exception = throwable;
+            Path dataFilePath = partitionFile.getFileMeta().getDataFilePath();
+            LOG.error("Failed to close data file channel: {}.", dataFilePath, throwable);
+        }
+
+        try {
+            CommonUtils.closeWithRetry(indexFileChannel);
+        } catch (Throwable throwable) {
+            exception = exception != null ? exception : throwable;
+            Path dataFilePath = partitionFile.getFileMeta().getIndexFilePath();
+            LOG.error("Failed to close index file channel: {}.", dataFilePath, throwable);
+        }
+
+        try {
+            releaseAllDataBuffers();
+        } catch (Throwable throwable) {
+            exception = exception != null ? exception : throwable;
+            LOG.error("Failed to release the pending data buffers.", throwable);
+        }
+
+        if (exception != null) {
+            ExceptionUtils.rethrowException(exception);
+        }
+    }
+
+    public int numCacheDataBuffers() {
+        return dataBuffers.size();
+    }
+
+    public int numDataBufferCacheSize() {
+        return dataBufferCacheSize;
+    }
+
+    public boolean isOpened() {
+        return isOpened;
+    }
+
+    protected boolean isClosed() {
+        return isClosed;
+    }
+
+    private void releaseAllDataBuffers() {
+        for (BufferOrMarker.DataBuffer dataBuffer : dataBuffers) {
+            BufferOrMarker.releaseBuffer(dataBuffer);
+        }
+        dataBuffers.clear();
+    }
+
+    private void checkNotClosed() {
+        checkState(!isClosed, "Partition file writer has been closed.");
+    }
+}

--- a/shuffle-storage/src/main/java/com/alibaba/flink/shuffle/storage/partition/SSDOnlyLocalFileMapPartitionFactory.java
+++ b/shuffle-storage/src/main/java/com/alibaba/flink/shuffle/storage/partition/SSDOnlyLocalFileMapPartitionFactory.java
@@ -19,6 +19,7 @@ package com.alibaba.flink.shuffle.storage.partition;
 import com.alibaba.flink.shuffle.common.config.Configuration;
 import com.alibaba.flink.shuffle.common.exception.ConfigurationException;
 import com.alibaba.flink.shuffle.core.config.StorageOptions;
+import com.alibaba.flink.shuffle.core.storage.DiskType;
 import com.alibaba.flink.shuffle.core.storage.StorageMeta;
 import com.alibaba.flink.shuffle.core.storage.StorageSpaceInfo;
 import com.alibaba.flink.shuffle.core.storage.StorageType;
@@ -83,6 +84,11 @@ public class SSDOnlyLocalFileMapPartitionFactory extends LocalFileMapPartitionFa
         for (StorageMeta storageMeta : storageMetas) {
             storageMeta.updateStorageHealthStatus();
         }
+    }
+
+    @Override
+    public DiskType getDiskType() {
+        return DiskType.SSD_ONLY;
     }
 
     @Override

--- a/shuffle-storage/src/main/java/com/alibaba/flink/shuffle/storage/partition/SSDOnlyLocalFileReducePartitionFactory.java
+++ b/shuffle-storage/src/main/java/com/alibaba/flink/shuffle/storage/partition/SSDOnlyLocalFileReducePartitionFactory.java
@@ -1,11 +1,13 @@
 /*
- * Copyright 2021 The Flink Remote Shuffle Project
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *  	http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -19,7 +21,6 @@ package com.alibaba.flink.shuffle.storage.partition;
 import com.alibaba.flink.shuffle.common.config.Configuration;
 import com.alibaba.flink.shuffle.common.exception.ConfigurationException;
 import com.alibaba.flink.shuffle.core.config.StorageOptions;
-import com.alibaba.flink.shuffle.core.storage.DataPartition;
 import com.alibaba.flink.shuffle.core.storage.DiskType;
 import com.alibaba.flink.shuffle.core.storage.StorageMeta;
 import com.alibaba.flink.shuffle.core.storage.StorageSpaceInfo;
@@ -28,51 +29,47 @@ import com.alibaba.flink.shuffle.core.storage.StorageType;
 import java.util.List;
 
 /**
- * A {@link LocalFileMapPartitionFactory} variant which only uses HDD to store data partition data.
+ * A {@link LocalFileReducePartitionFactory} variant which only uses SSD to store data partition
+ * data.
  */
-public class HDDOnlyLocalFileMapPartitionFactory extends LocalFileMapPartitionFactory {
+public class SSDOnlyLocalFileReducePartitionFactory extends LocalFileReducePartitionFactory {
 
     @Override
     public void initialize(Configuration configuration) {
         super.initialize(configuration);
 
-        if (hddStorageMetas.isEmpty()) {
+        if (ssdStorageMetas.isEmpty()) {
             throw new ConfigurationException(
                     String.format(
-                            "No valid data dir of HDD storage type is configured for %s.",
+                            "No valid data dir of SSD storage type is configured for %s.",
                             StorageOptions.STORAGE_LOCAL_DATA_DIRS.key()));
         }
-        ssdStorageMetas.clear();
+        hddStorageMetas.clear();
         updateStorageHealthStatus();
-        this.updateFreeStorageSpace();
+        updateFreeStorageSpace();
     }
 
     @Override
     protected StorageMeta getNextDataStorageMeta() {
         synchronized (lock) {
-            return getStorageMetaInNonEmptyQueue(hddStorageMetas);
+            return getStorageMetaInNonEmptyQueue(ssdStorageMetas);
         }
-    }
-
-    @Override
-    public DataPartition.DataPartitionType getDataPartitionType() {
-        return super.getDataPartitionType();
     }
 
     @Override
     public void updateFreeStorageSpace() {
-        storageSpaceInfo.setSsdMaxFreeSpaceBytes(0);
-        long maxHddFreeSpaceBytes = 0;
-        for (StorageMeta storageMeta : getHddStorageMetas()) {
+        storageSpaceInfo.setHddMaxFreeSpaceBytes(0);
+        long maxSsdFreeSpaceBytes = 0;
+        for (StorageMeta storageMeta : getSsdStorageMetas()) {
             if (!storageMeta.isHealthy()) {
                 continue;
             }
             long freeSpaceBytes = storageMeta.updateFreeStorageSpace();
-            if (freeSpaceBytes > maxHddFreeSpaceBytes) {
-                maxHddFreeSpaceBytes = freeSpaceBytes;
+            if (freeSpaceBytes > maxSsdFreeSpaceBytes) {
+                maxSsdFreeSpaceBytes = freeSpaceBytes;
             }
         }
-        storageSpaceInfo.setHddMaxFreeSpaceBytes(maxHddFreeSpaceBytes);
+        storageSpaceInfo.setSsdMaxFreeSpaceBytes(maxSsdFreeSpaceBytes);
     }
 
     @Override
@@ -80,13 +77,13 @@ public class HDDOnlyLocalFileMapPartitionFactory extends LocalFileMapPartitionFa
             StorageSpaceInfo storageSpaceInfo,
             long minReservedSpaceBytes,
             long maxUsableSpaceBytes) {
-        return minReservedSpaceBytes < storageSpaceInfo.getHddMaxFreeSpaceBytes()
-                && maxUsableSpaceBytes > storageSpaceInfo.getHddMaxUsedSpaceBytes();
+        return minReservedSpaceBytes < storageSpaceInfo.getSsdMaxFreeSpaceBytes()
+                && maxUsableSpaceBytes > storageSpaceInfo.getSsdMaxUsedSpaceBytes();
     }
 
     @Override
     public void updateStorageHealthStatus() {
-        List<StorageMeta> storageMetas = getHddStorageMetas();
+        List<StorageMeta> storageMetas = getSsdStorageMetas();
         for (StorageMeta storageMeta : storageMetas) {
             storageMeta.updateStorageHealthStatus();
         }
@@ -94,16 +91,16 @@ public class HDDOnlyLocalFileMapPartitionFactory extends LocalFileMapPartitionFa
 
     @Override
     public DiskType getDiskType() {
-        return DiskType.HDD_ONLY;
+        return DiskType.SSD_ONLY;
     }
 
     @Override
-    public boolean useHddOnly() {
+    public boolean useSsdOnly() {
         return true;
     }
 
     @Override
     public StorageType getPreferredStorageType() {
-        return StorageType.HDD;
+        return StorageType.SSD;
     }
 }

--- a/shuffle-storage/src/main/java/com/alibaba/flink/shuffle/storage/utils/DataPartitionUtils.java
+++ b/shuffle-storage/src/main/java/com/alibaba/flink/shuffle/storage/utils/DataPartitionUtils.java
@@ -57,6 +57,23 @@ public class DataPartitionUtils {
     }
 
     /**
+     * Helper method which releases all the given {@link DataPartitionReader}s and logs the
+     * encountered exception if any.
+     */
+    public static void releaseDataPartitionWriters(
+            @Nullable Collection<DataPartitionWriter> writers, @Nullable Throwable releaseCause) {
+        if (writers == null) {
+            return;
+        }
+
+        for (DataPartitionWriter partitionWriter : writers) {
+            releaseDataPartitionWriter(partitionWriter, releaseCause);
+        }
+        // clear method is not supported by all collections
+        CommonUtils.runQuietly(writers::clear);
+    }
+
+    /**
      * Helper method which releases the target {@link DataPartitionReader} and logs the encountered
      * exception if any.
      */

--- a/shuffle-storage/src/main/java/com/alibaba/flink/shuffle/storage/utils/IOUtils.java
+++ b/shuffle-storage/src/main/java/com/alibaba/flink/shuffle/storage/utils/IOUtils.java
@@ -261,4 +261,17 @@ public class IOUtils {
                 throw new IllegalArgumentException("Unknown storage version: " + storageVersion);
         }
     }
+
+    /** Return the header buffer size. For different versions, this value may be different. */
+    // TODO, fix this method.
+    public static int getHeaderBufferSizeOfLocalReducePartitionFile(int storageVersion) {
+        switch (storageVersion) {
+            case 0:
+                return 8;
+            case 1:
+                return 16;
+            default:
+                throw new IllegalArgumentException("Unknown storage version: " + storageVersion);
+        }
+    }
 }

--- a/shuffle-storage/src/main/resources/META-INF/services/com.alibaba.flink.shuffle.core.storage.DataPartitionFactory
+++ b/shuffle-storage/src/main/resources/META-INF/services/com.alibaba.flink.shuffle.core.storage.DataPartitionFactory
@@ -17,3 +17,6 @@
 com.alibaba.flink.shuffle.storage.partition.LocalFileMapPartitionFactory
 com.alibaba.flink.shuffle.storage.partition.SSDOnlyLocalFileMapPartitionFactory
 com.alibaba.flink.shuffle.storage.partition.HDDOnlyLocalFileMapPartitionFactory
+com.alibaba.flink.shuffle.storage.partition.LocalFileReducePartitionFactory
+com.alibaba.flink.shuffle.storage.partition.SSDOnlyLocalFileReducePartitionFactory
+com.alibaba.flink.shuffle.storage.partition.HDDOnlyLocalFileReducePartitionFactory

--- a/shuffle-storage/src/test/java/com/alibaba/flink/shuffle/storage/datastore/NoOpDataPartitionWriter.java
+++ b/shuffle-storage/src/test/java/com/alibaba/flink/shuffle/storage/datastore/NoOpDataPartitionWriter.java
@@ -24,6 +24,8 @@ import com.alibaba.flink.shuffle.core.memory.BufferRecycler;
 import com.alibaba.flink.shuffle.core.storage.BufferQueue;
 import com.alibaba.flink.shuffle.core.storage.DataPartitionWriter;
 
+import java.io.IOException;
+
 /** A no-op {@link DataPartitionWriter} implementation for tests. */
 public class NoOpDataPartitionWriter implements DataPartitionWriter {
 
@@ -43,13 +45,15 @@ public class NoOpDataPartitionWriter implements DataPartitionWriter {
     }
 
     @Override
-    public void addBuffer(ReducePartitionID reducePartitionID, Buffer buffer) {}
+    public void addBuffer(
+            ReducePartitionID reducePartitionID, int dataRegionIndex, Buffer buffer) {}
 
     @Override
-    public void startRegion(int dataRegionIndex, boolean isBroadcastRegion) {}
+    public void startRegion(
+            int dataRegionIndex, int numMaps, int needCredit, boolean isBroadcastRegion) {}
 
     @Override
-    public void finishRegion() {}
+    public void finishRegion(int dataRegionIndex) {}
 
     @Override
     public void finishDataInput(DataCommitListener commitListener) {}
@@ -60,8 +64,37 @@ public class NoOpDataPartitionWriter implements DataPartitionWriter {
     }
 
     @Override
+    public boolean isInProcessQueue() {
+        return false;
+    }
+
+    @Override
+    public int numBufferOrMarkers() {
+        return 0;
+    }
+
+    @Override
+    public void setInProcessQueue(boolean isInProcessQueue) {}
+
+    @Override
+    public boolean isWritingPartial() {
+        return false;
+    }
+
+    @Override
+    public void triggerFlushFileDataBuffers() throws IOException {}
+
+    @Override
+    public int numPendingCredit() {
+        return 0;
+    }
+
+    @Override
     public void onError(Throwable throwable) {}
 
     @Override
     public void release(Throwable throwable) {}
+
+    @Override
+    public void startRegion(int dataRegionIndex, boolean isBroadcastRegion) {}
 }

--- a/shuffle-storage/src/test/java/com/alibaba/flink/shuffle/storage/datastore/NoOpPartitionedDataStore.java
+++ b/shuffle-storage/src/test/java/com/alibaba/flink/shuffle/storage/datastore/NoOpPartitionedDataStore.java
@@ -23,6 +23,7 @@ import com.alibaba.flink.shuffle.core.ids.DataPartitionID;
 import com.alibaba.flink.shuffle.core.ids.DataSetID;
 import com.alibaba.flink.shuffle.core.ids.JobID;
 import com.alibaba.flink.shuffle.core.memory.BufferDispatcher;
+import com.alibaba.flink.shuffle.core.storage.DataPartitionFactory;
 import com.alibaba.flink.shuffle.core.storage.DataPartitionMeta;
 import com.alibaba.flink.shuffle.core.storage.DataPartitionReadingView;
 import com.alibaba.flink.shuffle.core.storage.DataPartitionWritingView;
@@ -66,6 +67,11 @@ public class NoOpPartitionedDataStore implements PartitionedDataStore {
     @Override
     public boolean isDataPartitionConsumable(DataPartitionMeta partitionMeta) {
         return false;
+    }
+
+    @Override
+    public Map<String, DataPartitionFactory> partitionFactories() {
+        return null;
     }
 
     @Override

--- a/shuffle-storage/src/test/java/com/alibaba/flink/shuffle/storage/datastore/PartitionWritingViewImplTest.java
+++ b/shuffle-storage/src/test/java/com/alibaba/flink/shuffle/storage/datastore/PartitionWritingViewImplTest.java
@@ -81,7 +81,7 @@ public class PartitionWritingViewImplTest {
         DataPartitionWritingView writingView = new PartitionWritingViewImpl(partitionWriter);
 
         writingView.finish(noOpDataCommitListener);
-        writingView.regionFinished();
+        writingView.regionFinished(0);
     }
 
     @Test(expected = IllegalStateException.class)
@@ -89,7 +89,7 @@ public class PartitionWritingViewImplTest {
         DataPartitionWritingView writingView = new PartitionWritingViewImpl(partitionWriter);
 
         writingView.onError(new ShuffleException("Test exception."));
-        writingView.regionFinished();
+        writingView.regionFinished(0);
     }
 
     @Test(expected = IllegalStateException.class)
@@ -124,7 +124,7 @@ public class PartitionWritingViewImplTest {
         Buffer buffer = new Buffer(ByteBuffer.allocateDirect(1024), recycleBuffer::set, 1024);
         assertThrows(
                 IllegalStateException.class,
-                () -> writingView.onBuffer(buffer, new ReducePartitionID(0)));
+                () -> writingView.onBuffer(buffer, 0, new ReducePartitionID(0)));
 
         assertNotNull(recycleBuffer.get());
     }
@@ -138,7 +138,7 @@ public class PartitionWritingViewImplTest {
         Buffer buffer = new Buffer(ByteBuffer.allocateDirect(1024), recycleBuffer::set, 1024);
         assertThrows(
                 IllegalStateException.class,
-                () -> writingView.onBuffer(buffer, new ReducePartitionID(0)));
+                () -> writingView.onBuffer(buffer, 0, new ReducePartitionID(0)));
 
         assertNotNull(recycleBuffer.get());
     }
@@ -150,7 +150,7 @@ public class PartitionWritingViewImplTest {
         writingView.regionStarted(10, true);
 
         Buffer buffer = new Buffer(ByteBuffer.allocateDirect(1024), recycleBuffer::set, 1024);
-        assertThrows(IllegalArgumentException.class, () -> writingView.onBuffer(buffer, null));
+        assertThrows(IllegalArgumentException.class, () -> writingView.onBuffer(buffer, 0, null));
 
         assertNotNull(recycleBuffer.get());
     }
@@ -158,7 +158,7 @@ public class PartitionWritingViewImplTest {
     @Test(expected = IllegalArgumentException.class)
     public void testOnNullBuffer() {
         DataPartitionWritingView writingView = new PartitionWritingViewImpl(partitionWriter);
-        writingView.onBuffer(null, new ReducePartitionID(0));
+        writingView.onBuffer(null, 0, new ReducePartitionID(0));
     }
 
     @Test
@@ -167,7 +167,7 @@ public class PartitionWritingViewImplTest {
         DataPartitionWritingView writingView = new PartitionWritingViewImpl(partitionWriter);
 
         Buffer buffer = new Buffer(ByteBuffer.allocateDirect(1024), recycleBuffer::set, 1024);
-        assertThrows(IllegalStateException.class, () -> writingView.onBuffer(buffer, null));
+        assertThrows(IllegalStateException.class, () -> writingView.onBuffer(buffer, 0, null));
 
         assertNotNull(recycleBuffer.get());
     }
@@ -175,7 +175,7 @@ public class PartitionWritingViewImplTest {
     @Test(expected = IllegalStateException.class)
     public void testRegionFinishBeforeStart() {
         DataPartitionWritingView writingView = new PartitionWritingViewImpl(partitionWriter);
-        writingView.regionFinished();
+        writingView.regionFinished(0);
     }
 
     @Test(expected = IllegalStateException.class)

--- a/shuffle-storage/src/test/java/com/alibaba/flink/shuffle/storage/partition/HDDOnlyLocalFileReducePartitionFactoryTest.java
+++ b/shuffle-storage/src/test/java/com/alibaba/flink/shuffle/storage/partition/HDDOnlyLocalFileReducePartitionFactoryTest.java
@@ -1,0 +1,153 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.flink.shuffle.storage.partition;
+
+import com.alibaba.flink.shuffle.common.config.Configuration;
+import com.alibaba.flink.shuffle.common.exception.ConfigurationException;
+import com.alibaba.flink.shuffle.core.config.StorageOptions;
+import com.alibaba.flink.shuffle.core.storage.StorageMeta;
+import com.alibaba.flink.shuffle.core.storage.StorageType;
+import com.alibaba.flink.shuffle.storage.utils.StorageTestUtils;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import java.util.Properties;
+
+import static com.alibaba.flink.shuffle.storage.partition.LocalFileReducePartitionFactoryTest.assertExpectedStorageMeta;
+import static com.alibaba.flink.shuffle.storage.partition.LocalFileReducePartitionFactoryTest.expectedReducePartitionEvenDiskUsedCount;
+import static com.alibaba.flink.shuffle.storage.partition.LocalFileReducePartitionFactoryTest.updateStorageFreeSpace;
+import static com.alibaba.flink.shuffle.storage.partition.LocalFileReducePartitionFactoryTest.updateStorageHealthStatus;
+import static org.junit.Assert.assertEquals;
+
+/** Tests for {@link HDDOnlyLocalFileReducePartitionFactory}. */
+public class HDDOnlyLocalFileReducePartitionFactoryTest {
+
+    @Rule public final TemporaryFolder temporaryFolder1 = new TemporaryFolder();
+
+    @Rule public final TemporaryFolder temporaryFolder2 = new TemporaryFolder();
+
+    @Test(expected = ConfigurationException.class)
+    public void testWithoutValidHddDataDir() {
+        HDDOnlyLocalFileReducePartitionFactory partitionFactory =
+                new HDDOnlyLocalFileReducePartitionFactory();
+        Properties properties = new Properties();
+        properties.setProperty(
+                StorageOptions.STORAGE_LOCAL_DATA_DIRS.key(),
+                "[SSD]" + temporaryFolder1.getRoot().getAbsolutePath());
+        partitionFactory.initialize(new Configuration(properties));
+    }
+
+    @Test
+    public void testHDDOnly() {
+        HDDOnlyLocalFileReducePartitionFactory partitionFactory =
+                new HDDOnlyLocalFileReducePartitionFactory();
+        Properties properties = new Properties();
+        properties.setProperty(
+                StorageOptions.STORAGE_LOCAL_DATA_DIRS.key(),
+                String.format(
+                        "[SSD]%s,[HDD]%s",
+                        temporaryFolder1.getRoot().getAbsolutePath(),
+                        temporaryFolder2.getRoot().getAbsolutePath()));
+        partitionFactory.initialize(new Configuration(properties));
+        for (int i = 0; i < 100; ++i) {
+            StorageMeta storageMeta = partitionFactory.getNextDataStorageMeta();
+            assertEquals(
+                    StorageTestUtils.getStoragePath(temporaryFolder2),
+                    storageMeta.getStoragePath());
+            assertEquals(StorageType.HDD, storageMeta.getStorageType());
+        }
+    }
+
+    @Test
+    public void testUpdateFreeStorageSpace() {
+        LocalFileReducePartitionFactory partitionFactory =
+                new HDDOnlyLocalFileReducePartitionFactory();
+        LocalFileReducePartitionFactoryTest.FakeStorageMeta[] storageMetas =
+                LocalFileReducePartitionFactoryTest.addStorageMetas(partitionFactory);
+
+        assertEquals(0, partitionFactory.getStorageSpaceInfo().getHddMaxFreeSpaceBytes());
+        assertEquals(0, partitionFactory.getStorageSpaceInfo().getSsdMaxFreeSpaceBytes());
+
+        updateStorageFreeSpace(storageMetas, 4, partitionFactory);
+        assertEquals(0, partitionFactory.getStorageSpaceInfo().getSsdMaxFreeSpaceBytes());
+        assertEquals(8, partitionFactory.getStorageSpaceInfo().getHddMaxFreeSpaceBytes());
+
+        updateStorageFreeSpace(storageMetas, 0, partitionFactory);
+        assertEquals(0, partitionFactory.getStorageSpaceInfo().getSsdMaxFreeSpaceBytes());
+        assertEquals(4, partitionFactory.getStorageSpaceInfo().getHddMaxFreeSpaceBytes());
+    }
+
+    @Test
+    public void testUpdateFreeStorageSpaceWithUnhealthyStorage() {
+        LocalFileReducePartitionFactory partitionFactory =
+                new HDDOnlyLocalFileReducePartitionFactory();
+        LocalFileReducePartitionFactoryTest.FakeStorageMeta[] storageMetas =
+                LocalFileReducePartitionFactoryTest.addStorageMetas(partitionFactory);
+        updateStorageFreeSpace(storageMetas, 0, partitionFactory);
+
+        updateStorageHealthStatus(storageMetas, 2, 4, false, partitionFactory);
+        assertEquals(0, partitionFactory.getStorageSpaceInfo().getSsdMaxFreeSpaceBytes());
+        assertEquals(2, partitionFactory.getStorageSpaceInfo().getHddMaxFreeSpaceBytes());
+
+        updateStorageHealthStatus(storageMetas, 0, 2, false, partitionFactory);
+        assertEquals(0, partitionFactory.getStorageSpaceInfo().getSsdMaxFreeSpaceBytes());
+        assertEquals(0, partitionFactory.getStorageSpaceInfo().getHddMaxFreeSpaceBytes());
+
+        updateStorageHealthStatus(storageMetas, 2, 4, true, partitionFactory);
+        assertEquals(0, partitionFactory.getStorageSpaceInfo().getSsdMaxFreeSpaceBytes());
+        assertEquals(4, partitionFactory.getStorageSpaceInfo().getHddMaxFreeSpaceBytes());
+    }
+
+    @Test
+    public void testGetNextStorageMetaWithUnhealthyStorage() {
+        LocalFileReducePartitionFactory partitionFactory =
+                new HDDOnlyLocalFileReducePartitionFactory();
+        LocalFileReducePartitionFactoryTest.FakeStorageMeta[] storageMetas =
+                LocalFileReducePartitionFactoryTest.addStorageMetas(partitionFactory);
+        updateStorageFreeSpace(storageMetas, 0, partitionFactory);
+
+        updateStorageHealthStatus(storageMetas, 2, 4, false, partitionFactory);
+        assertExpectedStorageMeta(partitionFactory, storageMetas[1]);
+
+        updateStorageHealthStatus(storageMetas, 0, 2, false, partitionFactory);
+        assertExpectedStorageMeta(partitionFactory, null);
+
+        updateStorageHealthStatus(storageMetas, 2, 4, true, partitionFactory);
+        assertExpectedStorageMeta(partitionFactory, storageMetas[3]);
+    }
+
+    @Test
+    public void testAllDisksWillBeUsed() {
+        HDDOnlyLocalFileReducePartitionFactory partitionFactory =
+                new HDDOnlyLocalFileReducePartitionFactory();
+        Properties properties = new Properties();
+        properties.setProperty(
+                StorageOptions.STORAGE_LOCAL_DATA_DIRS.key(),
+                String.format(
+                        "[HDD]%s,[HDD]%s",
+                        temporaryFolder1.getRoot().getAbsolutePath(),
+                        temporaryFolder2.getRoot().getAbsolutePath()));
+        partitionFactory.initialize(new Configuration(properties));
+
+        expectedReducePartitionEvenDiskUsedCount(
+                partitionFactory, temporaryFolder1, temporaryFolder2, StorageType.HDD);
+    }
+}

--- a/shuffle-storage/src/test/java/com/alibaba/flink/shuffle/storage/partition/LocalFileReducePartitionTest.java
+++ b/shuffle-storage/src/test/java/com/alibaba/flink/shuffle/storage/partition/LocalFileReducePartitionTest.java
@@ -1,11 +1,13 @@
 /*
- * Copyright 2021 The Flink Remote Shuffle Project
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *  	http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -18,6 +20,7 @@ package com.alibaba.flink.shuffle.storage.partition;
 
 import com.alibaba.flink.shuffle.common.exception.ShuffleException;
 import com.alibaba.flink.shuffle.common.utils.CommonUtils;
+import com.alibaba.flink.shuffle.core.ids.MapPartitionID;
 import com.alibaba.flink.shuffle.core.ids.ReducePartitionID;
 import com.alibaba.flink.shuffle.core.listener.FailureListener;
 import com.alibaba.flink.shuffle.core.memory.Buffer;
@@ -27,7 +30,6 @@ import com.alibaba.flink.shuffle.core.storage.DataPartitionWriter;
 import com.alibaba.flink.shuffle.core.storage.StorageMeta;
 import com.alibaba.flink.shuffle.core.storage.StorageType;
 import com.alibaba.flink.shuffle.core.utils.BufferUtils;
-import com.alibaba.flink.shuffle.storage.exception.ConcurrentWriteException;
 import com.alibaba.flink.shuffle.storage.utils.StorageTestUtils;
 import com.alibaba.flink.shuffle.storage.utils.TestDataCommitListener;
 import com.alibaba.flink.shuffle.storage.utils.TestDataRegionCreditListener;
@@ -47,31 +49,29 @@ import java.util.concurrent.TimeUnit;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
 
-/** Tests for {@link LocalFileMapPartition}. */
-public class LocalFileMapPartitionTest {
-
+/** Tests for {@link LocalFileReducePartition}. */
+public class LocalFileReducePartitionTest {
     @Rule public Timeout timeout = new Timeout(60, TimeUnit.SECONDS);
 
     @Rule public final TemporaryFolder temporaryFolder = new TemporaryFolder();
 
     @Test
     public void testWriteAndReadPartition() throws Exception {
-        LocalFileMapPartition dataPartition = createLocalFileMapPartition();
+        LocalFileReducePartition dataPartition = createLocalFileReducePartition();
 
-        int buffersWritten = writeLocalFileMapPartition(dataPartition, 10, false, true);
-        int buffersRead = readLocalFileMapPartition(dataPartition, false);
+        int buffersWritten = writeLocalFileReducePartition(dataPartition, 10, false, true);
+        int buffersRead = readLocalFileReducePartition(dataPartition, false);
 
         assertEquals(buffersWritten, buffersRead);
     }
 
     @Test
     public void testWriteAndReadEmptyPartition() throws Exception {
-        LocalFileMapPartition dataPartition = createLocalFileMapPartition();
+        LocalFileReducePartition dataPartition = createLocalFileReducePartition();
 
-        int buffersWritten = writeLocalFileMapPartition(dataPartition, 0, false, true);
-        int buffersRead = readLocalFileMapPartition(dataPartition, false);
+        int buffersWritten = writeLocalFileReducePartition(dataPartition, 0, false, true);
+        int buffersRead = readLocalFileReducePartition(dataPartition, false);
 
         assertEquals(0, buffersRead);
         assertEquals(0, buffersWritten);
@@ -81,13 +81,13 @@ public class LocalFileMapPartitionTest {
     public void testReleaseWhileWriting() throws Exception {
         CountDownLatch latch = new CountDownLatch(1);
 
-        LocalFileMapPartition dataPartition = createLocalFileMapPartition();
+        LocalFileReducePartition dataPartition = createLocalFileReducePartition();
         Thread writingThread =
                 new Thread(
                         () -> {
                             CommonUtils.runQuietly(
                                     () ->
-                                            writeLocalFileMapPartition(
+                                            writeLocalFileReducePartition(
                                                     dataPartition, 10, false, true));
                             latch.countDown();
                         });
@@ -104,14 +104,14 @@ public class LocalFileMapPartitionTest {
     @Test
     public void testReleaseWhileReading() throws Exception {
         CountDownLatch latch = new CountDownLatch(1);
-        LocalFileMapPartition dataPartition = createLocalFileMapPartition();
+        LocalFileReducePartition dataPartition = createLocalFileReducePartition();
 
-        writeLocalFileMapPartition(dataPartition, 10, false, true);
+        writeLocalFileReducePartition(dataPartition, 10, false, true);
         Thread readingThread =
                 new Thread(
                         () -> {
                             CommonUtils.runQuietly(
-                                    () -> readLocalFileMapPartition(dataPartition, false));
+                                    () -> readLocalFileReducePartition(dataPartition, false));
                             latch.countDown();
                         });
         readingThread.start();
@@ -126,27 +126,27 @@ public class LocalFileMapPartitionTest {
 
     @Test
     public void testOnErrorWhileWriting() throws Exception {
-        LocalFileMapPartition dataPartition = createLocalFileMapPartition();
-        writeLocalFileMapPartition(dataPartition, 10, true, true);
+        LocalFileReducePartition dataPartition = createLocalFileReducePartition();
+        writeLocalFileReducePartition(dataPartition, 10, true, true);
 
         StorageTestUtils.assertNoBufferLeaking();
     }
 
     @Test
     public void testOnErrorWhileReading() throws Exception {
-        LocalFileMapPartition dataPartition = createLocalFileMapPartition();
+        LocalFileReducePartition dataPartition = createLocalFileReducePartition();
 
-        writeLocalFileMapPartition(dataPartition, 10, false, true);
-        readLocalFileMapPartition(dataPartition, true);
+        writeLocalFileReducePartition(dataPartition, 10, false, true);
+        readLocalFileReducePartition(dataPartition, true);
 
         StorageTestUtils.assertNoBufferLeaking();
     }
 
     @Test
     public void testIsConsumableOfReleasedPartition() throws Exception {
-        LocalFileMapPartition dataPartition = createLocalFileMapPartition();
+        LocalFileReducePartition dataPartition = createLocalFileReducePartition();
 
-        writeLocalFileMapPartition(dataPartition, 10, false, true);
+        writeLocalFileReducePartition(dataPartition, 10, false, true);
         dataPartition.releasePartition(new ShuffleException("Test exception.")).get();
         assertFalse(dataPartition.isConsumable());
         StorageTestUtils.assertNoBufferLeaking();
@@ -154,11 +154,11 @@ public class LocalFileMapPartitionTest {
 
     @Test
     public void testIsConsumableOfUnfinishedPartition() throws Exception {
-        LocalFileMapPartition dataPartition = createLocalFileMapPartition();
+        LocalFileReducePartition dataPartition = createLocalFileReducePartition();
 
         DataPartitionWriter partitionWriter =
                 dataPartition.createPartitionWriter(
-                        dataPartition.getPartitionMeta().getDataPartitionID(),
+                        StorageTestUtils.MAP_PARTITION_ID,
                         StorageTestUtils.NO_OP_CREDIT_LISTENER,
                         StorageTestUtils.NO_OP_FAILURE_LISTENER);
         partitionWriter.startRegion(10, false);
@@ -172,13 +172,13 @@ public class LocalFileMapPartitionTest {
     public void testWritePartitionFileError() throws Exception {
         CountDownLatch latch = new CountDownLatch(1);
 
-        LocalFileMapPartition dataPartition = createLocalFileMapPartition();
+        LocalFileReducePartition dataPartition = createLocalFileReducePartition();
         Thread writingThread =
                 new Thread(
                         () -> {
                             CommonUtils.runQuietly(
                                     () ->
-                                            writeLocalFileMapPartition(
+                                            writeLocalFileReducePartition(
                                                     dataPartition, 10, false, false));
                             latch.countDown();
                         });
@@ -196,14 +196,14 @@ public class LocalFileMapPartitionTest {
     @Test
     public void testReadPartitionFileError() throws Exception {
         CountDownLatch latch = new CountDownLatch(1);
-        LocalFileMapPartition dataPartition = createLocalFileMapPartition();
+        LocalFileReducePartition dataPartition = createLocalFileReducePartition();
 
-        writeLocalFileMapPartition(dataPartition, 10, false, true);
+        writeLocalFileReducePartition(dataPartition, 10, false, true);
         Thread readingThread =
                 new Thread(
                         () -> {
                             CommonUtils.runQuietly(
-                                    () -> readLocalFileMapPartition(dataPartition, false), true);
+                                    () -> readLocalFileReducePartition(dataPartition, false), true);
                             latch.countDown();
                         });
         readingThread.start();
@@ -218,23 +218,12 @@ public class LocalFileMapPartitionTest {
     }
 
     @Test
-    public void testWritePartitionMultipleTimes() throws Exception {
-        LocalFileMapPartition dataPartition = createLocalFileMapPartition();
-
-        writeLocalFileMapPartition(dataPartition, 0, false, true);
-        TestFailureListener failureListener = new TestFailureListener();
-        CommonUtils.runQuietly(
-                () -> writeLocalFileMapPartition(dataPartition, 0, false, false, failureListener));
-        assertTrue(failureListener.getFailure().getCause() instanceof ConcurrentWriteException);
-    }
-
-    @Test
     public void testDeletePartitionIndexFile() throws Exception {
-        LocalFileMapPartition dataPartition = createLocalFileMapPartition();
-        writeLocalFileMapPartition(dataPartition, 10, false, true);
+        LocalFileReducePartition dataPartition = createLocalFileReducePartition();
+        writeLocalFileReducePartition(dataPartition, 10, false, true);
 
         for (File file : CommonUtils.checkNotNull(temporaryFolder.getRoot().listFiles())) {
-            if (file.getPath().contains(LocalMapPartitionFile.INDEX_FILE_SUFFIX)) {
+            if (file.getPath().contains(LocalReducePartitionFile.INDEX_FILE_SUFFIX)) {
                 Files.delete(file.toPath());
             }
         }
@@ -243,35 +232,35 @@ public class LocalFileMapPartitionTest {
 
     @Test
     public void testDeletePartitionDataFile() throws Exception {
-        LocalFileMapPartition dataPartition = createLocalFileMapPartition();
-        writeLocalFileMapPartition(dataPartition, 10, false, true);
+        LocalFileReducePartition dataPartition = createLocalFileReducePartition();
+        writeLocalFileReducePartition(dataPartition, 10, false, true);
 
         for (File file : CommonUtils.checkNotNull(temporaryFolder.getRoot().listFiles())) {
-            if (file.getPath().contains(LocalMapPartitionFile.DATA_FILE_SUFFIX)) {
+            if (file.getPath().contains(LocalReducePartitionFile.DATA_FILE_SUFFIX)) {
                 Files.delete(file.toPath());
             }
         }
         assertFalse(dataPartition.isConsumable());
     }
 
-    private LocalFileMapPartition createLocalFileMapPartition() {
+    private LocalFileReducePartition createLocalFileReducePartition() {
         String storagePath = temporaryFolder.getRoot().getAbsolutePath() + "/";
-        return new LocalFileMapPartition(
+        return new LocalFileReducePartition(
                 new StorageMeta(storagePath, StorageType.SSD, storagePath),
                 StorageTestUtils.NO_OP_PARTITIONED_DATA_STORE,
                 StorageTestUtils.JOB_ID,
                 StorageTestUtils.DATA_SET_ID,
-                StorageTestUtils.MAP_PARTITION_ID,
+                StorageTestUtils.REDUCE_PARTITION_ID,
                 StorageTestUtils.NUM_REDUCE_PARTITIONS);
     }
 
-    private int writeLocalFileMapPartition(
-            LocalFileMapPartition dataPartition,
+    private int writeLocalFileReducePartition(
+            LocalFileReducePartition dataPartition,
             int numRegions,
             boolean isError,
             boolean waitDataCommission)
             throws Exception {
-        return writeLocalFileMapPartition(
+        return writeLocalFileReducePartition(
                 dataPartition,
                 numRegions,
                 isError,
@@ -279,8 +268,8 @@ public class LocalFileMapPartitionTest {
                 StorageTestUtils.NO_OP_FAILURE_LISTENER);
     }
 
-    private int writeLocalFileMapPartition(
-            LocalFileMapPartition dataPartition,
+    private int writeLocalFileReducePartition(
+            LocalFileReducePartition dataPartition,
             int numRegions,
             boolean isError,
             boolean waitDataCommission,
@@ -289,35 +278,47 @@ public class LocalFileMapPartitionTest {
         TestDataRegionCreditListener creditListener = new TestDataRegionCreditListener();
         DataPartitionWriter partitionWriter =
                 dataPartition.createPartitionWriter(
-                        dataPartition.getPartitionMeta().getDataPartitionID(),
-                        creditListener,
-                        failureListener);
+                        StorageTestUtils.MAP_PARTITION_ID, creditListener, failureListener);
 
         int buffersWritten = 0;
         int numBuffers = 100;
 
-        for (int regionIndex = 0; regionIndex < numRegions; ++regionIndex) {
-            partitionWriter.startRegion(regionIndex, false);
-            for (int reduceIndex = 0;
-                    reduceIndex < StorageTestUtils.NUM_REDUCE_PARTITIONS;
-                    ++reduceIndex) {
-                for (int bufferIndex = 0; bufferIndex < numBuffers; ++bufferIndex) {
-                    Buffer buffer;
-                    while ((buffer = partitionWriter.pollBuffer()) == null) {
-                        creditListener.take(100, regionIndex);
-                    }
+        if (numRegions == 0) {
+            partitionWriter.startRegion(0, 1, numBuffers, false);
+            partitionWriter.finishRegion(0);
+            partitionWriter.finishDataInput(new TestDataCommitListener());
+            return buffersWritten;
+        }
 
-                    buffer.writeBytes(StorageTestUtils.DATA_BYTES);
-                    partitionWriter.addBuffer(new ReducePartitionID(reduceIndex), 0, buffer);
-                    ++buffersWritten;
+        for (int regionIndex = 0; regionIndex < numRegions; regionIndex++) {
+            partitionWriter.startRegion(
+                    regionIndex, StorageTestUtils.NUM_MAP_PARTITIONS, numBuffers, false);
+            for (int bufferIndex = 0; bufferIndex < numBuffers; ++bufferIndex) {
+                Buffer buffer;
+                while ((buffer = partitionWriter.pollBuffer()) == null) {
+                    creditListener.take(100, 0);
                 }
 
-                if (isError) {
-                    partitionWriter.onError(new ShuffleException("Test exception."));
-                    return buffersWritten;
-                }
+                buffer.writeBytes(StorageTestUtils.DATA_BYTES);
+                partitionWriter.addBuffer(new ReducePartitionID(0), 0, buffer);
+                ++buffersWritten;
+            }
+
+            if (isError) {
+                partitionWriter.onError(new ShuffleException("Test exception."));
+                return buffersWritten;
             }
             partitionWriter.finishRegion(regionIndex);
+        }
+
+        for (int i = 0; i < StorageTestUtils.NUM_MAP_PARTITIONS - 1; i++) {
+            MapPartitionID mapPartitionID = new MapPartitionID(CommonUtils.randomBytes(16));
+            DataPartitionWriter writer =
+                    dataPartition.createPartitionWriter(
+                            mapPartitionID, creditListener, failureListener);
+            writer.startRegion(0, StorageTestUtils.NUM_MAP_PARTITIONS, 1, false);
+            writer.finishRegion(0);
+            writer.finishDataInput(new TestDataCommitListener());
         }
 
         TestDataCommitListener commitListener = new TestDataCommitListener();
@@ -328,27 +329,23 @@ public class LocalFileMapPartitionTest {
         return buffersWritten;
     }
 
-    public int readLocalFileMapPartition(LocalFileMapPartition dataPartition, boolean isError)
+    public int readLocalFileReducePartition(LocalFileReducePartition dataPartition, boolean isError)
             throws Exception {
         ConcurrentHashMap<DataPartitionReader, TestFailureListener> readers =
                 new ConcurrentHashMap<>();
-        for (int reduceIndex = 0;
-                reduceIndex < StorageTestUtils.NUM_REDUCE_PARTITIONS;
-                ++reduceIndex) {
-            TestFailureListener failureListener = new TestFailureListener();
-            final int finalReduceIndex = reduceIndex;
-            CommonUtils.runQuietly(
-                    () -> {
-                        DataPartitionReader reader =
-                                dataPartition.createPartitionReader(
-                                        finalReduceIndex,
-                                        finalReduceIndex,
-                                        StorageTestUtils.NO_OP_DATA_LISTENER,
-                                        StorageTestUtils.NO_OP_BACKLOG_LISTENER,
-                                        failureListener);
-                        readers.put(reader, failureListener);
-                    });
-        }
+        TestFailureListener failureListener = new TestFailureListener();
+        final int reduceIndex = 0;
+        CommonUtils.runQuietly(
+                () -> {
+                    DataPartitionReader reader =
+                            dataPartition.createPartitionReader(
+                                    reduceIndex,
+                                    reduceIndex,
+                                    StorageTestUtils.NO_OP_DATA_LISTENER,
+                                    StorageTestUtils.NO_OP_BACKLOG_LISTENER,
+                                    failureListener);
+                    readers.put(reader, failureListener);
+                });
 
         int buffersRead = 0;
         while (!readers.isEmpty()) {

--- a/shuffle-storage/src/test/java/com/alibaba/flink/shuffle/storage/partition/LocalReducePartitionFileMetaTest.java
+++ b/shuffle-storage/src/test/java/com/alibaba/flink/shuffle/storage/partition/LocalReducePartitionFileMetaTest.java
@@ -1,0 +1,72 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.flink.shuffle.storage.partition;
+
+import com.alibaba.flink.shuffle.storage.utils.StorageTestUtils;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import java.io.DataInputStream;
+import java.io.DataOutputStream;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
+
+/** Tests for {@link LocalReducePartitionFileMeta}. */
+public class LocalReducePartitionFileMetaTest {
+
+    @Rule public final TemporaryFolder temporaryFolder = new TemporaryFolder();
+
+    @Test
+    public void testSerializeAndDeserialize() throws Exception {
+        LocalReducePartitionFileMeta fileMeta =
+                StorageTestUtils.createLocalReducePartitionFileMeta();
+
+        File tmpFile = temporaryFolder.newFile();
+        try (DataOutputStream output = new DataOutputStream(new FileOutputStream(tmpFile))) {
+            fileMeta.writeTo(output);
+        }
+
+        LocalReducePartitionFileMeta recovered;
+        try (DataInputStream input = new DataInputStream(new FileInputStream(tmpFile))) {
+            recovered = LocalReducePartitionFileMeta.readFrom(input);
+        }
+
+        assertEquals(fileMeta, recovered);
+    }
+
+    @Test
+    public void testIllegalArgument() {
+        assertThrows(
+                IllegalArgumentException.class,
+                () ->
+                        new LocalReducePartitionFileMeta(
+                                null, 10, LocalMapPartitionFile.LATEST_STORAGE_VERSION));
+        assertThrows(
+                IllegalArgumentException.class,
+                () ->
+                        new LocalReducePartitionFileMeta(
+                                "/tmp/test", 0, LocalMapPartitionFile.LATEST_STORAGE_VERSION));
+    }
+}

--- a/shuffle-storage/src/test/java/com/alibaba/flink/shuffle/storage/partition/LocalReducePartitionFileReaderTest.java
+++ b/shuffle-storage/src/test/java/com/alibaba/flink/shuffle/storage/partition/LocalReducePartitionFileReaderTest.java
@@ -1,0 +1,308 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.flink.shuffle.storage.partition;
+
+import com.alibaba.flink.shuffle.common.utils.CommonUtils;
+import com.alibaba.flink.shuffle.storage.exception.FileCorruptedException;
+import com.alibaba.flink.shuffle.storage.utils.StorageTestUtils;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import java.io.File;
+import java.nio.ByteBuffer;
+import java.nio.channels.FileChannel;
+import java.nio.file.StandardOpenOption;
+import java.util.ArrayDeque;
+import java.util.Queue;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertThrows;
+
+/** Tests for {@link LocalReducePartitionFileReader}. */
+@RunWith(Parameterized.class)
+public class LocalReducePartitionFileReaderTest {
+
+    @Rule public final TemporaryFolder temporaryFolder = new TemporaryFolder();
+
+    private final boolean dataChecksumEnabled;
+
+    @Parameterized.Parameters
+    public static Object[] data() {
+        return new Boolean[] {true, false};
+    }
+
+    public LocalReducePartitionFileReaderTest(boolean dataChecksumEnabled) {
+        this.dataChecksumEnabled = dataChecksumEnabled;
+    }
+
+    @Test
+    public void testReadData() throws Exception {
+        int numRegions = 10;
+        int numBuffers = 100;
+        LocalReducePartitionFile partitionFile = createPartitionFile();
+        StorageTestUtils.writeLocalReducePartitionFile(
+                partitionFile,
+                numRegions,
+                StorageTestUtils.NUM_MAP_PARTITIONS,
+                numBuffers,
+                false,
+                dataChecksumEnabled);
+
+        int buffersRead = readData(partitionFile, 1);
+        assertEquals(numRegions * numBuffers * StorageTestUtils.NUM_MAP_PARTITIONS, buffersRead);
+        assertNull(partitionFile.getIndexReadingChannel());
+        assertNull(partitionFile.getDataReadingChannel());
+    }
+
+    @Test
+    public void testReadEmptyData() throws Exception {
+        LocalReducePartitionFile partitionFile = createPartitionFile();
+        StorageTestUtils.writeLocalReducePartitionFile(
+                partitionFile, 1, 1, 1, false, dataChecksumEnabled);
+
+        LocalReducePartitionFileReader fileReader =
+                new LocalReducePartitionFileReader(dataChecksumEnabled, 0, 0, partitionFile);
+        assertFalse(fileReader.hasRemaining());
+        fileReader.finishReading();
+    }
+
+    @Test
+    public void testReadWithEmptyReducePartitions() throws Exception {
+        int numRegions = 10;
+        int numBuffers = 100;
+        LocalReducePartitionFile partitionFile = createPartitionFile();
+        StorageTestUtils.writeLocalReducePartitionFile(
+                partitionFile,
+                numRegions,
+                StorageTestUtils.NUM_MAP_PARTITIONS,
+                numBuffers,
+                true,
+                dataChecksumEnabled);
+
+        int buffersRead = readData(partitionFile, 1);
+        assertEquals(
+                numRegions * numBuffers * StorageTestUtils.NUM_MAP_PARTITIONS / 2, buffersRead);
+        assertNull(partitionFile.getIndexReadingChannel());
+        assertNull(partitionFile.getDataReadingChannel());
+    }
+
+    @Test
+    public void testReadMultipleReducePartitions() throws Exception {
+        int numRegions = 10;
+        int numBuffers = 100;
+        LocalReducePartitionFile partitionFile = createPartitionFile();
+        StorageTestUtils.writeLocalReducePartitionFile(
+                partitionFile,
+                numRegions,
+                StorageTestUtils.NUM_MAP_PARTITIONS,
+                numBuffers,
+                false,
+                dataChecksumEnabled);
+
+        int buffersRead = readData(partitionFile, 3);
+        assertEquals(numRegions * numBuffers * StorageTestUtils.NUM_MAP_PARTITIONS, buffersRead);
+        assertNull(partitionFile.getIndexReadingChannel());
+        assertNull(partitionFile.getDataReadingChannel());
+    }
+
+    @Test
+    public void testReadMultipleReducePartitionsWithBroadcastRegion() throws Exception {
+        int numRegions = 10;
+        int numBuffers = 100;
+        LocalReducePartitionFile partitionFile = createPartitionFile();
+        StorageTestUtils.writeLocalReducePartitionFile(
+                partitionFile,
+                numRegions,
+                StorageTestUtils.NUM_MAP_PARTITIONS,
+                numBuffers,
+                false,
+                dataChecksumEnabled);
+
+        int buffersRead = readData(partitionFile, 3);
+        assertEquals(numRegions * numBuffers * StorageTestUtils.NUM_MAP_PARTITIONS, buffersRead);
+        assertNull(partitionFile.getIndexReadingChannel());
+        assertNull(partitionFile.getDataReadingChannel());
+    }
+
+    @Test
+    public void testReadWithBroadcastRegion() throws Exception {
+        int numRegions = 10;
+        int numBuffers = 100;
+        LocalReducePartitionFile partitionFile = createPartitionFile();
+        StorageTestUtils.writeLocalReducePartitionFile(
+                partitionFile,
+                numRegions,
+                StorageTestUtils.NUM_MAP_PARTITIONS,
+                numBuffers,
+                false,
+                dataChecksumEnabled);
+
+        int buffersRead = readData(partitionFile, 1);
+        assertEquals(numRegions * numBuffers * StorageTestUtils.NUM_MAP_PARTITIONS, buffersRead);
+        assertNull(partitionFile.getIndexReadingChannel());
+        assertNull(partitionFile.getDataReadingChannel());
+    }
+
+    @Test
+    public void testReadMultipleReducePartitionsWithEmptyOnes() throws Exception {
+        int numRegions = 10;
+        int numBuffers = 100;
+        LocalReducePartitionFile partitionFile = createPartitionFile();
+        StorageTestUtils.writeLocalReducePartitionFile(
+                partitionFile,
+                numRegions,
+                StorageTestUtils.NUM_MAP_PARTITIONS,
+                numBuffers,
+                true,
+                dataChecksumEnabled);
+
+        int buffersRead = readData(partitionFile, 3);
+        assertEquals(
+                numRegions * numBuffers * StorageTestUtils.NUM_MAP_PARTITIONS / 2, buffersRead);
+        assertNull(partitionFile.getIndexReadingChannel());
+        assertNull(partitionFile.getDataReadingChannel());
+    }
+
+    @Test
+    public void testIndexFileCorruptedWithIncompleteRegion() throws Exception {
+        LocalReducePartitionFile partitionFile = createPartitionFile();
+        StorageTestUtils.writeLocalReducePartitionFile(
+                partitionFile,
+                10,
+                StorageTestUtils.NUM_MAP_PARTITIONS,
+                10,
+                false,
+                dataChecksumEnabled);
+
+        for (File file : CommonUtils.checkNotNull(temporaryFolder.getRoot().listFiles())) {
+            if (file.getPath().contains(LocalReducePartitionFile.INDEX_FILE_SUFFIX)) {
+                try (FileChannel fileChannel =
+                        FileChannel.open(file.toPath(), StandardOpenOption.WRITE)) {
+                    fileChannel.truncate(10);
+                }
+            }
+        }
+
+        LocalReducePartitionFileReader fileReader =
+                new LocalReducePartitionFileReader(dataChecksumEnabled, 0, 0, partitionFile);
+        assertThrows(FileCorruptedException.class, fileReader::open);
+        assertFalse(partitionFile.isConsumable());
+        assertEquals(0, CommonUtils.checkNotNull(temporaryFolder.getRoot().list()).length);
+    }
+
+    @Test
+    public void testIndexFileCorruptedWithWrongChecksum() throws Exception {
+        LocalReducePartitionFile partitionFile = createPartitionFile();
+        StorageTestUtils.writeLocalReducePartitionFile(
+                partitionFile,
+                10,
+                StorageTestUtils.NUM_MAP_PARTITIONS,
+                10,
+                false,
+                dataChecksumEnabled);
+
+        for (File file : CommonUtils.checkNotNull(temporaryFolder.getRoot().listFiles())) {
+            if (file.getPath().contains(LocalReducePartitionFile.INDEX_FILE_SUFFIX)) {
+                try (FileChannel fileChannel =
+                        FileChannel.open(file.toPath(), StandardOpenOption.WRITE)) {
+                    fileChannel.truncate(LocalReducePartitionFile.INDEX_ENTRY_SIZE);
+                }
+            }
+        }
+
+        LocalReducePartitionFileReader fileReader =
+                new LocalReducePartitionFileReader(dataChecksumEnabled, 0, 0, partitionFile);
+        assertThrows(FileCorruptedException.class, fileReader::open);
+        assertFalse(partitionFile.isConsumable());
+        assertEquals(0, CommonUtils.checkNotNull(temporaryFolder.getRoot().list()).length);
+    }
+
+    @Test
+    public void testDataFileCorrupted() throws Exception {
+        LocalReducePartitionFile partitionFile = createPartitionFile();
+        StorageTestUtils.writeLocalReducePartitionFile(
+                partitionFile,
+                10,
+                StorageTestUtils.NUM_MAP_PARTITIONS,
+                10,
+                false,
+                dataChecksumEnabled);
+
+        for (File file : CommonUtils.checkNotNull(temporaryFolder.getRoot().listFiles())) {
+            if (file.getPath().contains(LocalReducePartitionFile.DATA_FILE_SUFFIX)) {
+                try (FileChannel fileChannel =
+                        FileChannel.open(file.toPath(), StandardOpenOption.WRITE)) {
+                    fileChannel.truncate(10);
+                }
+            }
+        }
+
+        LocalReducePartitionFileReader fileReader =
+                new LocalReducePartitionFileReader(dataChecksumEnabled, 0, 0, partitionFile);
+        assertThrows(FileCorruptedException.class, fileReader::open);
+        assertFalse(partitionFile.isConsumable());
+        assertEquals(0, CommonUtils.checkNotNull(temporaryFolder.getRoot().list()).length);
+    }
+
+    private LocalReducePartitionFile createPartitionFile() {
+        return StorageTestUtils.createLocalReducePartitionFile(
+                temporaryFolder.getRoot().getAbsolutePath());
+    }
+
+    private int readData(LocalReducePartitionFile partitionFile, int numPartitions)
+            throws Exception {
+        Queue<LocalReducePartitionFileReader> fileReaders = new ArrayDeque<>();
+        for (int partitionIndex = 0; partitionIndex < 1; ) {
+            LocalReducePartitionFileReader fileReader =
+                    new LocalReducePartitionFileReader(
+                            dataChecksumEnabled,
+                            partitionIndex,
+                            Math.min(partitionIndex + numPartitions - 1, 0),
+                            partitionFile);
+            fileReader.open();
+            fileReaders.add(fileReader);
+            partitionIndex += numPartitions;
+        }
+
+        int buffersRead = 0;
+        ByteBuffer buffer = ByteBuffer.allocate(StorageTestUtils.DATA_BUFFER_SIZE);
+        while (!fileReaders.isEmpty()) {
+            LocalReducePartitionFileReader fileReader = fileReaders.poll();
+            if (!fileReader.hasRemaining()) {
+                fileReader.finishReading();
+                continue;
+            }
+            fileReaders.add(fileReader);
+
+            buffer.clear();
+            fileReader.readBuffer(buffer);
+
+            ++buffersRead;
+            assertEquals(
+                    ByteBuffer.wrap(StorageTestUtils.DATA_BYTES).position(), buffer.position());
+        }
+        return buffersRead;
+    }
+}

--- a/shuffle-storage/src/test/java/com/alibaba/flink/shuffle/storage/partition/LocalReducePartitionFileTest.java
+++ b/shuffle-storage/src/test/java/com/alibaba/flink/shuffle/storage/partition/LocalReducePartitionFileTest.java
@@ -1,0 +1,164 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.flink.shuffle.storage.partition;
+
+import com.alibaba.flink.shuffle.common.utils.CommonUtils;
+import com.alibaba.flink.shuffle.storage.exception.FileCorruptedException;
+import com.alibaba.flink.shuffle.storage.utils.StorageTestUtils;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import java.io.IOException;
+import java.nio.channels.ClosedChannelException;
+import java.nio.channels.FileChannel;
+import java.nio.file.Files;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+/** Tests for {@link LocalReducePartitionFile}. */
+@RunWith(Parameterized.class)
+public class LocalReducePartitionFileTest {
+    @Rule public final TemporaryFolder temporaryFolder = new TemporaryFolder();
+
+    private final boolean dataChecksumEnabled;
+
+    @Parameterized.Parameters
+    public static Object[] data() {
+        return new Boolean[] {true, false};
+    }
+
+    public LocalReducePartitionFileTest(boolean dataChecksumEnabled) {
+        this.dataChecksumEnabled = dataChecksumEnabled;
+    }
+
+    @Test
+    public void testConsumable() throws Exception {
+        LocalReducePartitionFile partitionFile1 = createPartitionFile();
+        assertTrue(partitionFile1.isConsumable());
+        Files.delete(partitionFile1.getFileMeta().getDataFilePath());
+        assertFalse(partitionFile1.isConsumable());
+        partitionFile1.deleteFile();
+
+        LocalReducePartitionFile partitionFile2 = createPartitionFile();
+        assertTrue(partitionFile2.isConsumable());
+        Files.delete(partitionFile2.getFileMeta().getIndexFilePath());
+        assertFalse(partitionFile2.isConsumable());
+        partitionFile2.deleteFile();
+
+        LocalReducePartitionFile partitionFile3 = createPartitionFile();
+        assertTrue(partitionFile3.isConsumable());
+        partitionFile3.setConsumable(false);
+        assertFalse(partitionFile3.isConsumable());
+        assertEquals(0, CommonUtils.checkNotNull(temporaryFolder.getRoot().list()).length);
+    }
+
+    @Test
+    public void testOpenAndCloseFile() throws Exception {
+        LocalReducePartitionFile partitionFile = createPartitionFile();
+
+        Object reader1 = new Object();
+        partitionFile.openFile(reader1);
+
+        FileChannel dataChannel = CommonUtils.checkNotNull(partitionFile.getDataReadingChannel());
+        FileChannel indexChannel = CommonUtils.checkNotNull(partitionFile.getIndexReadingChannel());
+        assertTrue(dataChannel.isOpen());
+        assertTrue(indexChannel.isOpen());
+
+        Object reader2 = new Object();
+        partitionFile.openFile(reader2);
+
+        assertTrue(dataChannel.isOpen());
+        assertTrue(indexChannel.isOpen());
+
+        partitionFile.closeFile(reader1);
+
+        assertTrue(dataChannel.isOpen());
+        assertTrue(indexChannel.isOpen());
+
+        partitionFile.closeFile(reader2);
+
+        assertFalse(dataChannel.isOpen());
+        assertFalse(indexChannel.isOpen());
+        assertNull(partitionFile.getDataReadingChannel());
+        assertNull(partitionFile.getIndexReadingChannel());
+    }
+
+    @Test
+    public void testDeleteFile() throws Exception {
+        LocalReducePartitionFile partitionFile = createPartitionFile();
+
+        Object reader = new Object();
+        partitionFile.openFile(reader);
+
+        partitionFile.deleteFile();
+
+        assertNull(partitionFile.getDataReadingChannel());
+        assertNull(partitionFile.getIndexReadingChannel());
+        assertEquals(0, CommonUtils.checkNotNull(temporaryFolder.getRoot().list()).length);
+    }
+
+    @Test
+    public void testOnError() throws Exception {
+        LocalReducePartitionFile partitionFile1 = createPartitionFile();
+        partitionFile1.onError(new Exception("Test exception."));
+        partitionFile1.onError(new Exception("Test exception."));
+        partitionFile1.onError(new Exception("Test exception."));
+        partitionFile1.onError(new Exception("Test exception."));
+        assertTrue(partitionFile1.isConsumable());
+
+        partitionFile1.onError(new FileCorruptedException());
+        assertFalse(partitionFile1.isConsumable());
+
+        LocalReducePartitionFile partitionFile2 = createPartitionFile();
+        partitionFile2.onError(new ClosedChannelException());
+        partitionFile2.onError(new ClosedChannelException());
+        partitionFile2.onError(new ClosedChannelException());
+        partitionFile2.onError(new ClosedChannelException());
+        assertTrue(partitionFile2.isConsumable());
+
+        assertTrue(partitionFile2.isConsumable());
+        partitionFile2.onError(new IOException("Test exception."));
+
+        assertTrue(partitionFile2.isConsumable());
+        partitionFile2.onError(new IOException("Test exception."));
+
+        assertTrue(partitionFile2.isConsumable());
+        partitionFile2.onError(new IOException("Test exception."));
+
+        assertTrue(partitionFile2.isConsumable());
+        partitionFile2.onError(new IOException("Test exception."));
+        assertFalse(partitionFile2.isConsumable());
+    }
+
+    private LocalReducePartitionFile createPartitionFile() throws Exception {
+        String baseDir = temporaryFolder.getRoot().getAbsolutePath();
+        LocalReducePartitionFile partitionFile =
+                StorageTestUtils.createLocalReducePartitionFile(baseDir);
+        StorageTestUtils.writeLocalReducePartitionFile(
+                partitionFile, 1, 1, 1, false, dataChecksumEnabled);
+        return partitionFile;
+    }
+}

--- a/shuffle-storage/src/test/java/com/alibaba/flink/shuffle/storage/partition/LocalReducePartitionFileWriterTest.java
+++ b/shuffle-storage/src/test/java/com/alibaba/flink/shuffle/storage/partition/LocalReducePartitionFileWriterTest.java
@@ -1,0 +1,211 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.flink.shuffle.storage.partition;
+
+import com.alibaba.flink.shuffle.common.utils.CommonUtils;
+import com.alibaba.flink.shuffle.storage.utils.StorageTestUtils;
+import com.alibaba.flink.shuffle.storage.utils.TestDataCommitListener;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.ByteBuffer;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+/** Tests for {@link LocalReducePartitionFileWriter}. */
+@RunWith(Parameterized.class)
+public class LocalReducePartitionFileWriterTest {
+    @Rule public final TemporaryFolder temporaryFolder = new TemporaryFolder();
+
+    private final boolean dataChecksumEnabled;
+
+    @Parameterized.Parameters
+    public static Object[] data() {
+        return new Boolean[] {true, false};
+    }
+
+    public LocalReducePartitionFileWriterTest(boolean dataChecksumEnabled) {
+        this.dataChecksumEnabled = dataChecksumEnabled;
+    }
+
+    @Test
+    public void testWriteData() throws Exception {
+        LocalReducePartitionFile partitionFile = createPartitionFile();
+        StorageTestUtils.writeLocalReducePartitionFile(
+                partitionFile,
+                10,
+                StorageTestUtils.NUM_REDUCE_PARTITIONS,
+                10,
+                false,
+                dataChecksumEnabled);
+
+        assertTrue(partitionFile.isConsumable());
+        assertEquals(2, CommonUtils.checkNotNull(temporaryFolder.getRoot().list()).length);
+    }
+
+    @Test
+    public void testWriteEmptyData() throws Exception {
+        LocalReducePartitionFile partitionFile = createPartitionFile();
+        StorageTestUtils.writeLocalReducePartitionFile(
+                partitionFile,
+                0,
+                StorageTestUtils.NUM_REDUCE_PARTITIONS,
+                0,
+                false,
+                dataChecksumEnabled);
+
+        assertTrue(partitionFile.isConsumable());
+        assertEquals(2, CommonUtils.checkNotNull(temporaryFolder.getRoot().list()).length);
+
+        LocalReducePartitionFileMeta fileMeta = partitionFile.getFileMeta();
+        assertEquals(0, new File(fileMeta.getDataFilePath().toString()).length());
+        assertEquals(
+                LocalReducePartitionFile.INDEX_DATA_CHECKSUM_SIZE + 4 + 16,
+                new File(fileMeta.getIndexFilePath().toString()).length());
+    }
+
+    @Test
+    public void testWriteWithEmptyReducePartition() throws Exception {
+        LocalReducePartitionFile partitionFile = createPartitionFile();
+        StorageTestUtils.writeLocalReducePartitionFile(
+                partitionFile,
+                10,
+                StorageTestUtils.NUM_REDUCE_PARTITIONS,
+                10,
+                true,
+                dataChecksumEnabled);
+
+        assertTrue(partitionFile.isConsumable());
+        assertEquals(2, CommonUtils.checkNotNull(temporaryFolder.getRoot().list()).length);
+    }
+
+    @Test
+    public void testWriteEmptyBuffer() throws Exception {
+        LocalReducePartitionFile partitionFile = createPartitionFile();
+        LocalReducePartitionFileWriter fileWriter =
+                new LocalReducePartitionFileWriter(partitionFile, 2, dataChecksumEnabled);
+        fileWriter.open();
+
+        fileWriter.startRegion(false, StorageTestUtils.MAP_PARTITION_ID);
+        ByteBuffer data = ByteBuffer.allocateDirect(0);
+        fileWriter.writeBuffer(StorageTestUtils.createDataBuffer(data, 0), false);
+        fileWriter.finishRegion(StorageTestUtils.MAP_PARTITION_ID);
+
+        fileWriter.prepareFinishWriting(
+                new BufferOrMarker.InputFinishedMarker(
+                        StorageTestUtils.MAP_PARTITION_ID, new TestDataCommitListener()));
+        fileWriter.closeWriting();
+
+        assertTrue(partitionFile.isConsumable());
+        assertEquals(2, CommonUtils.checkNotNull(temporaryFolder.getRoot().list()).length);
+
+        LocalReducePartitionFileMeta fileMeta = partitionFile.getFileMeta();
+        assertEquals(0, new File(fileMeta.getDataFilePath().toString()).length());
+        assertEquals(
+                LocalReducePartitionFile.INDEX_DATA_CHECKSUM_SIZE + 4 + 16,
+                new File(fileMeta.getIndexFilePath().toString()).length());
+    }
+
+    @Test(expected = IllegalStateException.class)
+    public void testStartRegionAfterClose() throws Exception {
+        LocalReducePartitionFileWriter fileWriter =
+                new LocalReducePartitionFileWriter(createPartitionFile(), 2, dataChecksumEnabled);
+
+        fileWriter.close();
+        fileWriter.startRegion(false, StorageTestUtils.MAP_PARTITION_ID);
+    }
+
+    @Test(expected = IllegalStateException.class)
+    public void testFinishRegionAfterClose() throws Exception {
+        LocalReducePartitionFileWriter fileWriter =
+                new LocalReducePartitionFileWriter(createPartitionFile(), 2, dataChecksumEnabled);
+
+        fileWriter.close();
+        fileWriter.finishRegion(StorageTestUtils.MAP_PARTITION_ID);
+    }
+
+    @Test(expected = IllegalStateException.class)
+    public void testWriteBufferAfterClose() throws Exception {
+        LocalReducePartitionFileWriter fileWriter =
+                new LocalReducePartitionFileWriter(createPartitionFile(), 1, dataChecksumEnabled);
+
+        fileWriter.close();
+        fileWriter.writeBuffer(
+                StorageTestUtils.createDataBuffer(StorageTestUtils.createRandomData(), 0), false);
+    }
+
+    @Test(expected = IllegalStateException.class)
+    public void testFinishWritingAfterClose() throws Exception {
+        LocalReducePartitionFileWriter fileWriter =
+                new LocalReducePartitionFileWriter(createPartitionFile(), 2, dataChecksumEnabled);
+
+        fileWriter.close();
+        fileWriter.prepareFinishWriting(
+                new BufferOrMarker.InputFinishedMarker(
+                        StorageTestUtils.MAP_PARTITION_ID, new TestDataCommitListener()));
+    }
+
+    @Test(expected = IllegalStateException.class)
+    public void testWriteNotInPartitionIndexOrder() throws IOException {
+        LocalReducePartitionFileWriter fileWriter =
+                new LocalReducePartitionFileWriter(createPartitionFile(), 2, dataChecksumEnabled);
+
+        fileWriter.startRegion(false, StorageTestUtils.MAP_PARTITION_ID);
+        fileWriter.writeBuffer(
+                StorageTestUtils.createDataBuffer(StorageTestUtils.createRandomData(), 5), false);
+        fileWriter.writeBuffer(
+                StorageTestUtils.createDataBuffer(StorageTestUtils.createRandomData(), 0), false);
+    }
+
+    @Test(expected = IllegalStateException.class)
+    public void testStartRegionBeforeFinish() throws IOException {
+        LocalReducePartitionFileWriter fileWriter =
+                new LocalReducePartitionFileWriter(createPartitionFile(), 1, dataChecksumEnabled);
+
+        fileWriter.startRegion(false, StorageTestUtils.MAP_PARTITION_ID);
+        fileWriter.writeBuffer(
+                StorageTestUtils.createDataBuffer(StorageTestUtils.createRandomData(), 5), false);
+        fileWriter.startRegion(false, StorageTestUtils.MAP_PARTITION_ID);
+    }
+
+    @Test(expected = IllegalStateException.class)
+    public void testFinishWritingBeforeFinishRegion() throws Exception {
+        LocalReducePartitionFileWriter fileWriter =
+                new LocalReducePartitionFileWriter(createPartitionFile(), 1, dataChecksumEnabled);
+
+        fileWriter.startRegion(false, StorageTestUtils.MAP_PARTITION_ID);
+        fileWriter.writeBuffer(
+                StorageTestUtils.createDataBuffer(StorageTestUtils.createRandomData(), 0), false);
+        fileWriter.prepareFinishWriting(
+                new BufferOrMarker.InputFinishedMarker(
+                        StorageTestUtils.MAP_PARTITION_ID, new TestDataCommitListener()));
+    }
+
+    private LocalReducePartitionFile createPartitionFile() {
+        return StorageTestUtils.createLocalReducePartitionFile(
+                temporaryFolder.getRoot().getAbsolutePath());
+    }
+}

--- a/shuffle-storage/src/test/java/com/alibaba/flink/shuffle/storage/partition/SSDOnlyLocalFileReducePartitionFactoryTest.java
+++ b/shuffle-storage/src/test/java/com/alibaba/flink/shuffle/storage/partition/SSDOnlyLocalFileReducePartitionFactoryTest.java
@@ -1,0 +1,156 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.flink.shuffle.storage.partition;
+
+import com.alibaba.flink.shuffle.common.config.Configuration;
+import com.alibaba.flink.shuffle.common.exception.ConfigurationException;
+import com.alibaba.flink.shuffle.core.config.StorageOptions;
+import com.alibaba.flink.shuffle.core.storage.StorageMeta;
+import com.alibaba.flink.shuffle.core.storage.StorageType;
+import com.alibaba.flink.shuffle.storage.utils.StorageTestUtils;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import java.util.Properties;
+
+import static com.alibaba.flink.shuffle.storage.partition.LocalFileReducePartitionFactoryTest.assertExpectedStorageMeta;
+import static com.alibaba.flink.shuffle.storage.partition.LocalFileReducePartitionFactoryTest.expectedReducePartitionEvenDiskUsedCount;
+import static com.alibaba.flink.shuffle.storage.partition.LocalFileReducePartitionFactoryTest.updateStorageFreeSpace;
+import static com.alibaba.flink.shuffle.storage.partition.LocalFileReducePartitionFactoryTest.updateStorageHealthStatus;
+import static org.junit.Assert.assertEquals;
+
+/** Tests for {@link SSDOnlyLocalFileReducePartitionFactory}. */
+public class SSDOnlyLocalFileReducePartitionFactoryTest {
+
+    @Rule public final TemporaryFolder temporaryFolder1 = new TemporaryFolder();
+
+    @Rule public final TemporaryFolder temporaryFolder2 = new TemporaryFolder();
+
+    @Test(expected = ConfigurationException.class)
+    public void testPreferHddWithoutValidHddDataDir() {
+        SSDOnlyLocalFileReducePartitionFactory partitionFactory =
+                new SSDOnlyLocalFileReducePartitionFactory();
+        Properties properties = new Properties();
+        properties.setProperty(
+                StorageOptions.STORAGE_LOCAL_DATA_DIRS.key(),
+                "[HDD]" + temporaryFolder1.getRoot().getAbsolutePath());
+        partitionFactory.initialize(new Configuration(properties));
+    }
+
+    @Test
+    public void testSSDOnly() {
+        SSDOnlyLocalFileReducePartitionFactory partitionFactory =
+                new SSDOnlyLocalFileReducePartitionFactory();
+        Properties properties = new Properties();
+        properties.setProperty(
+                StorageOptions.STORAGE_LOCAL_DATA_DIRS.key(),
+                String.format(
+                        "[SSD]%s,[HDD]%s",
+                        temporaryFolder1.getRoot().getAbsolutePath(),
+                        temporaryFolder2.getRoot().getAbsolutePath()));
+        partitionFactory.initialize(new Configuration(properties));
+
+        for (int i = 0; i < 100; ++i) {
+            StorageMeta storageMeta = partitionFactory.getNextDataStorageMeta();
+            assertEquals(
+                    StorageTestUtils.getStoragePath(temporaryFolder1),
+                    storageMeta.getStoragePath());
+            assertEquals(StorageType.SSD, storageMeta.getStorageType());
+        }
+    }
+
+    @Test
+    public void testUpdateFreeStorageSpace() {
+        LocalFileReducePartitionFactory partitionFactory =
+                new SSDOnlyLocalFileReducePartitionFactory();
+        LocalFileReducePartitionFactoryTest.FakeStorageMeta[] storageMetas =
+                LocalFileReducePartitionFactoryTest.addStorageMetas(partitionFactory);
+
+        assertEquals(0, partitionFactory.getStorageSpaceInfo().getHddMaxFreeSpaceBytes());
+        assertEquals(0, partitionFactory.getStorageSpaceInfo().getSsdMaxFreeSpaceBytes());
+
+        LocalFileReducePartitionFactoryTest.updateStorageFreeSpace(
+                storageMetas, 4, partitionFactory);
+        assertEquals(7, partitionFactory.getStorageSpaceInfo().getSsdMaxFreeSpaceBytes());
+        assertEquals(0, partitionFactory.getStorageSpaceInfo().getHddMaxFreeSpaceBytes());
+
+        LocalFileReducePartitionFactoryTest.updateStorageFreeSpace(
+                storageMetas, 0, partitionFactory);
+        assertEquals(3, partitionFactory.getStorageSpaceInfo().getSsdMaxFreeSpaceBytes());
+        assertEquals(0, partitionFactory.getStorageSpaceInfo().getHddMaxFreeSpaceBytes());
+    }
+
+    @Test
+    public void testUpdateFreeStorageSpaceWithUnhealthyStorage() {
+        LocalFileReducePartitionFactory partitionFactory =
+                new SSDOnlyLocalFileReducePartitionFactory();
+        LocalFileReducePartitionFactoryTest.FakeStorageMeta[] storageMetas =
+                LocalFileReducePartitionFactoryTest.addStorageMetas(partitionFactory);
+        updateStorageFreeSpace(storageMetas, 0, partitionFactory);
+
+        updateStorageHealthStatus(storageMetas, 2, 4, false, partitionFactory);
+        assertEquals(1, partitionFactory.getStorageSpaceInfo().getSsdMaxFreeSpaceBytes());
+        assertEquals(0, partitionFactory.getStorageSpaceInfo().getHddMaxFreeSpaceBytes());
+
+        updateStorageHealthStatus(storageMetas, 0, 2, false, partitionFactory);
+        assertEquals(0, partitionFactory.getStorageSpaceInfo().getSsdMaxFreeSpaceBytes());
+        assertEquals(0, partitionFactory.getStorageSpaceInfo().getHddMaxFreeSpaceBytes());
+
+        updateStorageHealthStatus(storageMetas, 2, 4, true, partitionFactory);
+        assertEquals(3, partitionFactory.getStorageSpaceInfo().getSsdMaxFreeSpaceBytes());
+        assertEquals(0, partitionFactory.getStorageSpaceInfo().getHddMaxFreeSpaceBytes());
+    }
+
+    @Test
+    public void testGetNextStorageMetaWithUnhealthyStorage() {
+        LocalFileReducePartitionFactory partitionFactory =
+                new SSDOnlyLocalFileReducePartitionFactory();
+        LocalFileReducePartitionFactoryTest.FakeStorageMeta[] storageMetas =
+                LocalFileReducePartitionFactoryTest.addStorageMetas(partitionFactory);
+        updateStorageFreeSpace(storageMetas, 0, partitionFactory);
+
+        updateStorageHealthStatus(storageMetas, 2, 4, false, partitionFactory);
+        assertExpectedStorageMeta(partitionFactory, storageMetas[0]);
+
+        updateStorageHealthStatus(storageMetas, 0, 2, false, partitionFactory);
+        assertExpectedStorageMeta(partitionFactory, null);
+
+        updateStorageHealthStatus(storageMetas, 2, 4, true, partitionFactory);
+        assertExpectedStorageMeta(partitionFactory, storageMetas[2]);
+    }
+
+    @Test
+    public void testAllDisksWillBeUsed() {
+        SSDOnlyLocalFileReducePartitionFactory partitionFactory =
+                new SSDOnlyLocalFileReducePartitionFactory();
+        Properties properties = new Properties();
+        properties.setProperty(
+                StorageOptions.STORAGE_LOCAL_DATA_DIRS.key(),
+                String.format(
+                        "[SSD]%s,[SSD]%s",
+                        temporaryFolder1.getRoot().getAbsolutePath(),
+                        temporaryFolder2.getRoot().getAbsolutePath()));
+        partitionFactory.initialize(new Configuration(properties));
+
+        expectedReducePartitionEvenDiskUsedCount(
+                partitionFactory, temporaryFolder1, temporaryFolder2, StorageType.SSD);
+    }
+}

--- a/shuffle-transfer/src/main/java/com/alibaba/flink/shuffle/transfer/CommonTransferMessageDecoder.java
+++ b/shuffle-transfer/src/main/java/com/alibaba/flink/shuffle/transfer/CommonTransferMessageDecoder.java
@@ -23,6 +23,8 @@ import com.alibaba.flink.shuffle.transfer.TransferMessage.ErrorResponse;
 import com.alibaba.flink.shuffle.transfer.TransferMessage.Heartbeat;
 import com.alibaba.flink.shuffle.transfer.TransferMessage.ReadAddCredit;
 import com.alibaba.flink.shuffle.transfer.TransferMessage.ReadHandshakeRequest;
+import com.alibaba.flink.shuffle.transfer.TransferMessage.ReducePartitionReadHandshakeRequest;
+import com.alibaba.flink.shuffle.transfer.TransferMessage.ReducePartitionWriteHandshakeRequest;
 import com.alibaba.flink.shuffle.transfer.TransferMessage.WriteAddCredit;
 import com.alibaba.flink.shuffle.transfer.TransferMessage.WriteFinish;
 import com.alibaba.flink.shuffle.transfer.TransferMessage.WriteFinishCommit;
@@ -67,6 +69,9 @@ public class CommonTransferMessageDecoder extends TransferMessageDecoder {
             case WriteHandshakeRequest.ID:
                 return TransferMessageDecoder.DecodingResult.fullMessage(
                         WriteHandshakeRequest.readFrom(messageBuffer));
+            case ReducePartitionWriteHandshakeRequest.ID:
+                return TransferMessageDecoder.DecodingResult.fullMessage(
+                        ReducePartitionWriteHandshakeRequest.readFrom(messageBuffer));
             case WriteAddCredit.ID:
                 return TransferMessageDecoder.DecodingResult.fullMessage(
                         WriteAddCredit.readFrom(messageBuffer));
@@ -85,6 +90,9 @@ public class CommonTransferMessageDecoder extends TransferMessageDecoder {
             case ReadHandshakeRequest.ID:
                 return TransferMessageDecoder.DecodingResult.fullMessage(
                         ReadHandshakeRequest.readFrom(messageBuffer));
+            case ReducePartitionReadHandshakeRequest.ID:
+                return TransferMessageDecoder.DecodingResult.fullMessage(
+                        ReducePartitionReadHandshakeRequest.readFrom(messageBuffer));
             case ReadAddCredit.ID:
                 return TransferMessageDecoder.DecodingResult.fullMessage(
                         ReadAddCredit.readFrom(messageBuffer));

--- a/shuffle-transfer/src/main/java/com/alibaba/flink/shuffle/transfer/DecoderDelegate.java
+++ b/shuffle-transfer/src/main/java/com/alibaba/flink/shuffle/transfer/DecoderDelegate.java
@@ -35,6 +35,8 @@ import static com.alibaba.flink.shuffle.transfer.TransferMessage.MAGIC_NUMBER;
 import static com.alibaba.flink.shuffle.transfer.TransferMessage.ReadAddCredit;
 import static com.alibaba.flink.shuffle.transfer.TransferMessage.ReadData;
 import static com.alibaba.flink.shuffle.transfer.TransferMessage.ReadHandshakeRequest;
+import static com.alibaba.flink.shuffle.transfer.TransferMessage.ReducePartitionReadHandshakeRequest;
+import static com.alibaba.flink.shuffle.transfer.TransferMessage.ReducePartitionWriteHandshakeRequest;
 import static com.alibaba.flink.shuffle.transfer.TransferMessage.WriteData;
 import static com.alibaba.flink.shuffle.transfer.TransferMessage.WriteFinish;
 import static com.alibaba.flink.shuffle.transfer.TransferMessage.WriteHandshakeRequest;
@@ -79,10 +81,12 @@ public class DecoderDelegate extends ChannelInboundHandlerAdapter {
                 msgID -> {
                     switch (msgID) {
                         case WriteHandshakeRequest.ID:
+                        case ReducePartitionWriteHandshakeRequest.ID:
                         case WriteRegionStart.ID:
                         case WriteRegionFinish.ID:
                         case WriteFinish.ID:
                         case ReadHandshakeRequest.ID:
+                        case ReducePartitionReadHandshakeRequest.ID:
                         case ReadAddCredit.ID:
                         case CloseChannel.ID:
                         case CloseConnection.ID:

--- a/shuffle-transfer/src/main/java/com/alibaba/flink/shuffle/transfer/ReadClientHandler.java
+++ b/shuffle-transfer/src/main/java/com/alibaba/flink/shuffle/transfer/ReadClientHandler.java
@@ -188,7 +188,7 @@ public class ReadClientHandler extends ChannelInboundHandlerAdapter {
                 SocketAddress address = ctx.channel().remoteAddress();
                 ChannelID channelID = backlog.getChannelID();
                 currentChannelID = channelID;
-                LOG.trace("({}) Received {}.", address, backlog);
+                LOG.debug("({}) Received {}.", address, backlog);
                 ShuffleReadClient shuffleReadClient = readClientsByChannelID.get(channelID);
                 assertChannelExists(channelID, shuffleReadClient);
                 shuffleReadClient.backlogReceived(backlog.getBacklog());

--- a/shuffle-transfer/src/main/java/com/alibaba/flink/shuffle/transfer/ReadingService.java
+++ b/shuffle-transfer/src/main/java/com/alibaba/flink/shuffle/transfer/ReadingService.java
@@ -20,6 +20,7 @@ import com.alibaba.flink.shuffle.common.utils.CommonUtils;
 import com.alibaba.flink.shuffle.core.ids.ChannelID;
 import com.alibaba.flink.shuffle.core.ids.DataSetID;
 import com.alibaba.flink.shuffle.core.ids.MapPartitionID;
+import com.alibaba.flink.shuffle.core.ids.ReducePartitionID;
 import com.alibaba.flink.shuffle.core.storage.DataPartitionReadingView;
 import com.alibaba.flink.shuffle.core.storage.PartitionedDataStore;
 import com.alibaba.flink.shuffle.core.storage.ReadingViewContext;
@@ -91,6 +92,46 @@ public class ReadingService {
                                 failureHandler::accept));
         LOG.debug(
                 "(channel: {}) Reading handshake cost {} ms.",
+                channelID,
+                (System.nanoTime() - startTime) / 1000_000);
+        dataViewReader.setReadingView(readingView);
+        servingChannels.put(channelID, dataViewReader);
+        numReadingFlows.inc();
+    }
+
+    public void reducePartitionHandshake(
+            ChannelID channelID,
+            DataSetID dataSetID,
+            ReducePartitionID reduceID,
+            int numSubs,
+            Consumer<DataViewReader> dataListener,
+            Consumer<Integer> backlogListener,
+            Consumer<Throwable> failureHandler,
+            int initialCredit,
+            String addressStr)
+            throws Throwable {
+
+        checkState(
+                !servingChannels.containsKey(channelID),
+                () -> "Duplicate handshake for channel: " + channelID);
+        DataViewReader dataViewReader = new DataViewReader(channelID, addressStr, dataListener);
+        if (initialCredit > 0) {
+            dataViewReader.addCredit(initialCredit);
+        }
+        long startTime = System.nanoTime();
+        DataPartitionReadingView readingView =
+                dataStore.createDataPartitionReadingView(
+                        new ReadingViewContext(
+                                dataSetID,
+                                reduceID,
+                                reduceID.getPartitionIndex(),
+                                reduceID.getPartitionIndex(),
+                                numSubs,
+                                () -> dataListener.accept(dataViewReader),
+                                backlogListener::accept,
+                                failureHandler::accept));
+        LOG.debug(
+                "(channel: {}) Reading handshake for reduce partition cost {} ms.",
                 channelID,
                 (System.nanoTime() - startTime) / 1000_000);
         dataViewReader.setReadingView(readingView);

--- a/shuffle-transfer/src/main/java/com/alibaba/flink/shuffle/transfer/ShuffleReadDataDecoder.java
+++ b/shuffle-transfer/src/main/java/com/alibaba/flink/shuffle/transfer/ShuffleReadDataDecoder.java
@@ -22,11 +22,16 @@ import com.alibaba.flink.shuffle.core.ids.ChannelID;
 import org.apache.flink.shaded.netty4.io.netty.buffer.ByteBuf;
 import org.apache.flink.shaded.netty4.io.netty.channel.ChannelHandlerContext;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import java.util.function.Function;
 import java.util.function.Supplier;
 
 /** {@link TransferMessageDecoder} for {@link TransferMessage.ReadData}. */
 public class ShuffleReadDataDecoder extends TransferMessageDecoder {
+
+    private static final Logger LOG = LoggerFactory.getLogger(ShuffleReadDataDecoder.class);
 
     private ByteBuf headerByteBuf;
 

--- a/shuffle-transfer/src/main/java/com/alibaba/flink/shuffle/transfer/WriteClientHandler.java
+++ b/shuffle-transfer/src/main/java/com/alibaba/flink/shuffle/transfer/WriteClientHandler.java
@@ -86,6 +86,7 @@ public class WriteClientHandler extends ChannelInboundHandlerAdapter {
 
     @Override
     public void channelActive(ChannelHandlerContext ctx) throws Exception {
+        LOG.debug("({}) Connection active.", ctx.channel().remoteAddress());
         if (heartbeatInterval > 0) {
             heartbeatFuture =
                     ctx.executor()

--- a/shuffle-transfer/src/test/java/com/alibaba/flink/shuffle/transfer/FakedDataPartitionWritingView.java
+++ b/shuffle-transfer/src/test/java/com/alibaba/flink/shuffle/transfer/FakedDataPartitionWritingView.java
@@ -62,7 +62,7 @@ public class FakedDataPartitionWritingView implements DataPartitionWritingView {
     }
 
     @Override
-    public void onBuffer(Buffer buffer, ReducePartitionID reducePartitionID) {
+    public void onBuffer(Buffer buffer, int regionIndex, ReducePartitionID reducePartitionID) {
         dataHandler.accept(buffer);
         buffer.clear();
         buffers.add(buffer);
@@ -71,12 +71,18 @@ public class FakedDataPartitionWritingView implements DataPartitionWritingView {
 
     @Override
     public void regionStarted(int dataRegionIndex, boolean isBroadcastRegion) {
+        regionStarted(dataRegionIndex, 1, 0, isBroadcastRegion);
+    }
+
+    @Override
+    public void regionStarted(
+            int dataRegionIndex, int numMaps, int needCredit, boolean isBroadcastRegion) {
         regionStartCount++;
         dataRegionCreditListener.notifyCredits(1, regionFinishCount);
     }
 
     @Override
-    public void regionFinished() {
+    public void regionFinished(int dataRegionIndex) {
         regionFinishCount++;
     }
 

--- a/shuffle-transfer/src/test/java/com/alibaba/flink/shuffle/transfer/utils/NoOpMapPartitionFactory.java
+++ b/shuffle-transfer/src/test/java/com/alibaba/flink/shuffle/transfer/utils/NoOpMapPartitionFactory.java
@@ -1,0 +1,109 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.flink.shuffle.transfer.utils;
+
+import com.alibaba.flink.shuffle.common.config.Configuration;
+import com.alibaba.flink.shuffle.core.ids.DataPartitionID;
+import com.alibaba.flink.shuffle.core.ids.DataSetID;
+import com.alibaba.flink.shuffle.core.ids.JobID;
+import com.alibaba.flink.shuffle.core.storage.DataPartition;
+import com.alibaba.flink.shuffle.core.storage.DataPartitionFactory;
+import com.alibaba.flink.shuffle.core.storage.DataPartitionMeta;
+import com.alibaba.flink.shuffle.core.storage.DiskType;
+import com.alibaba.flink.shuffle.core.storage.PartitionedDataStore;
+import com.alibaba.flink.shuffle.core.storage.StorageSpaceInfo;
+
+import java.io.DataInput;
+import java.util.Map;
+
+/** An empty data partition factory used for tests. */
+public class NoOpMapPartitionFactory implements DataPartitionFactory {
+    @Override
+    public void initialize(Configuration configuration) throws Exception {}
+
+    @Override
+    public DataPartition createDataPartition(
+            PartitionedDataStore dataStore,
+            JobID jobID,
+            DataSetID dataSetID,
+            DataPartitionID dataPartitionID,
+            int numMapPartitions,
+            int numReducePartitions)
+            throws Exception {
+        return null;
+    }
+
+    @Override
+    public DataPartition createDataPartition(
+            PartitionedDataStore dataStore, DataPartitionMeta partitionMeta) throws Exception {
+        return null;
+    }
+
+    @Override
+    public DataPartitionMeta recoverDataPartitionMeta(DataInput dataInput) throws Exception {
+        return null;
+    }
+
+    @Override
+    public DataPartition.DataPartitionType getDataPartitionType() {
+        return DataPartition.DataPartitionType.MAP_PARTITION;
+    }
+
+    @Override
+    public void updateFreeStorageSpace() {}
+
+    @Override
+    public StorageSpaceInfo getStorageSpaceInfo() {
+        return null;
+    }
+
+    @Override
+    public boolean isStorageSpaceValid(
+            StorageSpaceInfo storageSpaceInfo,
+            long minReservedSpaceBytes,
+            long maxUsableSpaceBytes) {
+        return false;
+    }
+
+    @Override
+    public String getStorageNameFromPath(String storagePath) {
+        return null;
+    }
+
+    @Override
+    public void updateUsedStorageSpace(Map<String, Long> storageUsedBytes) {}
+
+    @Override
+    public void updateStorageHealthStatus() {}
+
+    @Override
+    public DiskType getDiskType() {
+        return DiskType.ANY_TYPE;
+    }
+
+    @Override
+    public boolean useSsdOnly() {
+        return false;
+    }
+
+    @Override
+    public boolean useHddOnly() {
+        return false;
+    }
+}

--- a/shuffle-transfer/src/test/java/com/alibaba/flink/shuffle/transfer/utils/NoOpPartitionedDataStore.java
+++ b/shuffle-transfer/src/test/java/com/alibaba/flink/shuffle/transfer/utils/NoOpPartitionedDataStore.java
@@ -22,6 +22,7 @@ import com.alibaba.flink.shuffle.core.ids.DataPartitionID;
 import com.alibaba.flink.shuffle.core.ids.DataSetID;
 import com.alibaba.flink.shuffle.core.ids.JobID;
 import com.alibaba.flink.shuffle.core.memory.BufferDispatcher;
+import com.alibaba.flink.shuffle.core.storage.DataPartitionFactory;
 import com.alibaba.flink.shuffle.core.storage.DataPartitionMeta;
 import com.alibaba.flink.shuffle.core.storage.DataPartitionReadingView;
 import com.alibaba.flink.shuffle.core.storage.DataPartitionWritingView;
@@ -34,7 +35,10 @@ import com.alibaba.flink.shuffle.core.storage.WritingViewContext;
 
 import javax.annotation.Nullable;
 
+import java.util.HashMap;
 import java.util.Map;
+
+import static com.alibaba.flink.shuffle.common.utils.ProtocolUtils.emptyDataPartitionType;
 
 /** An empty partitioned data store used for tests. */
 public class NoOpPartitionedDataStore implements PartitionedDataStore {
@@ -54,6 +58,13 @@ public class NoOpPartitionedDataStore implements PartitionedDataStore {
     @Override
     public boolean isDataPartitionConsumable(DataPartitionMeta partitionMeta) {
         return false;
+    }
+
+    @Override
+    public Map<String, DataPartitionFactory> partitionFactories() {
+        Map<String, DataPartitionFactory> partitionFactories = new HashMap<>();
+        partitionFactories.put(emptyDataPartitionType(), new NoOpMapPartitionFactory());
+        return partitionFactories;
     }
 
     @Override

--- a/shuffle-yarn/src/test/java/com/alibaba/flink/shuffle/yarn/WordCountITCaseTest.java
+++ b/shuffle-yarn/src/test/java/com/alibaba/flink/shuffle/yarn/WordCountITCaseTest.java
@@ -69,6 +69,9 @@ public class WordCountITCaseTest extends BatchJobTestBase {
 
         flinkConfiguration.setString(
                 "shuffle-service-factory.class", RemoteShuffleServiceFactory.class.getName());
+        flinkConfiguration.setString(
+                "remote-shuffle.job.data-partition-factory-name",
+                "com.alibaba.flink.shuffle.storage.partition.LocalFileReducePartitionFactory");
         flinkConfiguration.setString("remote-shuffle.job.memory-per-gate", "8m");
 
         flinkConfiguration.setString(HA_MODE.key(), "ZOOKEEPER");
@@ -123,7 +126,7 @@ public class WordCountITCaseTest extends BatchJobTestBase {
         words.keyBy(value -> value.f0)
                 .sum(1)
                 .map((MapFunction<Tuple2<String, Long>, Long>) wordCount -> wordCount.f1)
-                .addSink(new VerifySink(parallelism * WORD_COUNT));
+                .addSink(new VerifySink((long) parallelism * WORD_COUNT));
 
         StreamGraph streamGraph = env.getStreamGraph();
         streamGraph.setGlobalStreamExchangeMode(GlobalStreamExchangeMode.ALL_EDGES_BLOCKING);


### PR DESCRIPTION
<!--

*Thank you very much for contributing to remote-shuffle-service-for-flink. To help the community review your issue or contribution in the best possible way，please take a few minutes to fulfill the following items.*

-->

## What is the purpose of the change

This change introduces the `ReducePartition` shuffle mode for remote shuffle service.

`ReducePartition` is a good supplement to the current `MapPartition`. It has several good features, for example, it can benefit streaming and hybrid shuffle (mixed streaming and batch) and it is suitable for performance in some scenarios.

## Brief changelog

  - *Support ReducePartition for API/client/transfer/storage/manager layers.*
  - *Add tests for ReducePartition.*

## Verifying this change

This change added tests.
