### PR TITLE
[FRS-72] Fix the heartbeat issue caused by zookeeper restart

### DIFF
--- a/shuffle-coordinator/src/main/java/com/alibaba/flink/shuffle/coordinator/heartbeat/HeartbeatMonitor.java
+++ b/shuffle-coordinator/src/main/java/com/alibaba/flink/shuffle/coordinator/heartbeat/HeartbeatMonitor.java
@@ -17,7 +17,10 @@
 package com.alibaba.flink.shuffle.coordinator.heartbeat;
 
 import com.alibaba.flink.shuffle.core.ids.InstanceID;
-import com.alibaba.flink.shuffle.rpc.executor.ScheduledExecutor;
+
+import org.slf4j.Logger;
+
+import java.util.concurrent.ScheduledExecutorService;
 
 /**
  * Heartbeat monitor which manages the heartbeat state of the associated heartbeat target. The
@@ -66,16 +69,17 @@ public interface HeartbeatMonitor<O> {
          *
          * @param instanceID the resource id
          * @param heartbeatTarget the heartbeat target
-         * @param mainThreadExecutor the main thread executor
          * @param heartbeatListener the heartbeat listener
          * @param heartbeatTimeoutIntervalMs the heartbeat timeout interval ms
+         * @param log for logging
          * @return the heartbeat monitor
          */
         HeartbeatMonitor<O> createHeartbeatMonitor(
                 InstanceID instanceID,
                 HeartbeatTarget<O> heartbeatTarget,
-                ScheduledExecutor mainThreadExecutor,
+                ScheduledExecutorService scheduledExecutor,
                 HeartbeatListener<?, O> heartbeatListener,
-                long heartbeatTimeoutIntervalMs);
+                long heartbeatTimeoutIntervalMs,
+                Logger log);
     }
 }

--- a/shuffle-coordinator/src/main/java/com/alibaba/flink/shuffle/coordinator/heartbeat/HeartbeatServices.java
+++ b/shuffle-coordinator/src/main/java/com/alibaba/flink/shuffle/coordinator/heartbeat/HeartbeatServices.java
@@ -17,9 +17,10 @@
 package com.alibaba.flink.shuffle.coordinator.heartbeat;
 
 import com.alibaba.flink.shuffle.core.ids.InstanceID;
-import com.alibaba.flink.shuffle.rpc.executor.ScheduledExecutor;
 
 import org.slf4j.Logger;
+
+import java.util.concurrent.ScheduledExecutorService;
 
 import static com.alibaba.flink.shuffle.common.utils.CommonUtils.checkArgument;
 
