### PR TITLE
[FRS-16]Support reporting metrics to prometheus

### DIFF
--- a/shuffle-common/src/main/java/com/alibaba/flink/shuffle/common/config/StructuredOptionsSplitter.java
+++ b/shuffle-common/src/main/java/com/alibaba/flink/shuffle/common/config/StructuredOptionsSplitter.java
@@ -28,7 +28,7 @@ import static com.alibaba.flink.shuffle.common.utils.CommonUtils.checkNotNull;
  * <p>This class is copied from Apache Flink
  * (org.apache.flink.configuration.StructuredOptionsSplitter).
  */
-class StructuredOptionsSplitter {
+public class StructuredOptionsSplitter {
 
     /**
      * Splits the given string on the given delimiter. It supports quoting parts of the string with
@@ -48,7 +48,7 @@ class StructuredOptionsSplitter {
      * @param delimiter delimiter to split on
      * @return a list of splits
      */
-    static List<String> splitEscaped(String string, char delimiter) {
+    public static List<String> splitEscaped(String string, char delimiter) {
         List<Token> tokens = tokenize(checkNotNull(string), delimiter);
         return processTokens(tokens);
     }
@@ -74,7 +74,7 @@ class StructuredOptionsSplitter {
      * @param charsToEscape escape chars for the escape conditions
      * @return escaped string by single quote
      */
-    static String escapeWithSingleQuote(String string, String... charsToEscape) {
+    public static String escapeWithSingleQuote(String string, String... charsToEscape) {
         boolean escape =
                 Arrays.stream(charsToEscape).anyMatch(string::contains)
                         || string.contains("\"")

--- a/shuffle-common/src/main/java/com/alibaba/flink/shuffle/common/utils/CommonUtils.java
+++ b/shuffle-common/src/main/java/com/alibaba/flink/shuffle/common/utils/CommonUtils.java
@@ -200,6 +200,10 @@ public class CommonUtils {
         return bb.array();
     }
 
+    public static boolean isValidHostPort(int port) {
+        return 0 <= port && port <= 65535;
+    }
+
     /**
      * Runs the given {@link RunnableWithException} in current thread silently and do nothing even
      * when any exception occurs.

--- a/shuffle-core/src/main/java/com/alibaba/flink/shuffle/core/exception/TraversableOnceException.java
+++ b/shuffle-core/src/main/java/com/alibaba/flink/shuffle/core/exception/TraversableOnceException.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2021 The Flink Remote Shuffle Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  	http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.flink.shuffle.core.exception;
+
+/**
+ * An exception, indicating that an {@link Iterable} can only be traversed once, but has been
+ * attempted to traverse an additional time.
+ *
+ * <p>This class is copied from Apache Flink (org.apache.flink.util.TraversableOnceException).
+ */
+public class TraversableOnceException extends RuntimeException {
+
+    private static final long serialVersionUID = 7636881584773577290L;
+
+    /** Creates a new exception with a default message. */
+    public TraversableOnceException() {
+        super(
+                "The Iterable can be iterated over only once. Only the first call to 'iterator()' will succeed.");
+    }
+}

--- a/shuffle-core/src/main/java/com/alibaba/flink/shuffle/core/utils/ConfigurationParserUtils.java
+++ b/shuffle-core/src/main/java/com/alibaba/flink/shuffle/core/utils/ConfigurationParserUtils.java
@@ -17,6 +17,8 @@
 package com.alibaba.flink.shuffle.core.utils;
 
 import com.alibaba.flink.shuffle.common.config.Configuration;
+import com.alibaba.flink.shuffle.common.config.StructuredOptionsSplitter;
+import com.alibaba.flink.shuffle.common.exception.ConfigurationException;
 import com.alibaba.flink.shuffle.common.exception.ShuffleException;
 
 import org.apache.commons.cli.CommandLine;
@@ -27,9 +29,14 @@ import org.apache.commons.cli.ParseException;
 
 import java.io.File;
 import java.io.IOException;
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.Map;
 import java.util.Properties;
+import java.util.stream.Collectors;
 
 import static com.alibaba.flink.shuffle.common.utils.CommonUtils.checkNotNull;
+import static com.alibaba.flink.shuffle.common.utils.CommonUtils.isValidHostPort;
 
 /** Utility class to load and parse {@link Configuration} from args and config file. */
 public class ConfigurationParserUtils {
@@ -74,6 +81,98 @@ public class ConfigurationParserUtils {
         final File confDirectory = new File(homeDirectory, DEFAULT_SHUFFLE_CONF_DIR);
 
         return confDirectory.getAbsolutePath();
+    }
+
+    /**
+     * Returns a map of configuration.
+     *
+     * @param stringSerializedMap
+     * @return Map of configuration parsed
+     */
+    public static Map<String, String> parseIntoMap(String stringSerializedMap) {
+        return StructuredOptionsSplitter.splitEscaped(stringSerializedMap, ',').stream()
+                .map(p -> StructuredOptionsSplitter.splitEscaped(p, ':'))
+                .collect(
+                        Collectors.toMap(
+                                arr -> arr.get(0), // key name
+                                arr -> arr.get(1) // value
+                                ));
+    }
+
+    // ------------------------------------------------------------------------
+    //  Port range parsing
+    // ------------------------------------------------------------------------
+
+    /**
+     * Returns an iterator over available ports defined by the range definition.
+     *
+     * @param rangeDefinition String describing a single port, a range of ports or multiple ranges.
+     * @return Set of ports from the range definition
+     * @throws NumberFormatException If an invalid string is passed.
+     */
+    public static Iterator<Integer> getPortRangeFromString(String rangeDefinition)
+            throws NumberFormatException {
+        final String[] ranges = rangeDefinition.trim().split(",");
+
+        UnionIterator<Integer> iterators = new UnionIterator<>();
+
+        for (String rawRange : ranges) {
+            Iterator<Integer> rangeIterator;
+            String range = rawRange.trim();
+            int dashIdx = range.indexOf('-');
+            if (dashIdx == -1) {
+                // only one port in range:
+                final int port = Integer.valueOf(range);
+                if (!isValidHostPort(port)) {
+                    throw new ConfigurationException(
+                            "Invalid port configuration. Port must be between 0"
+                                    + "and 65535, but was "
+                                    + port
+                                    + ".");
+                }
+                rangeIterator = Collections.singleton(Integer.valueOf(range)).iterator();
+            } else {
+                // evaluate range
+                final int start = Integer.valueOf(range.substring(0, dashIdx));
+                if (!isValidHostPort(start)) {
+                    throw new ConfigurationException(
+                            "Invalid port configuration. Port must be between 0"
+                                    + "and 65535, but was "
+                                    + start
+                                    + ".");
+                }
+                final int end = Integer.valueOf(range.substring(dashIdx + 1, range.length()));
+                if (!isValidHostPort(end)) {
+                    throw new ConfigurationException(
+                            "Invalid port configuration. Port must be between 0"
+                                    + "and 65535, but was "
+                                    + end
+                                    + ".");
+                }
+                rangeIterator =
+                        new Iterator<Integer>() {
+                            int i = start;
+
+                            @Override
+                            public boolean hasNext() {
+                                return i <= end;
+                            }
+
+                            @Override
+                            public Integer next() {
+                                return i++;
+                            }
+
+                            @Override
+                            public void remove() {
+                                throw new UnsupportedOperationException("Remove not supported");
+                            }
+                        };
+            }
+            iterators.add(rangeIterator);
+        }
+
+        return iterators;
     }
 
     public static final Option CONFIG_DIR_OPTION =

--- a/shuffle-core/src/main/java/com/alibaba/flink/shuffle/core/utils/UnionIterator.java
+++ b/shuffle-core/src/main/java/com/alibaba/flink/shuffle/core/utils/UnionIterator.java
@@ -1,0 +1,105 @@
+/*
+ * Copyright 2021 The Flink Remote Shuffle Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  	http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.flink.shuffle.core.utils;
+
+import com.alibaba.flink.shuffle.core.exception.TraversableOnceException;
+
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+import java.util.NoSuchElementException;
+
+/**
+ * An iterator that concatenates a collection of iterators. The UnionIterator is a mutable, reusable
+ * type.
+ *
+ * @param <T> The type returned by the iterator. This class is copied from Apache Flink
+ *     (org.apache.flink.util.UnionIterator).
+ */
+public class UnionIterator<T> implements Iterator<T>, Iterable<T> {
+
+    private Iterator<T> currentIterator;
+
+    private ArrayList<Iterator<T>> furtherIterators = new ArrayList<>();
+
+    private int nextIterator;
+
+    private boolean iteratorAvailable = true;
+
+    // ------------------------------------------------------------------------
+
+    public void clear() {
+        currentIterator = null;
+        furtherIterators.clear();
+        nextIterator = 0;
+        iteratorAvailable = true;
+    }
+
+    public void addList(List<T> list) {
+        add(list.iterator());
+    }
+
+    public void add(Iterator<T> iterator) {
+        if (currentIterator == null) {
+            currentIterator = iterator;
+        } else {
+            furtherIterators.add(iterator);
+        }
+    }
+
+    // ------------------------------------------------------------------------
+
+    @Override
+    public Iterator<T> iterator() {
+        if (iteratorAvailable) {
+            iteratorAvailable = false;
+            return this;
+        } else {
+            throw new TraversableOnceException();
+        }
+    }
+
+    @Override
+    public boolean hasNext() {
+        while (currentIterator != null) {
+            if (currentIterator.hasNext()) {
+                return true;
+            } else if (nextIterator < furtherIterators.size()) {
+                currentIterator = furtherIterators.get(nextIterator);
+                nextIterator++;
+            } else {
+                currentIterator = null;
+            }
+        }
+
+        return false;
+    }
+
+    @Override
+    public T next() {
+        if (hasNext()) {
+            return currentIterator.next();
+        } else {
+            throw new NoSuchElementException();
+        }
+    }
+
+    @Override
+    public void remove() {
+        throw new UnsupportedOperationException();
+    }
+}

--- a/shuffle-metrics/pom.xml
+++ b/shuffle-metrics/pom.xml
@@ -26,6 +26,10 @@
 
 	<artifactId>shuffle-metrics</artifactId>
 
+	<properties>
+		<prometheus.version>0.8.1</prometheus.version>
+	</properties>
+
 	<dependencies>
 		<!-- com.alibaba.middleware.metrics is a open source metrics project,
 		reference: https://github.com/alibaba/metrics -->
@@ -65,6 +69,31 @@
 			<groupId>com.alibaba.flink.shuffle</groupId>
 			<artifactId>shuffle-core</artifactId>
 			<version>${project.version}</version>
+		</dependency>
+
+		<dependency>
+			<groupId>io.prometheus</groupId>
+			<artifactId>simpleclient</artifactId>
+			<version>${prometheus.version}</version>
+		</dependency>
+
+		<dependency>
+			<groupId>io.prometheus</groupId>
+			<artifactId>simpleclient_httpserver</artifactId>
+			<version>${prometheus.version}</version>
+		</dependency>
+
+		<dependency>
+			<groupId>io.prometheus</groupId>
+			<artifactId>simpleclient_pushgateway</artifactId>
+			<version>${prometheus.version}</version>
+		</dependency>
+
+		<dependency>
+			<groupId>org.apache.httpcomponents</groupId>
+			<artifactId>httpcore</artifactId>
+			<version>4.1.2</version>
+			<scope>test</scope>
 		</dependency>
 	</dependencies>
 

--- a/shuffle-metrics/src/main/java/com/alibaba/flink/shuffle/metrics/reporter/prometheus/AbstractPrometheusReporter.java
+++ b/shuffle-metrics/src/main/java/com/alibaba/flink/shuffle/metrics/reporter/prometheus/AbstractPrometheusReporter.java
@@ -1,0 +1,334 @@
+/*
+ * Copyright 2021 The Flink Remote Shuffle Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  	http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.flink.shuffle.metrics.reporter.prometheus;
+
+import com.alibaba.metrics.ClusterHistogram;
+import com.alibaba.metrics.Compass;
+import com.alibaba.metrics.Counter;
+import com.alibaba.metrics.FastCompass;
+import com.alibaba.metrics.Gauge;
+import com.alibaba.metrics.Histogram;
+import com.alibaba.metrics.IMetricManager;
+import com.alibaba.metrics.Meter;
+import com.alibaba.metrics.Metric;
+import com.alibaba.metrics.MetricFilter;
+import com.alibaba.metrics.MetricName;
+import com.alibaba.metrics.Snapshot;
+import com.alibaba.metrics.Timer;
+import com.alibaba.metrics.common.config.MetricsCollectPeriodConfig;
+import com.alibaba.metrics.reporter.MetricManagerReporter;
+import io.prometheus.client.Collector;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.AbstractMap;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.TimeUnit;
+import java.util.regex.Pattern;
+
+/** Base prometheus reporter for prometheus metrics. */
+public class AbstractPrometheusReporter extends MetricManagerReporter {
+
+    protected static final Logger LOG = LoggerFactory.getLogger(AbstractPrometheusReporter.class);
+
+    private static final Pattern UNALLOWED_CHAR_PATTERN = Pattern.compile("[^a-zA-Z0-9:_]");
+    private final Map<String, String> commonTags;
+
+    private final Map<String, AbstractMap.SimpleImmutableEntry<Collector, Integer>>
+            collectorsWithCountByMetricName = new ConcurrentHashMap<>();
+
+    public AbstractPrometheusReporter(
+            IMetricManager metricManager,
+            String name,
+            MetricFilter filter,
+            Map<String, String> commonTags,
+            MetricsCollectPeriodConfig metricsReportPeriodConfig,
+            TimeUnit rateUnit,
+            TimeUnit durationUnit) {
+        super(metricManager, name, filter, metricsReportPeriodConfig, rateUnit, durationUnit);
+        this.commonTags = commonTags;
+    }
+
+    @Override
+    public void report(
+            Map<MetricName, Gauge> gauges,
+            Map<MetricName, Counter> counters,
+            Map<MetricName, Histogram> histograms,
+            Map<MetricName, Meter> meters,
+            Map<MetricName, Timer> timers,
+            Map<MetricName, Compass> compasses,
+            Map<MetricName, FastCompass> fastCompasses,
+            Map<MetricName, ClusterHistogram> clusterHistogrames) {
+
+        Arrays.asList(
+                        gauges,
+                        counters,
+                        histograms,
+                        meters,
+                        timers,
+                        compasses,
+                        fastCompasses,
+                        clusterHistogrames)
+                .forEach(this::reportMetrics);
+    }
+
+    private void reportMetrics(Map<MetricName, ? extends Metric> metricMap) {
+        metricMap.forEach(this::sinkIntoCollector);
+    }
+
+    private void sinkIntoCollector(MetricName metricName, Metric metric) {
+
+        String validMetricName = filterCharacters(metricName.getKey());
+
+        List<String> dimensionKeys = new LinkedList<>();
+        List<String> dimensionValues = new LinkedList<>();
+
+        for (final Map.Entry<String, String> tagEntry : commonTags.entrySet()) {
+            dimensionKeys.add(tagEntry.getKey());
+            dimensionValues.add(tagEntry.getValue());
+        }
+
+        for (final Map.Entry<String, String> dimension : metricName.getTags().entrySet()) {
+            dimensionKeys.add(filterCharacters(dimension.getKey()));
+            dimensionValues.add(filterCharacters(dimension.getValue()));
+        }
+        final Collector collector;
+        int count = 0;
+        if (collectorsWithCountByMetricName.containsKey(validMetricName)) {
+            final AbstractMap.SimpleImmutableEntry<Collector, Integer> collectorWithCount =
+                    collectorsWithCountByMetricName.get(validMetricName);
+            collector = collectorWithCount.getKey();
+            count = collectorWithCount.getValue();
+        } else {
+            collector =
+                    createCollector(
+                            metric,
+                            dimensionKeys,
+                            dimensionValues,
+                            validMetricName,
+                            String.format("HELP %s", metricName.getKey()));
+            try {
+                collector.register();
+            } catch (Exception e) {
+                LOG.warn("There was a problem registering metric {}.", validMetricName, e);
+            }
+        }
+        addMetricToCollector(metric, dimensionValues, collector);
+        collectorsWithCountByMetricName.put(
+                validMetricName, new AbstractMap.SimpleImmutableEntry<>(collector, count + 1));
+    }
+
+    private Collector createCollector(
+            Metric metric,
+            List<String> dimensionKeys,
+            List<String> dimensionValues,
+            String scopedMetricName,
+            String helpString) {
+        Collector collector;
+        if (metric instanceof Gauge || metric instanceof Counter || metric instanceof Meter) {
+            collector =
+                    io.prometheus.client.Gauge.build()
+                            .name(scopedMetricName)
+                            .help(helpString)
+                            .labelNames(toArray(dimensionKeys))
+                            .create();
+        } else if (metric instanceof Histogram) {
+            collector =
+                    new HistogramSummaryProxy(
+                            (Histogram) metric,
+                            scopedMetricName,
+                            helpString,
+                            dimensionKeys,
+                            dimensionValues);
+        } else {
+            LOG.warn(
+                    "Cannot create collector for unknown metric type: {}. "
+                            + "Metric types [Timer, Compass, FastCompass, ClusterHistogram] is not supported by this reporter.",
+                    metric.getClass().getName());
+            collector = null;
+        }
+        return collector;
+    }
+
+    static class HistogramSummaryProxy extends Collector {
+        static final String DEFAULT_HELP_STRING = "";
+        static final List<Double> QUANTILES = Arrays.asList(.5, .75, .95, .98, .99, .999);
+
+        private final String metricName;
+        private final String helpString;
+        private final List<String> labelNamesWithQuantile;
+
+        private final Map<List<String>, Histogram> histogramsByLabelValues = new HashMap<>();
+
+        HistogramSummaryProxy(
+                final Histogram histogram,
+                final String metricName,
+                final List<String> labelNames,
+                final List<String> labelValues) {
+            this(histogram, metricName, DEFAULT_HELP_STRING, labelNames, labelValues);
+        }
+
+        HistogramSummaryProxy(
+                final Histogram histogram,
+                final String metricName,
+                final String helpString,
+                final List<String> labelNames,
+                final List<String> labelValues) {
+            this.metricName = metricName;
+            this.helpString = helpString;
+            this.labelNamesWithQuantile = addToList(labelNames, "quantile");
+            histogramsByLabelValues.put(labelValues, histogram);
+        }
+
+        @Override
+        public List<MetricFamilySamples> collect() {
+            // We cannot use SummaryMetricFamily because it is impossible to get a sum of all values
+            // (at least for Dropwizard histograms,
+            // whose snapshot's values array only holds a sample of recent values).
+
+            List<MetricFamilySamples.Sample> samples = new LinkedList<>();
+            for (Map.Entry<List<String>, Histogram> labelValuesToHistogram :
+                    histogramsByLabelValues.entrySet()) {
+                addSamples(
+                        labelValuesToHistogram.getKey(),
+                        labelValuesToHistogram.getValue(),
+                        samples);
+            }
+            return Collections.singletonList(
+                    new MetricFamilySamples(metricName, Type.SUMMARY, helpString, samples));
+        }
+
+        void addChild(final Histogram histogram, final List<String> labelValues) {
+            histogramsByLabelValues.put(labelValues, histogram);
+        }
+
+        void remove(final List<String> labelValues) {
+            histogramsByLabelValues.remove(labelValues);
+        }
+
+        private void addSamples(
+                final List<String> labelValues,
+                final Histogram histogram,
+                final List<MetricFamilySamples.Sample> samples) {
+            samples.add(
+                    new MetricFamilySamples.Sample(
+                            metricName + "_count",
+                            labelNamesWithQuantile.subList(0, labelNamesWithQuantile.size() - 1),
+                            labelValues,
+                            histogram.getCount()));
+            final Snapshot statistics = histogram.getSnapshot();
+
+            for (final Double quantile : QUANTILES) {
+                samples.add(
+                        new MetricFamilySamples.Sample(
+                                metricName,
+                                labelNamesWithQuantile,
+                                addToList(labelValues, quantile.toString()),
+                                statistics.getValue(quantile)));
+            }
+        }
+    }
+
+    private static List<String> addToList(List<String> list, String element) {
+        final List<String> result = new ArrayList<>(list);
+        result.add(element);
+        return result;
+    }
+
+    private static String[] toArray(List<String> list) {
+        return list.toArray(new String[list.size()]);
+    }
+
+    private void addMetricToCollector(
+            Metric metric, List<String> dimensionValues, Collector collector) {
+        if (metric instanceof Gauge) {
+            ((io.prometheus.client.Gauge) collector)
+                    .setChild(gaugeFrom((Gauge) metric), toArray(dimensionValues));
+        } else if (metric instanceof Counter) {
+            ((io.prometheus.client.Gauge) collector)
+                    .setChild(gaugeFrom((Counter) metric), toArray(dimensionValues));
+        } else if (metric instanceof Meter) {
+            ((io.prometheus.client.Gauge) collector)
+                    .setChild(gaugeFrom((Meter) metric), toArray(dimensionValues));
+        } else if (metric instanceof Histogram) {
+            ((HistogramSummaryProxy) collector).addChild((Histogram) metric, dimensionValues);
+        } else {
+            LOG.warn(
+                    "Cannot add unknown metric type: {}. This indicates that the metric type is not supported by this reporter.",
+                    metric.getClass().getName());
+        }
+    }
+
+    io.prometheus.client.Gauge.Child gaugeFrom(Gauge gauge) {
+        return new io.prometheus.client.Gauge.Child() {
+            @Override
+            public double get() {
+                final Object value = gauge.getValue();
+                if (value == null) {
+                    LOG.debug("Gauge {} is null-valued, defaulting to 0.", gauge);
+                    return 0;
+                }
+                if (value instanceof Double) {
+                    return (double) value;
+                }
+                if (value instanceof Number) {
+                    return ((Number) value).doubleValue();
+                }
+                if (value instanceof Boolean) {
+                    return ((Boolean) value) ? 1 : 0;
+                }
+                LOG.debug(
+                        "Invalid type for Gauge {}: {}, only number types and booleans are supported by this reporter.",
+                        gauge,
+                        value.getClass().getName());
+                return 0;
+            }
+        };
+    }
+
+    private static io.prometheus.client.Gauge.Child gaugeFrom(Counter counter) {
+        return new io.prometheus.client.Gauge.Child() {
+            @Override
+            public double get() {
+                return (double) counter.getCount();
+            }
+        };
+    }
+
+    private static io.prometheus.client.Gauge.Child gaugeFrom(Meter meter) {
+        return new io.prometheus.client.Gauge.Child() {
+            @Override
+            public double get() {
+                return meter.getOneMinuteRate();
+            }
+        };
+    }
+
+    private static String filterCharacters(String input) {
+        // https://prometheus.io/docs/instrumenting/writing_exporters/
+        // Only [a-zA-Z0-9:_] are valid in metric names, any other characters should be sanitized to
+        // an underscore.
+        return UNALLOWED_CHAR_PATTERN.matcher(input).replaceAll("_");
+    }
+}

--- a/shuffle-metrics/src/main/java/com/alibaba/flink/shuffle/metrics/reporter/prometheus/PrometheusReporter.java
+++ b/shuffle-metrics/src/main/java/com/alibaba/flink/shuffle/metrics/reporter/prometheus/PrometheusReporter.java
@@ -1,0 +1,151 @@
+/*
+ * Copyright 2021 The Flink Remote Shuffle Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  	http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.flink.shuffle.metrics.reporter.prometheus;
+
+import com.alibaba.metrics.IMetricManager;
+import com.alibaba.metrics.Metric;
+import com.alibaba.metrics.MetricFilter;
+import com.alibaba.metrics.common.config.MetricsCollectPeriodConfig;
+import com.alibaba.metrics.reporter.MetricManagerReporter;
+import io.prometheus.client.exporter.HTTPServer;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.util.Iterator;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+
+/** {@link MetricManagerReporter} that exports {@link Metric Metrics} via Prometheus. */
+public class PrometheusReporter extends AbstractPrometheusReporter {
+
+    protected static final Logger LOG = LoggerFactory.getLogger(PrometheusReporter.class);
+
+    private HTTPServer httpServer;
+    private int port;
+    private static final String INIT_FLAG = "com.alibaba.metrics.file_reporter.init_flag";
+    private static final String REPORTER_NAME = "prometheus-reporter";
+
+    protected PrometheusReporter(
+            Iterator<Integer> ports,
+            Map<String, String> commonTags,
+            IMetricManager metricManager,
+            MetricFilter filter,
+            MetricsCollectPeriodConfig metricsReportPeriodConfig,
+            TimeUnit rateUnit,
+            TimeUnit durationUnit) {
+        super(
+                metricManager,
+                REPORTER_NAME,
+                filter,
+                commonTags,
+                metricsReportPeriodConfig,
+                rateUnit,
+                durationUnit);
+        while (ports.hasNext()) {
+            port = ports.next();
+            try {
+                // internally accesses CollectorRegistry.defaultRegistry
+                httpServer = new HTTPServer(port);
+                LOG.info("Started PrometheusReporter HTTP server on port {}.", port);
+                break;
+            } catch (IOException ioe) { // assume port conflict
+                LOG.debug("Could not start PrometheusReporter HTTP server on port {}.", port, ioe);
+            }
+        }
+
+        if (httpServer == null) {
+            throw new RuntimeException(
+                    "Could not start PrometheusReporter HTTP server on any configured port. Ports: "
+                            + ports);
+        }
+    }
+
+    @Override
+    public void start(long period, TimeUnit unit) {
+        String initFlag = System.getProperty(INIT_FLAG);
+
+        if ("false".equals(initFlag)) {
+            LOG.info("PrometheusReporter disabled...");
+            return;
+        }
+
+        if (initFlag == null) {
+            System.setProperty(INIT_FLAG, "true");
+            super.start(period, unit);
+        } else {
+            LOG.info("PrometheusReporter has been started...");
+        }
+    }
+
+    @Override
+    public void close() {
+        if (httpServer != null) {
+            httpServer.stop();
+        }
+        super.close();
+    }
+
+    /** A builder for PrometheusReporter instances. */
+    public static class Builder {
+        private Iterator<Integer> ports;
+        private MetricFilter filter;
+        private Map<String, String> commonTags;
+        private IMetricManager metricManager;
+        private MetricsCollectPeriodConfig metricsReportPeriodConfig;
+        private TimeUnit rateUnit;
+        private TimeUnit durationUnit;
+
+        Builder(IMetricManager metricManager) {
+            this.metricManager = metricManager;
+            this.rateUnit = TimeUnit.SECONDS;
+            this.durationUnit = TimeUnit.MILLISECONDS;
+            this.filter = MetricFilter.ALL;
+        }
+
+        public PrometheusReporter.Builder ports(Iterator<Integer> ports) {
+            this.ports = ports;
+            return this;
+        }
+
+        public PrometheusReporter.Builder commonTags(Map<String, String> commonTags) {
+            this.commonTags = commonTags;
+            return this;
+        }
+
+        /**
+         * @param metricsReportPeriodConfig
+         * @return
+         */
+        public PrometheusReporter.Builder metricsReportPeriodConfig(
+                MetricsCollectPeriodConfig metricsReportPeriodConfig) {
+            this.metricsReportPeriodConfig = metricsReportPeriodConfig;
+            return this;
+        }
+
+        public PrometheusReporter build() {
+            return new PrometheusReporter(
+                    ports,
+                    commonTags,
+                    metricManager,
+                    filter,
+                    metricsReportPeriodConfig,
+                    rateUnit,
+                    durationUnit);
+        }
+    }
+}

--- a/shuffle-metrics/src/main/java/com/alibaba/flink/shuffle/metrics/reporter/prometheus/PrometheusReporterFactory.java
+++ b/shuffle-metrics/src/main/java/com/alibaba/flink/shuffle/metrics/reporter/prometheus/PrometheusReporterFactory.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2021 The Flink Remote Shuffle Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  	http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.flink.shuffle.metrics.reporter.prometheus;
+
+import com.alibaba.flink.shuffle.common.config.Configuration;
+import com.alibaba.flink.shuffle.core.utils.ConfigurationParserUtils;
+import com.alibaba.flink.shuffle.metrics.reporter.MetricReporterFactory;
+
+import com.alibaba.metrics.common.config.MetricsCollectPeriodConfig;
+import com.alibaba.metrics.reporter.MetricManagerReporter;
+
+import java.time.Duration;
+import java.util.Iterator;
+import java.util.Map;
+import java.util.Properties;
+import java.util.concurrent.TimeUnit;
+
+import static com.alibaba.flink.shuffle.metrics.reporter.prometheus.PrometheusReporterOptions.INTERVAL;
+import static com.alibaba.metrics.MetricManager.getIMetricManager;
+
+/** {@link MetricReporterFactory} for {@link PrometheusReporter}. */
+public class PrometheusReporterFactory implements MetricReporterFactory {
+
+    @Override
+    public MetricManagerReporter createMetricReporter(Properties conf) {
+        Configuration configuration = new Configuration(conf);
+        String portsConfig = configuration.getString(PrometheusReporterOptions.PORTS);
+        Iterator<Integer> ports = ConfigurationParserUtils.getPortRangeFromString(portsConfig);
+        Duration interval = configuration.getDuration(INTERVAL);
+        Map<String, String> commonTags =
+                ConfigurationParserUtils.parseIntoMap(
+                        configuration.getString(PrometheusReporterOptions.COMMON_TAGS));
+
+        PrometheusReporter.Builder builder = new PrometheusReporter.Builder(getIMetricManager());
+        builder.ports(ports);
+        builder.commonTags(commonTags);
+        builder.metricsReportPeriodConfig(
+                new MetricsCollectPeriodConfig((int) interval.getSeconds()));
+
+        // start reporter
+        MetricManagerReporter reporter = builder.build();
+        reporter.start(interval.getSeconds(), TimeUnit.SECONDS);
+        return reporter;
+    }
+}

--- a/shuffle-metrics/src/main/java/com/alibaba/flink/shuffle/metrics/reporter/prometheus/PrometheusReporterOptions.java
+++ b/shuffle-metrics/src/main/java/com/alibaba/flink/shuffle/metrics/reporter/prometheus/PrometheusReporterOptions.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2021 The Flink Remote Shuffle Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  	http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.flink.shuffle.metrics.reporter.prometheus;
+
+import com.alibaba.flink.shuffle.common.config.ConfigOption;
+
+import java.time.Duration;
+
+/** Config options for the {@link PrometheusReporter}. */
+public class PrometheusReporterOptions {
+
+    public static final ConfigOption<String> COMMON_TAGS =
+            new ConfigOption<String>("remote-shuffle.metrics.reporter.prom.common-tags")
+                    .defaultValue("")
+                    .description("Specifies the common tags for all metrics.");
+
+    public static final ConfigOption<Duration> INTERVAL =
+            new ConfigOption<Duration>("remote-shuffle.metrics.reporter.prom.interval")
+                    .defaultValue(Duration.ofSeconds(10))
+                    .description(
+                            "The interval between reports. This is used as a suffix in an actual reporter config.");
+
+    public static final ConfigOption<String> PORTS =
+            new ConfigOption<String>("remote-shuffle.metrics.reporter.prom.ports")
+                    .defaultValue("9349-9359")
+                    .description("The ports for PrometheusServer in pull mode.");
+}

--- a/shuffle-storage/src/main/java/com/alibaba/flink/shuffle/storage/StorageMetricsUtil.java
+++ b/shuffle-storage/src/main/java/com/alibaba/flink/shuffle/storage/StorageMetricsUtil.java
@@ -18,6 +18,7 @@ package com.alibaba.flink.shuffle.storage;
 
 import com.alibaba.flink.shuffle.metrics.entry.MetricUtils;
 
+import com.alibaba.metrics.Counter;
 import com.alibaba.metrics.Gauge;
 import com.alibaba.metrics.Meter;
 
@@ -98,6 +99,10 @@ public class StorageMetricsUtil {
 
     /** Current reading throughput in bytes. */
     public static final String READING_THROUGHPUT_BYTES = STORAGE + ".reading_throughput_bytes";
+
+    public static final String NUM_WRITE_FAILS = STORAGE + ".num_write_fails";
+
+    public static final String NUM_READ_FAILS = STORAGE + ".num_read_fails";
 
     public static void registerTotalNumExecutors(Supplier<Integer> totalNumExecutors) {
         MetricUtils.registerMetric(
@@ -447,5 +452,13 @@ public class StorageMetricsUtil {
 
     public static Meter registerReadingThroughputBytes() {
         return MetricUtils.getMeter(STORAGE, READING_THROUGHPUT_BYTES);
+    }
+
+    public static Counter registerNumWriteFails() {
+        return MetricUtils.getCounter(STORAGE, NUM_WRITE_FAILS);
+    }
+
+    public static Counter registerNumReadFails() {
+        return MetricUtils.getCounter(STORAGE, NUM_READ_FAILS);
     }
 }


### PR DESCRIPTION
## What is the purpose of the change
Support reporting metrics to prometheus


## Brief change log

  - *Support reporting metrics to prometheus*


## Verifying this change

Add Tests:
- `com.alibaba.flink.shuffle.metrics.reporter.PrometheusReporterTest`
- `ConfigurationParserUtilsTest`


This change is already covered by existing tests, such as `com.alibaba.flink.shuffle.metrics.reporter.ReporterSetupTest`

