### PR TITLE
[FRS-79] Fix the bug that BaseMapPartition may not read data sequentially

### DIFF
--- a/docs/deploy_on_yarn.md
+++ b/docs/deploy_on_yarn.md
@@ -105,7 +105,20 @@ export HADOOP_CLASSPATH=$HADOOP_CLASSPATH:<the path that contains the JAR>/shuff
     </property>
 ```
 
-4. Restart all `NodeManager`s in your cluster. Note that the heap and direct memory size of `NodeManager` should be increased to avoid `out of memory` problems. The heap size of `ShuffleWorker` is mainly used by `remote-shuffle.worker.memory.heap-size`, which is 1g by default. The direct memory used includes `remote-shuffle.worker.memory.off-heap-size`(128m by default), `remote-shuffle.memory.data-writing-size`(4g by default) and `remote-shuffle.memory.data-reading-size`(4g by default). In total, please increase at least 1g heap size and 8.2g direct memory size by default for `NodeManager`. In your production environment, you can adjust these configurations to change the memory usage of `ShuffleWorker`.
+4. In addition, you also need to add the configurations of YARN aux service. Please refer to [YARN pluggable shuffle configurations](https://hadoop.apache.org/docs/r2.7.7/hadoop-mapreduce-client/hadoop-mapreduce-client-core/PluggableShuffleAndPluggableSort.html). You can alse add the following configurations to `etc/hadoop/yarn-site.xml` directly.
+```
+    <property>
+      <name>yarn.nodemanager.aux-services</name>
+      <value>REPLACE_THIS_WITH_OTHER_SERVICE_NAMES,flink_remote_shuffle</value>
+    </property>
+
+    <property>
+      <name>yarn.nodemanager.aux-services.flink_remote_shuffle.class</name>
+      <value>com.alibaba.flink.shuffle.yarn.entry.worker.YarnShuffleWorkerEntrypoint</value>
+    </property>
+```
+
+5. Restart all `NodeManager`s in your cluster. Note that the heap and direct memory size of `NodeManager` should be increased to avoid `out of memory` problems. The heap size of `ShuffleWorker` is mainly used by `remote-shuffle.worker.memory.heap-size`, which is 1g by default. The direct memory used includes `remote-shuffle.worker.memory.off-heap-size`(128m by default), `remote-shuffle.memory.data-writing-size`(4g by default) and `remote-shuffle.memory.data-reading-size`(4g by default). In total, please increase at least 1g heap size and 8.2g direct memory size by default for `NodeManager`. In your production environment, you can adjust these configurations to change the memory usage of `ShuffleWorker`.
 
 Alternatively, when starting a local standalone or YARN cluster on your laptop, you can reduce `remote-shuffle.memory.data-reading-size` or `remote-shuffle.memory.data-writing-size` to decrease the memory usage of `ShuffleWorker`, for example, set to 128m. For more `ShuffleWorker` configurations, please refer to [configuration page](./configuration.md).
 

--- a/shuffle-storage/src/main/java/com/alibaba/flink/shuffle/storage/partition/BaseDataPartition.java
+++ b/shuffle-storage/src/main/java/com/alibaba/flink/shuffle/storage/partition/BaseDataPartition.java
@@ -44,6 +44,8 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedList;
 import java.util.Map;
+import java.util.PriorityQueue;
+import java.util.Queue;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 
@@ -72,8 +74,17 @@ public abstract class BaseDataPartition implements DataPartition {
     /** {@link PartitionedDataStore} storing this data partition. */
     protected final PartitionedDataStore dataStore;
 
+    /** All failed subpartition readers to be released. */
+    protected final Set<DataPartitionReader> failedReaders = new HashSet<>();
+
     /** All {@link DataPartitionReader} reading this data partition. */
     protected final Set<DataPartitionReader> readers = new HashSet<>();
+
+    /**
+     * All readers to be read in order. This queue sorts all readers by file offset to achieve
+     * better sequential IO.
+     */
+    protected final Queue<DataPartitionReader> sortedReaders = new PriorityQueue<>();
 
     /** All {@link DataPartitionWriter} writing this data partition. */
     protected final Map<MapPartitionID, DataPartitionWriter> writers = new HashMap<>();
@@ -184,6 +195,8 @@ public abstract class BaseDataPartition implements DataPartition {
             }
         }
         readers.clear();
+        sortedReaders.clear();
+        failedReaders.clear();
 
         if (exception != null) {
             ExceptionUtils.rethrowException(exception);

--- a/shuffle-storage/src/main/java/com/alibaba/flink/shuffle/storage/partition/BaseMapPartition.java
+++ b/shuffle-storage/src/main/java/com/alibaba/flink/shuffle/storage/partition/BaseMapPartition.java
@@ -45,8 +45,14 @@ import org.slf4j.LoggerFactory;
 import javax.annotation.Nullable;
 
 import java.nio.ByteBuffer;
+import java.util.ArrayDeque;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashSet;
 import java.util.List;
-import java.util.PriorityQueue;
+import java.util.Queue;
+import java.util.Set;
 
 /**
  * Base {@link MapPartition} implementation which takes care of allocating resources and io
@@ -160,6 +166,7 @@ public abstract class BaseMapPartition extends BaseDataPartition implements MapP
                         // allocate resources when the first reader is registered
                         boolean allocateResources = readers.isEmpty();
                         readers.add(reader);
+                        sortedReaders.add(reader);
 
                         if (allocateResources) {
                             DataPartitionReadingTask readingTask =
@@ -167,7 +174,9 @@ public abstract class BaseMapPartition extends BaseDataPartition implements MapP
                             readingTask.allocateResources();
                         }
                     } catch (Throwable throwable) {
-                        DataPartitionUtils.releaseDataPartitionReader(reader, throwable);
+                        readingTask.failSubpartitionReaders(
+                                Collections.singletonList(reader), throwable);
+                        readingTask.removeFinishedAndFailedReaders();
                         LOG.error("Failed to create data partition reader.", throwable);
                     }
                 },
@@ -342,7 +351,7 @@ public abstract class BaseMapPartition extends BaseDataPartition implements MapP
         }
 
         @Override
-        public void allocateResources() throws Exception {
+        public void allocateResources() {
             CommonUtils.checkState(inExecutorThread(), "Not in main thread.");
             checkInProcessState();
 
@@ -510,6 +519,7 @@ public abstract class BaseMapPartition extends BaseDataPartition implements MapP
 
         @Override
         public void process() {
+            Set<DataPartitionReader> finishedReaders = new HashSet<>();
             try {
                 CommonUtils.checkState(inExecutorThread(), "Not in main thread.");
 
@@ -524,32 +534,90 @@ public abstract class BaseMapPartition extends BaseDataPartition implements MapP
                         reader.open();
                     }
                 }
-                PriorityQueue<DataPartitionReader> sortedReaders = new PriorityQueue<>(readers);
 
-                while (buffers.size() > 0 && !sortedReaders.isEmpty()) {
-                    DataPartitionReader reader = sortedReaders.poll();
+                ArrayList<DataPartitionReader> unfinishedReaders = new ArrayList<>();
+                DataPartitionReader reader = getNextReader();
+                while (reader != null) {
                     try {
                         if (!reader.readData(buffers, this::recycle)) {
-                            removePartitionReader(reader);
+                            finishedReaders.add(reader);
                             LOG.debug("Successfully read partition data: {}.", reader);
+                        } else {
+                            unfinishedReaders.add(reader);
                         }
                     } catch (Throwable throwable) {
                         numReadFails.inc();
-                        removePartitionReader(reader);
-                        DataPartitionUtils.releaseDataPartitionReader(reader, throwable);
+                        failSubpartitionReaders(Collections.singletonList(reader), throwable);
+                        removeFinishedAndFailedReaders();
                         LOG.debug("Failed to read partition data: {}.", reader, throwable);
                     }
+
+                    if (buffers.size() == 0) {
+                        break;
+                    }
+                    reader = getNextReader();
+                    if (reader == null && !unfinishedReaders.isEmpty()) {
+                        returnUnfinishedReaders(unfinishedReaders);
+                        reader = getNextReader();
+                    }
                 }
+
+                returnUnfinishedReaders(unfinishedReaders);
+                removeFinishedAndFailedReaders(finishedReaders);
             } catch (Throwable throwable) {
-                DataPartitionUtils.releaseDataPartitionReaders(readers, throwable);
-                buffers.recycleAll();
+                failSubpartitionReaders(getAllReaders(), throwable);
+                removeFinishedAndFailedReaders(finishedReaders);
                 LOG.error("Fatal: failed to read partition data.", throwable);
             }
         }
 
-        private void removePartitionReader(DataPartitionReader reader) {
-            readers.remove(reader);
+        private Queue<DataPartitionReader> getAllReaders() {
+            if (isReleased) {
+                return new ArrayDeque<>();
+            }
+            return new ArrayDeque<>(readers);
+        }
+
+        @Nullable
+        private DataPartitionReader getNextReader() {
+            DataPartitionReader subpartitionReader = sortedReaders.poll();
+            while (subpartitionReader != null && failedReaders.contains(subpartitionReader)) {
+                subpartitionReader = sortedReaders.poll();
+            }
+            return subpartitionReader;
+        }
+
+        private void returnUnfinishedReaders(ArrayList<DataPartitionReader> readers) {
+            if (readers != null && !readers.isEmpty()) {
+                sortedReaders.addAll(readers);
+                readers.clear();
+            }
+        }
+
+        private void failSubpartitionReaders(
+                Collection<DataPartitionReader> readers, Throwable failureCause) {
+            failedReaders.addAll(readers);
+
+            DataPartitionUtils.releaseDataPartitionReaders(readers, failureCause);
+        }
+
+        private void removeFinishedAndFailedReaders() {
+            removeFinishedAndFailedReaders(new HashSet<>());
+        }
+
+        private void removeFinishedAndFailedReaders(Set<DataPartitionReader> finishedReaders) {
+            for (DataPartitionReader reader : finishedReaders) {
+                readers.remove(reader);
+            }
+            finishedReaders.clear();
+
+            for (DataPartitionReader reader : failedReaders) {
+                readers.remove(reader);
+            }
+            failedReaders.clear();
+
             if (readers.isEmpty()) {
+                sortedReaders.clear();
                 buffers.recycleAll();
             }
         }
@@ -581,15 +649,15 @@ public abstract class BaseMapPartition extends BaseDataPartition implements MapP
                                 allocateResources();
                             }
                         } catch (Throwable throwable) {
-                            DataPartitionUtils.releaseDataPartitionReaders(readers, throwable);
-                            buffers.recycleAll();
+                            failSubpartitionReaders(getAllReaders(), throwable);
+                            removeFinishedAndFailedReaders();
                             LOG.error("Resource recycling error.", throwable);
                         }
                     });
         }
 
         @Override
-        public void allocateResources() throws Exception {
+        public void allocateResources() {
             CommonUtils.checkState(inExecutorThread(), "Not in main thread.");
             CommonUtils.checkState(!readers.isEmpty(), "No reader registered.");
             CommonUtils.checkState(!isReleased, "Partition has been released.");
@@ -640,8 +708,8 @@ public abstract class BaseMapPartition extends BaseDataPartition implements MapP
                             buffers.add(allocatedBuffers);
                             triggerReading();
                         } catch (Throwable throwable) {
-                            DataPartitionUtils.releaseDataPartitionReaders(readers, throwable);
-                            buffers.release();
+                            failSubpartitionReaders(getAllReaders(), throwable);
+                            removeFinishedAndFailedReaders();
                             LOG.error("Resource allocation error.", throwable);
                         }
                     });

--- a/shuffle-storage/src/main/java/com/alibaba/flink/shuffle/storage/partition/LocalFileMapPartitionReader.java
+++ b/shuffle-storage/src/main/java/com/alibaba/flink/shuffle/storage/partition/LocalFileMapPartitionReader.java
@@ -120,8 +120,6 @@ public class LocalFileMapPartitionReader extends BaseDataPartitionReader {
 
     @Override
     public long getPriority() {
-        CommonUtils.checkState(isOpened, "Partition reader is not opened.");
-
         // small file offset has high reading priority, it means when reading the partition file,
         // the reader always reads data in file offset order which can reduce random IO and lead to
         // more sequential reading thus is better for IO performance


### PR DESCRIPTION
<!--

*Thank you very much for contributing to remote-shuffle-service-for-flink. To help the community review your issue or contribution in the best possible way，please take a few minutes to fulfill following items.*

-->

## What is the purpose of the change

*When reading data from MapPartition files, It is common that some subpartitions are requested before others and their region indexes are ahead of others. If all region data of a subpartition can be read in one round, some subpartition readers will always ahead of others which will cause random IO. This patch fixes this case by polling one subpartition reader at a time.*


## Brief change log

*(for example:)*
  - *Fix the bug that BaseMapPartition may not read data sequentially.*
  - *Optimize compareTo method in LocalFileMapPartitionReader.*


## Verifying this change

This change is already covered by existing tests, such as *LocalFileMapPartitionReaderTest, ReadingIntegrationTest*.
