### PR TITLE
[FRS-59] Fix SHUFFLE_CONF_DIR didn't work in standalone mode

### DIFF
--- a/shuffle-dist/src/main/shuffle-bin/bin/config.sh
+++ b/shuffle-dist/src/main/shuffle-bin/bin/config.sh
@@ -175,7 +175,7 @@ runBashJavaUtilsCmd() {
 EOF
 
     local log_setting=("-Dlog4j.configurationFile=file:${java_utils_log_conf}")
-    local output=`"${JAVA_RUN}" "${log_setting}" -classpath "${class_path}" com.alibaba.flink.shuffle.core.utils.BashJavaUtils ${cmd} "${dynamic_args[@]}" 2>&1 | tail -n 1000`
+    local output=`"${JAVA_RUN}" "${log_setting}" -classpath "${class_path}" com.alibaba.flink.shuffle.core.utils.BashJavaUtils ${cmd} "${dynamic_args[@]}" -c ${SHUFFLE_CONF_DIR} 2>&1 | tail -n 1000`
     if [[ $? -ne 0 ]]; then
         echo "[ERROR] Cannot run BashJavaUtils to execute command ${cmd}." 1>&2
         # Print the output in case the user redirect the log to console.

--- a/shuffle-dist/src/main/shuffle-bin/bin/shuffle-console.sh
+++ b/shuffle-dist/src/main/shuffle-bin/bin/shuffle-console.sh
@@ -91,4 +91,4 @@ echo $$ >> "$pid" 2>/dev/null
 # Release the lock because the java process runs in the foreground and would block other processes from modifying the pid file
 [[ ${flock_exist} -eq 0 ]] &&  flock -u 200
 
-exec "$JAVA_RUN" "${log_setting[@]}" $JVM_ARGS -classpath "`manglePathList "$SHUFFLE_CLASSPATH"`" ${CLASS_TO_RUN} "${ARGS[@]}"
+exec "$JAVA_RUN" "${log_setting[@]}" $JVM_ARGS -classpath "`manglePathList "$SHUFFLE_CLASSPATH"`" ${CLASS_TO_RUN} "${ARGS[@]}" -c ${SHUFFLE_CONF_DIR}

--- a/shuffle-dist/src/main/shuffle-bin/bin/shuffle-daemon.sh
+++ b/shuffle-dist/src/main/shuffle-bin/bin/shuffle-daemon.sh
@@ -113,7 +113,7 @@ case $STARTSTOP in
 
         echo "Starting $DAEMON daemon on host $HOSTNAME."
 
-        "$JAVA_RUN" "${log_setting[@]}" $JVM_ARGS -classpath "`manglePathList "$SHUFFLE_CLASSPATH"`" ${CLASS_TO_RUN} "${ARGS[@]}" > "$out" 200<&- 2>&1 < /dev/null &
+        "$JAVA_RUN" "${log_setting[@]}" $JVM_ARGS -classpath "`manglePathList "$SHUFFLE_CLASSPATH"`" ${CLASS_TO_RUN} "${ARGS[@]}" -c ${SHUFFLE_CONF_DIR} > "$out" 200<&- 2>&1 < /dev/null &
 
         mypid=$!
 


### PR DESCRIPTION
<!--

*Thank you very much for contributing to remote-shuffle-service-for-flink. To help the community review your issue or contribution in the best possible way，please take a few minutes to fulfill following items.*

-->

## What is the purpose of the change

Fix bug: Env variable `SHUFFLE_CONF_DIR` didn't work in standalone mode

## Brief change log

  - *Change start-daemon script*



## Verifying this change

This change is already covered by existing tests.

