### PR TITLE
[FRS-69] Add the metrics reporter configuration in documents and modify the delimiter of the metric reporter classes

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -195,11 +195,12 @@ conf/remote-shuffle-conf.yaml file.
 
 ### Metric & Rest Related
 
-| Key | Value Type | Default Value | Version | Required | Description |
-| --- | ---------- | ------------- | ------- | -------- | ----------- |
-| `remote-shuffle.rest.bind-host` | String | `0.0.0.0` | 1.0.0 | false | Local address of the network interface that the rest server binds to. |
-| `remote-shuffle.rest.manager.bind-port` | Integer | `23101` | 1.0.0 | false | `ShuffleManager` rest server bind port. |
-| `remote-shuffle.rest.worker.bind-port` | Integer | `23103` | 1.0.0 | false | `ShuffleWorker` rest server bind port. |
+| Key                                                 | Value Type | Default Value    | Version | Required | Description                                                                                                                                                                                                |
+|-----------------------------------------------------|------------|------------------| ------- | -------- |------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `remote-shuffle.rest.bind-host`                     | String     | `0.0.0.0`        | 1.0.0 | false | Local address of the network interface that the rest server binds to.                                                                                                                                      |
+| `remote-shuffle.rest.manager.bind-port`             | Integer    | `23101`          | 1.0.0 | false | `ShuffleManager` rest server bind port.                                                                                                                                                                    |
+| `remote-shuffle.rest.worker.bind-port`              | Integer    | `23103`          | 1.0.0 | false | `ShuffleWorker` rest server bind port.                                                                                                                                                                     |
+| `remote-shuffle.metrics.reporter.factories`         | String     | `null`           | 1.1.0 | false | Specify the implementation classes of metrics reporter. If there are multiple class names, please separate them by `,`. Each class name needs a package name prefix, e.g. `a.b.c.Factory1,a.b.c.Factory2`. |
 
 ## Options for Deployment
 

--- a/shuffle-metrics/src/main/java/com/alibaba/flink/shuffle/metrics/MetricsConstants.java
+++ b/shuffle-metrics/src/main/java/com/alibaba/flink/shuffle/metrics/MetricsConstants.java
@@ -1,0 +1,49 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.flink.shuffle.metrics;
+
+/** Common constants used in metrics and reporters. */
+public class MetricsConstants {
+
+    /** The prefix string for all reporter configurations. */
+    public static final String METRICS_REPORTER_PREFIX = "metrics.reporter.";
+
+    /** The delimiter used for configurations. */
+    public static final String CONFIGURATION_ARGS_DELIMITER = ",";
+
+    // ---------------------------------------------------------------
+    // Metrics suffixes
+    // ---------------------------------------------------------------
+    public static final String METRIC_COUNT_SUFFIX = "count";
+    public static final String METRIC_MAX_SUFFIX = "max";
+    public static final String METRIC_MIN_SUFFIX = "min";
+    public static final String METRIC_MEAN_SUFFIX = "mean";
+    public static final String METRIC_MEDIAN_SUFFIX = "median";
+    public static final String METRIC_50PERCENTILE_SUFFIX = "50percentile";
+    public static final String METRIC_75PERCENTILE_SUFFIX = "75percentile";
+    public static final String METRIC_95PERCENTILE_SUFFIX = "95percentile";
+    public static final String METRIC_98PERCENTILE_SUFFIX = "98percentile";
+    public static final String METRIC_99PERCENTILE_SUFFIX = "99percentile";
+    public static final String METRIC_999PERCENTILE_SUFFIX = "999percentile";
+    public static final String METRIC_STD_DEV_SUFFIX = "stddev";
+    public static final String METRIC_MEAN_RATE_SUFFIX = "rate_mean";
+    public static final String METRIC_1_MIN_RATE_SUFFIX = "rate_1_min";
+    public static final String METRIC_5_MIN_RATE_SUFFIX = "rate_5_min";
+    public static final String METRIC_15_MIN_RATE_SUFFIX = "rate_15_min";
+}

--- a/shuffle-metrics/src/main/java/com/alibaba/flink/shuffle/metrics/reporter/ReporterSetup.java
+++ b/shuffle-metrics/src/main/java/com/alibaba/flink/shuffle/metrics/reporter/ReporterSetup.java
@@ -28,12 +28,11 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import static com.alibaba.flink.shuffle.core.config.MetricOptions.METRICS_REPORTER_CLASSES;
+import static com.alibaba.flink.shuffle.metrics.MetricsConstants.CONFIGURATION_ARGS_DELIMITER;
 
 /** Encapsulates everything needed for the instantiation and configuration of a metric reporter. */
 public final class ReporterSetup {
     private static final Logger LOG = LoggerFactory.getLogger(ReporterSetup.class);
-
-    private static final String CONFIGURATION_ARGS_DELIMITER = ";";
 
     public static void fromConfiguration(final Configuration conf) {
         String reportersString = conf.getString(METRICS_REPORTER_CLASSES);

--- a/shuffle-metrics/src/test/java/com/alibaba/flink/shuffle/metrics/reporter/ReporterSetupTest.java
+++ b/shuffle-metrics/src/test/java/com/alibaba/flink/shuffle/metrics/reporter/ReporterSetupTest.java
@@ -51,7 +51,7 @@ public class ReporterSetupTest {
         Properties properties = new Properties();
         properties.setProperty(
                 METRICS_REPORTER_CLASSES.key(),
-                "com.alibaba.flink.shuffle.metrics.reporter.FakedMetricReporterFactory;"
+                "com.alibaba.flink.shuffle.metrics.reporter.FakedMetricReporterFactory,"
                         + "com.alibaba.flink.shuffle.metrics.reporter.FakedMetricReporterFactory");
         Configuration conf = new Configuration(properties);
 
@@ -66,7 +66,7 @@ public class ReporterSetupTest {
         Properties properties = new Properties();
         properties.setProperty(
                 METRICS_REPORTER_CLASSES.key(),
-                "com.alibaba.flink.shuffle.metrics.reporter.FakedMetricReporterFactory;"
+                "com.alibaba.flink.shuffle.metrics.reporter.FakedMetricReporterFactory,"
                         + "com.alibaba.flink.shuffle.metrics.reporter.AnotherFakedReporterFactory");
         Configuration conf = new Configuration(properties);
 


### PR DESCRIPTION


<!--

*Thank you very much for contributing to remote-shuffle-service-for-flink. To help the community review your issue or contribution in the best possible way，please take a few minutes to fulfill following items.*

-->

## What is the purpose of the change

*Add the metrics reporter configuration in documents and modify the delimiter of the metric reporter classes*


## Brief change log

  - *Add the metrics reporter configuration in documents.*
  - *Modify the delimiter of the metric reporter classes.*


## Verifying this change

This change is already covered by existing tests, such as *(please describe tests)*.