@@ -51,7 +52,7 @@ public class HeartbeatServices {
      * @param instanceID Resource Id which identifies the owner of the heartbeat manager
      * @param heartbeatListener Listener which will be notified upon heartbeat timeouts for
      *     registered targets
-     * @param mainThreadExecutor Scheduled executor to be used for scheduling heartbeat timeouts
+     * @param scheduledExecutor Scheduled executor to be used for scheduling heartbeat timeouts
      * @param log Logger to be used for the logging
      * @param <I> Type of the incoming payload
      * @param <O> Type of the outgoing payload
@@ -60,11 +61,11 @@ public class HeartbeatServices {
     public <I, O> HeartbeatManager<I, O> createHeartbeatManager(
             InstanceID instanceID,
             HeartbeatListener<I, O> heartbeatListener,
-            ScheduledExecutor mainThreadExecutor,
+            ScheduledExecutorService scheduledExecutor,
             Logger log) {
 
         return new HeartbeatManagerImpl<>(
-                heartbeatTimeout, instanceID, heartbeatListener, mainThreadExecutor, log);
+                heartbeatTimeout, instanceID, heartbeatListener, scheduledExecutor, log);
     }
 
     /**
@@ -73,7 +74,7 @@ public class HeartbeatServices {
      * @param instanceID Resource Id which identifies the owner of the heartbeat manager
      * @param heartbeatListener Listener which will be notified upon heartbeat timeouts for
      *     registered targets
-     * @param mainThreadExecutor Scheduled executor to be used for scheduling heartbeat timeouts and
+     * @param scheduledExecutor Scheduled executor to be used for scheduling heartbeat timeouts and
      *     periodically send heartbeat requests
      * @param log Logger to be used for the logging
      * @param <I> Type of the incoming payload
@@ -83,7 +84,7 @@ public class HeartbeatServices {
     public <I, O> HeartbeatManager<I, O> createHeartbeatManagerSender(
             InstanceID instanceID,
             HeartbeatListener<I, O> heartbeatListener,
-            ScheduledExecutor mainThreadExecutor,
+            ScheduledExecutorService scheduledExecutor,
             Logger log) {
 
         return new HeartbeatManagerSenderImpl<>(
@@ -91,7 +92,7 @@ public class HeartbeatServices {
                 heartbeatTimeout,
                 instanceID,
                 heartbeatListener,
-                mainThreadExecutor,
+                scheduledExecutor,
                 log);
     }
 

--- a/shuffle-coordinator/src/main/java/com/alibaba/flink/shuffle/coordinator/manager/assignmenttracker/AssignmentTrackerImpl.java
+++ b/shuffle-coordinator/src/main/java/com/alibaba/flink/shuffle/coordinator/manager/assignmenttracker/AssignmentTrackerImpl.java
@@ -111,8 +111,8 @@ public class AssignmentTrackerImpl implements AssignmentTracker {
         ClusterMetricsUtil.registerNumShuffleWorkers(workers::size);
         ClusterMetricsUtil.registerHddMaxFreeBytes(this::getHddMaxStorageFreeSpace);
         ClusterMetricsUtil.registerSsdMaxFreeBytes(this::getSsdMaxStorageFreeSpace);
-        ClusterMetricsUtil.registerHddMaxUsedBytes(this::getHddMaxStorageFreeSpace);
-        ClusterMetricsUtil.registerSsdMaxUsedBytes(this::getSsdMaxStorageFreeSpace);
+        ClusterMetricsUtil.registerHddMaxUsedBytes(this::getHddMaxStorageUsedSpace);
+        ClusterMetricsUtil.registerSsdMaxUsedBytes(this::getSsdMaxStorageUsedSpace);
     }
 
     public long getHddMaxStorageFreeSpace() {

--- a/shuffle-coordinator/src/main/java/com/alibaba/flink/shuffle/coordinator/manager/entrypoint/ShuffleManagerEntrypoint.java
+++ b/shuffle-coordinator/src/main/java/com/alibaba/flink/shuffle/coordinator/manager/entrypoint/ShuffleManagerEntrypoint.java
@@ -49,8 +49,8 @@ import java.util.Collection;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
-import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -83,7 +83,7 @@ public class ShuffleManagerEntrypoint implements AutoCloseableAsync, FatalErrorH
 
     private final RemoteShuffleRpcService shuffleRpcService;
 
-    private final ExecutorService ioExecutor;
+    private final ScheduledExecutorService ioExecutor;
 
     private final ShuffleManager shuffleManager;
 
@@ -110,7 +110,8 @@ public class ShuffleManagerEntrypoint implements AutoCloseableAsync, FatalErrorH
         configuration.setString(ManagerOptions.RPC_ADDRESS, shuffleRpcService.getAddress());
         configuration.setInteger(ManagerOptions.RPC_PORT, shuffleRpcService.getPort());
 
-        this.ioExecutor = Executors.newFixedThreadPool(1, new ExecutorThreadFactory("cluster-io"));
+        this.ioExecutor =
+                Executors.newSingleThreadScheduledExecutor(new ExecutorThreadFactory("cluster-io"));
 
         this.haServices = HaServiceUtils.createHAServices(configuration);
 

--- a/shuffle-coordinator/src/main/java/com/alibaba/flink/shuffle/minicluster/ShuffleMiniCluster.java
+++ b/shuffle-coordinator/src/main/java/com/alibaba/flink/shuffle/minicluster/ShuffleMiniCluster.java
@@ -56,8 +56,8 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 
 import static com.alibaba.flink.shuffle.common.utils.CommonUtils.checkNotNull;
@@ -91,7 +91,7 @@ public class ShuffleMiniCluster implements AutoCloseableAsync {
     private final Collection<RemoteShuffleRpcService> rpcServices;
 
     @GuardedBy("lock")
-    private ExecutorService ioExecutor;
+    private ScheduledExecutorService ioExecutor;
 
     @GuardedBy("lock")
     private HeartbeatServices workerHeartbeatServices;
@@ -197,8 +197,8 @@ public class ShuffleMiniCluster implements AutoCloseableAsync {
                                 configuration, null, "0", shuffleManagerBindAddress);
 
                 ioExecutor =
-                        Executors.newFixedThreadPool(
-                                1, new ExecutorThreadFactory("mini-cluster-io"));
+                        Executors.newSingleThreadScheduledExecutor(
+                                new ExecutorThreadFactory("mini-cluster-io"));
 
                 workerHeartbeatServices =
                         HeartbeatServicesUtils.createManagerWorkerHeartbeatServices(configuration);

--- a/shuffle-coordinator/src/test/java/com/alibaba/flink/shuffle/coordinator/heartbeat/HeartbeatManagerTest.java
+++ b/shuffle-coordinator/src/test/java/com/alibaba/flink/shuffle/coordinator/heartbeat/HeartbeatManagerTest.java
@@ -20,8 +20,6 @@ import com.alibaba.flink.shuffle.coordinator.utils.TestingUtils;
 import com.alibaba.flink.shuffle.core.ids.InstanceID;
 import com.alibaba.flink.shuffle.core.utils.OneShotLatch;
 import com.alibaba.flink.shuffle.core.utils.TestLogger;
-import com.alibaba.flink.shuffle.rpc.executor.ScheduledExecutor;
-import com.alibaba.flink.shuffle.rpc.executor.ScheduledExecutorServiceAdapter;
 
 import org.hamcrest.Matcher;
 import org.junit.Test;
@@ -33,6 +31,7 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.ArrayBlockingQueue;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.ScheduledThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
@@ -114,7 +113,7 @@ public class HeartbeatManagerTest extends TestLogger {
         InstanceID targetInstanceID = new InstanceID("barfoo");
         @SuppressWarnings("unchecked")
         HeartbeatListener<Object, Object> heartbeatListener = mock(HeartbeatListener.class);
-        ScheduledExecutor scheduledExecutor = mock(ScheduledExecutor.class);
+        ScheduledExecutorService scheduledExecutor = mock(ScheduledExecutorService.class);
         ScheduledFuture<?> scheduledFuture = mock(ScheduledFuture.class);
 
         doReturn(scheduledFuture)
@@ -314,7 +313,7 @@ public class HeartbeatManagerTest extends TestLogger {
                         heartbeatTimeout,
                         instanceID,
                         heartbeatListener,
-                        mock(ScheduledExecutor.class),
+                        mock(ScheduledExecutorService.class),
                         LOG);
 
         try {
@@ -340,7 +339,7 @@ public class HeartbeatManagerTest extends TestLogger {
                         heartbeatTimeout,
                         instanceID,
                         heartbeatListener,
-                        mock(ScheduledExecutor.class),
+                        mock(ScheduledExecutorService.class),
                         LOG);
 
         try {
@@ -448,7 +447,7 @@ public class HeartbeatManagerTest extends TestLogger {
                         new InstanceID(),
                         new TargetDependentHeartbeatSender(
                                 specialTargetId, specialResponse, defaultResponse),
-                        new ScheduledExecutorServiceAdapter(scheduledThreadPoolExecutor),
+                        scheduledThreadPoolExecutor,
                         LOG);
 
         try {

--- a/shuffle-coordinator/src/test/java/com/alibaba/flink/shuffle/coordinator/heartbeat/TestingHeartbeatServices.java
+++ b/shuffle-coordinator/src/test/java/com/alibaba/flink/shuffle/coordinator/heartbeat/TestingHeartbeatServices.java
@@ -17,7 +17,6 @@
 package com.alibaba.flink.shuffle.coordinator.heartbeat;
 
 import com.alibaba.flink.shuffle.core.ids.InstanceID;
-import com.alibaba.flink.shuffle.rpc.executor.ScheduledExecutor;
 
 import org.slf4j.Logger;
 
@@ -25,6 +24,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ScheduledExecutorService;
 
 import static com.alibaba.flink.shuffle.common.utils.CommonUtils.checkState;
 
@@ -62,7 +62,7 @@ public class TestingHeartbeatServices extends HeartbeatServices {
     public <I, O> HeartbeatManager<I, O> createHeartbeatManager(
             InstanceID instanceID,
             HeartbeatListener<I, O> heartbeatListener,
-            ScheduledExecutor mainThreadExecutor,
+            ScheduledExecutorService scheduledExecutor,
             Logger log) {
 
         HeartbeatManagerImpl<I, O> heartbeatManager =
@@ -70,7 +70,7 @@ public class TestingHeartbeatServices extends HeartbeatServices {
                         heartbeatTimeout,
                         instanceID,
                         heartbeatListener,
-                        mainThreadExecutor,
+                        scheduledExecutor,
                         log,
                         new TestingHeartbeatMonitorFactory<>());
 
@@ -97,7 +97,7 @@ public class TestingHeartbeatServices extends HeartbeatServices {
     public <I, O> HeartbeatManager<I, O> createHeartbeatManagerSender(
             InstanceID instanceID,
             HeartbeatListener<I, O> heartbeatListener,
-            ScheduledExecutor mainThreadExecutor,
+            ScheduledExecutorService scheduledExecutor,
             Logger log) {
 
         HeartbeatManagerSenderImpl<I, O> heartbeatManager =
@@ -106,7 +106,7 @@ public class TestingHeartbeatServices extends HeartbeatServices {
                         heartbeatTimeout,
                         instanceID,
                         heartbeatListener,
-                        mainThreadExecutor,
+                        scheduledExecutor,
                         log,
                         new TestingHeartbeatMonitorFactory<>());
 
@@ -178,16 +178,18 @@ public class TestingHeartbeatServices extends HeartbeatServices {
         public HeartbeatMonitor<O> createHeartbeatMonitor(
                 InstanceID instanceID,
                 HeartbeatTarget<O> heartbeatTarget,
-                ScheduledExecutor mainThreadExecutor,
+                ScheduledExecutorService scheduledExecutor,
                 HeartbeatListener<?, O> heartbeatListener,
-                long heartbeatTimeoutIntervalMs) {
+                long heartbeatTimeoutIntervalMs,
+                Logger log) {
 
             return new TestingHeartbeatMonitor<>(
                     instanceID,
                     heartbeatTarget,
-                    mainThreadExecutor,
+                    scheduledExecutor,
                     heartbeatListener,
-                    heartbeatTimeoutIntervalMs);
+                    heartbeatTimeoutIntervalMs,
+                    log);
         }
     }
 
@@ -203,16 +205,18 @@ public class TestingHeartbeatServices extends HeartbeatServices {
         TestingHeartbeatMonitor(
                 InstanceID instanceID,
                 HeartbeatTarget<O> heartbeatTarget,
-                ScheduledExecutor scheduledExecutor,
+                ScheduledExecutorService scheduledExecutor,
                 HeartbeatListener<?, O> heartbeatListener,
-                long heartbeatTimeoutIntervalMs) {
+                long heartbeatTimeoutIntervalMs,
+                Logger log) {
 
             super(
                     instanceID,
                     heartbeatTarget,
                     scheduledExecutor,
                     heartbeatListener,
-                    heartbeatTimeoutIntervalMs);
+                    heartbeatTimeoutIntervalMs,
+                    log);
         }
 
         @Override

--- a/shuffle-coordinator/src/test/java/com/alibaba/flink/shuffle/coordinator/manager/ShuffleManagerHATest.java
+++ b/shuffle-coordinator/src/test/java/com/alibaba/flink/shuffle/coordinator/manager/ShuffleManagerHATest.java
@@ -25,6 +25,7 @@ import com.alibaba.flink.shuffle.coordinator.leaderelection.TestingLeaderElectio
 import com.alibaba.flink.shuffle.coordinator.manager.assignmenttracker.AssignmentTracker;
 import com.alibaba.flink.shuffle.coordinator.manager.assignmenttracker.ChangedWorkerStatus;
 import com.alibaba.flink.shuffle.coordinator.utils.TestingFatalErrorHandler;
+import com.alibaba.flink.shuffle.coordinator.utils.TestingUtils;
 import com.alibaba.flink.shuffle.coordinator.worker.ShuffleWorkerGateway;
 import com.alibaba.flink.shuffle.core.ids.DataPartitionID;
 import com.alibaba.flink.shuffle.core.ids.DataSetID;
@@ -44,7 +45,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.ForkJoinPool;
 
 /** Tests for the ShuffleManager HA. */
 public class ShuffleManagerHATest {
@@ -82,7 +82,7 @@ public class ShuffleManagerHATest {
                         rmInstanceID,
                         highAvailabilityServices,
                         testingFatalErrorHandler,
-                        ForkJoinPool.commonPool(),
+                        TestingUtils.defaultScheduledExecutor(),
                         new HeartbeatServices(100, 200),
                         new HeartbeatServices(100, 200),
                         new TestAssignmentTracker()) {

--- a/shuffle-coordinator/src/test/java/com/alibaba/flink/shuffle/coordinator/manager/ShuffleManagerTest.java
+++ b/shuffle-coordinator/src/test/java/com/alibaba/flink/shuffle/coordinator/manager/ShuffleManagerTest.java
@@ -57,7 +57,6 @@ import java.util.Map;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
-import java.util.concurrent.ForkJoinPool;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 
@@ -616,7 +615,7 @@ public class ShuffleManagerTest extends TestLogger {
                         shuffleManagerInstanceID,
                         highAvailabilityServices,
                         testingFatalErrorHandler,
-                        ForkJoinPool.commonPool(),
+                        TestingUtils.defaultScheduledExecutor(),
                         heartbeatServices,
                         heartbeatServices,
                         testAssignmentTracker);

--- a/shuffle-coordinator/src/test/java/com/alibaba/flink/shuffle/coordinator/utils/RecordingHeartbeatServices.java
+++ b/shuffle-coordinator/src/test/java/com/alibaba/flink/shuffle/coordinator/utils/RecordingHeartbeatServices.java
@@ -23,12 +23,12 @@ import com.alibaba.flink.shuffle.coordinator.heartbeat.HeartbeatManagerSenderImp
 import com.alibaba.flink.shuffle.coordinator.heartbeat.HeartbeatServices;
 import com.alibaba.flink.shuffle.coordinator.heartbeat.HeartbeatTarget;
 import com.alibaba.flink.shuffle.core.ids.InstanceID;
-import com.alibaba.flink.shuffle.rpc.executor.ScheduledExecutor;
 
 import org.slf4j.Logger;
 
 import java.util.concurrent.ArrayBlockingQueue;
 import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.ScheduledExecutorService;
 
 /** Special {@link HeartbeatServices} which records the unmonitored targets. */
 public class RecordingHeartbeatServices extends HeartbeatServices {
@@ -48,13 +48,13 @@ public class RecordingHeartbeatServices extends HeartbeatServices {
     public <I, O> HeartbeatManager<I, O> createHeartbeatManager(
             InstanceID instanceID,
             HeartbeatListener<I, O> heartbeatListener,
-            ScheduledExecutor mainThreadExecutor,
+            ScheduledExecutorService scheduledExecutor,
             Logger log) {
         return new RecordingHeartbeatManagerImpl<>(
                 heartbeatTimeout,
                 instanceID,
                 heartbeatListener,
-                mainThreadExecutor,
+                scheduledExecutor,
                 log,
                 unmonitoredTargets,
                 monitoredTargets);
@@ -64,14 +64,14 @@ public class RecordingHeartbeatServices extends HeartbeatServices {
     public <I, O> HeartbeatManager<I, O> createHeartbeatManagerSender(
             InstanceID instanceID,
             HeartbeatListener<I, O> heartbeatListener,
-            ScheduledExecutor mainThreadExecutor,
+            ScheduledExecutorService scheduledExecutor,
             Logger log) {
         return new RecordingHeartbeatManagerSenderImpl<>(
                 heartbeatInterval,
                 heartbeatTimeout,
                 instanceID,
                 heartbeatListener,
-                mainThreadExecutor,
+                scheduledExecutor,
                 log,
                 unmonitoredTargets,
                 monitoredTargets);
@@ -97,7 +97,7 @@ public class RecordingHeartbeatServices extends HeartbeatServices {
                 long heartbeatTimeoutIntervalMs,
                 InstanceID ownInstanceID,
                 HeartbeatListener<I, O> heartbeatListener,
-                ScheduledExecutor mainThreadExecutor,
+                ScheduledExecutorService scheduledExecutor,
                 Logger log,
                 BlockingQueue<InstanceID> unmonitoredTargets,
                 BlockingQueue<InstanceID> monitoredTargets) {
@@ -105,7 +105,7 @@ public class RecordingHeartbeatServices extends HeartbeatServices {
                     heartbeatTimeoutIntervalMs,
                     ownInstanceID,
                     heartbeatListener,
-                    mainThreadExecutor,
+                    scheduledExecutor,
                     log);
             this.unmonitoredTargets = unmonitoredTargets;
             this.monitoredTargets = monitoredTargets;
@@ -137,7 +137,7 @@ public class RecordingHeartbeatServices extends HeartbeatServices {
                 long heartbeatTimeout,
                 InstanceID ownInstanceID,
                 HeartbeatListener<I, O> heartbeatListener,
-                ScheduledExecutor mainThreadExecutor,
+                ScheduledExecutorService scheduledExecutor,
                 Logger log,
                 BlockingQueue<InstanceID> unmonitoredTargets,
                 BlockingQueue<InstanceID> monitoredTargets) {
@@ -146,7 +146,7 @@ public class RecordingHeartbeatServices extends HeartbeatServices {
                     heartbeatTimeout,
                     ownInstanceID,
                     heartbeatListener,
-                    mainThreadExecutor,
+                    scheduledExecutor,
                     log);
             this.unmonitoredTargets = unmonitoredTargets;
             this.monitoredTargets = monitoredTargets;

--- a/shuffle-coordinator/src/test/java/com/alibaba/flink/shuffle/coordinator/utils/TestingUtils.java
+++ b/shuffle-coordinator/src/test/java/com/alibaba/flink/shuffle/coordinator/utils/TestingUtils.java
@@ -16,9 +16,6 @@
 
 package com.alibaba.flink.shuffle.coordinator.utils;
 
-import com.alibaba.flink.shuffle.rpc.executor.ScheduledExecutor;
-import com.alibaba.flink.shuffle.rpc.executor.ScheduledExecutorServiceAdapter;
-
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 
@@ -27,10 +24,10 @@ public class TestingUtils {
 
     private static ScheduledExecutorService scheduledExecutor;
 
-    public static synchronized ScheduledExecutor defaultScheduledExecutor() {
+    public static synchronized ScheduledExecutorService defaultScheduledExecutor() {
         if (scheduledExecutor == null || scheduledExecutor.isShutdown()) {
             scheduledExecutor = Executors.newSingleThreadScheduledExecutor();
         }
-        return new ScheduledExecutorServiceAdapter(scheduledExecutor);
+        return scheduledExecutor;
     }
 }

--- a/shuffle-e2e-tests/src/test/java/com/alibaba/flink/shuffle/e2e/AbstractInstableE2ETest.java
+++ b/shuffle-e2e-tests/src/test/java/com/alibaba/flink/shuffle/e2e/AbstractInstableE2ETest.java
@@ -60,7 +60,7 @@ public class AbstractInstableE2ETest {
             FileUtils.deleteDirectory(logDir);
         }
 
-        zkEnv = new ZooKeeperTestEnvironment(1);
+        zkEnv = new ZooKeeperTestEnvironment();
         String zkConnect = zkEnv.getConnect();
         String logPath = logDir.getAbsolutePath();
         shuffleCluster =

--- a/shuffle-e2e-tests/src/test/java/com/alibaba/flink/shuffle/e2e/InstableZookeeperE2ETest.java
+++ b/shuffle-e2e-tests/src/test/java/com/alibaba/flink/shuffle/e2e/InstableZookeeperE2ETest.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2021 The Flink Remote Shuffle Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  	http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.flink.shuffle.e2e;
+
+import com.alibaba.flink.shuffle.common.config.Configuration;
+import com.alibaba.flink.shuffle.core.config.HeartbeatOptions;
+import com.alibaba.flink.shuffle.e2e.shufflecluster.LocalShuffleCluster;
+
+import org.junit.Test;
+
+import java.nio.file.Path;
+import java.time.Duration;
+
+import static org.junit.Assert.assertEquals;
+
+/** Tests for instable Zookeeper. */
+public class InstableZookeeperE2ETest extends AbstractInstableE2ETest {
+
+    @Test(timeout = 180000)
+    public void testZookeeperRestart() throws Exception {
+        assertNumWorkers(2);
+
+        zkEnv.restart();
+        assertNumWorkers(2);
+
+        shuffleCluster.killShuffleWorker(0);
+        assertNumWorkers(1);
+        for (int i = 0; i < 100; ++i) {
+            assertEquals(1, shuffleCluster.getNumRegisteredWorkers());
+            Thread.sleep(100);
+        }
+
+        shuffleCluster.recoverShuffleWorker(0);
+        assertNumWorkers(2);
+        for (int i = 0; i < 100; ++i) {
+            assertEquals(2, shuffleCluster.getNumRegisteredWorkers());
+            Thread.sleep(100);
+        }
+    }
+
+    private void assertNumWorkers(int expected) throws Exception {
+        while (true) {
+            try {
+                int numWorkers = shuffleCluster.getNumRegisteredWorkers();
+                if (numWorkers == expected) {
+                    break;
+                }
+            } catch (Throwable ignored) {
+                Thread.sleep(100);
+            }
+        }
+    }
+
+    @Override
+    protected LocalShuffleCluster createLocalShuffleCluster(
+            String logPath, String zkConnect, Path dataPath) {
+        Configuration configuration = new Configuration();
+        configuration.setDuration(
+                HeartbeatOptions.HEARTBEAT_WORKER_INTERVAL, Duration.ofSeconds(1));
+        configuration.setDuration(HeartbeatOptions.HEARTBEAT_WORKER_TIMEOUT, Duration.ofSeconds(5));
+        return new LocalShuffleCluster(logPath, 2, zkConnect, dataPath, configuration);
+    }
+}

--- a/shuffle-e2e-tests/src/test/java/com/alibaba/flink/shuffle/e2e/ShuffleManagerHAE2ETest.java
+++ b/shuffle-e2e-tests/src/test/java/com/alibaba/flink/shuffle/e2e/ShuffleManagerHAE2ETest.java
@@ -63,7 +63,7 @@ public class ShuffleManagerHAE2ETest {
 
     @Before
     public void setup() throws Exception {
-        zkCluster = new ZooKeeperTestEnvironment(1);
+        zkCluster = new ZooKeeperTestEnvironment();
 
         logDir =
                 new File(

--- a/shuffle-e2e-tests/src/test/java/com/alibaba/flink/shuffle/e2e/ShuffleManagerLostE2ETest.java
+++ b/shuffle-e2e-tests/src/test/java/com/alibaba/flink/shuffle/e2e/ShuffleManagerLostE2ETest.java
@@ -73,7 +73,7 @@ public class ShuffleManagerLostE2ETest {
 
     @Before
     public void setup() throws Exception {
-        zkCluster = new ZooKeeperTestEnvironment(1);
+        zkCluster = new ZooKeeperTestEnvironment();
 
         logDir =
                 new File(

--- a/shuffle-e2e-tests/src/test/java/com/alibaba/flink/shuffle/e2e/flinkcluster/FlinkLocalClusterE2ETest.java
+++ b/shuffle-e2e-tests/src/test/java/com/alibaba/flink/shuffle/e2e/flinkcluster/FlinkLocalClusterE2ETest.java
@@ -60,7 +60,7 @@ public class FlinkLocalClusterE2ETest {
             FileUtils.deleteDirectory(logDir);
         }
 
-        zkCluster = new ZooKeeperTestEnvironment(1);
+        zkCluster = new ZooKeeperTestEnvironment();
         cluster =
                 new FlinkLocalCluster(
                         logDir.getAbsolutePath(),

--- a/shuffle-e2e-tests/src/test/java/com/alibaba/flink/shuffle/e2e/shufflecluster/LocalShuffleCluster.java
+++ b/shuffle-e2e-tests/src/test/java/com/alibaba/flink/shuffle/e2e/shufflecluster/LocalShuffleCluster.java
@@ -175,6 +175,10 @@ public class LocalShuffleCluster {
         LOG.info("Local shuffle cluster started successfully.");
     }
 
+    public int getNumRegisteredWorkers() throws Exception {
+        return shuffleManagerClient.getNumberOfRegisteredWorkers().get();
+    }
+
     public String getDataDirForWorker(int index) {
         return new File(parentDataDir.toFile(), "ShuffleWorker-" + index).getAbsolutePath();
     }

--- a/shuffle-e2e-tests/src/test/java/com/alibaba/flink/shuffle/e2e/shufflecluster/LocalShuffleClusterE2ETest.java
+++ b/shuffle-e2e-tests/src/test/java/com/alibaba/flink/shuffle/e2e/shufflecluster/LocalShuffleClusterE2ETest.java
@@ -67,7 +67,7 @@ public class LocalShuffleClusterE2ETest {
             FileUtils.deleteDirectory(logDir);
         }
 
-        zkCluster = new ZooKeeperTestEnvironment(1);
+        zkCluster = new ZooKeeperTestEnvironment();
         cluster =
                 new LocalShuffleCluster(
                         logDir.getAbsolutePath(),

--- a/shuffle-e2e-tests/src/test/java/com/alibaba/flink/shuffle/e2e/zookeeper/ZooKeeperTestEnvironment.java
+++ b/shuffle-e2e-tests/src/test/java/com/alibaba/flink/shuffle/e2e/zookeeper/ZooKeeperTestEnvironment.java
@@ -16,58 +16,32 @@
 
 package com.alibaba.flink.shuffle.e2e.zookeeper;
 
-import org.apache.curator.test.TestingCluster;
 import org.apache.curator.test.TestingServer;
 
 /** Simple ZooKeeper and CuratorFramework setup for tests. */
 public class ZooKeeperTestEnvironment {
 
     private final TestingServer zooKeeperServer;
-    private final TestingCluster zooKeeperCluster;
 
-    /**
-     * Starts a ZooKeeper cluster with the number of quorum peers and a client.
-     *
-     * @param numberOfZooKeeperQuorumPeers Starts a {@link TestingServer}, if <code>1</code>. Starts
-     *     a {@link TestingCluster}, if <code>=>1</code>.
-     */
-    public ZooKeeperTestEnvironment(int numberOfZooKeeperQuorumPeers) {
-        if (numberOfZooKeeperQuorumPeers <= 0) {
-            throw new IllegalArgumentException("Number of peers needs to be >= 1.");
-        }
-
+    /** Starts a ZooKeeper server and a client. */
+    public ZooKeeperTestEnvironment() {
         try {
-            if (numberOfZooKeeperQuorumPeers == 1) {
-                zooKeeperServer = new TestingServer(true);
-                zooKeeperCluster = null;
-            } else {
-                zooKeeperServer = null;
-                zooKeeperCluster = new TestingCluster(numberOfZooKeeperQuorumPeers);
-
-                zooKeeperCluster.start();
-            }
+            zooKeeperServer = new TestingServer(true);
         } catch (Exception e) {
             throw new RuntimeException("Error setting up ZooKeeperTestEnvironment", e);
         }
     }
 
+    public void restart() throws Exception {
+        zooKeeperServer.restart();
+    }
+
     /** Shutdown the client and ZooKeeper server/cluster. */
     public void shutdown() throws Exception {
-
-        if (zooKeeperServer != null) {
-            zooKeeperServer.close();
-        }
-
-        if (zooKeeperCluster != null) {
-            zooKeeperCluster.close();
-        }
+        zooKeeperServer.close();
     }
 
     public String getConnect() {
-        if (zooKeeperServer != null) {
-            return zooKeeperServer.getConnectString();
-        } else {
-            return zooKeeperCluster.getConnectString();
-        }
+        return zooKeeperServer.getConnectString();
     }
 }


### PR DESCRIPTION
## What is the purpose of the change

This resolves #72 . Currently, the shuffle manager may fail to remove a lost shuffle worker if the Zookeeper restart which will cause the change of RPC main thread executor. This patch fixes the issue.

## Brief change log

  - Add e2e test to cover the scenario.
  - Use the cluster IO executor to perform heartbeat timeout check.
  - Fix a metric issue as a hotfix commit.


## Verifying this change

This change added tests.
