### PR TITLE
[FRS-77] Fix ShuffleReadClient block when create channel

### DIFF
--- a/shuffle-plugin/src/main/java/com/alibaba/flink/shuffle/plugin/transfer/RemoteShuffleInputGate.java
+++ b/shuffle-plugin/src/main/java/com/alibaba/flink/shuffle/plugin/transfer/RemoteShuffleInputGate.java
@@ -334,17 +334,17 @@ public class RemoteShuffleInputGate extends IndexedInputGate {
     public void close() throws Exception {
         List<Buffer> buffersToRecycle;
         Throwable closeException = null;
-        synchronized (lock) {
-            // Do not check closed flag, thus to allow calling this method from both task thread and
-            // cancel thread.
-            for (ShuffleReadClient shuffleReadClient : shuffleReadClients) {
-                try {
-                    shuffleReadClient.close();
-                } catch (Throwable throwable) {
-                    closeException = closeException == null ? throwable : closeException;
-                    LOG.error("Failed to close shuffle read client.", throwable);
-                }
+        // Do not check closed flag, thus to allow calling this method from both task thread and
+        // cancel thread.
+        for (ShuffleReadClient shuffleReadClient : shuffleReadClients) {
+            try {
+                shuffleReadClient.close();
+            } catch (Throwable throwable) {
+                closeException = closeException == null ? throwable : closeException;
+                LOG.error("Failed to close shuffle read client.", throwable);
             }
+        }
+        synchronized (lock) {
             buffersToRecycle =
                     receivedBuffers.stream().map(Pair::getLeft).collect(Collectors.toList());
             receivedBuffers.clear();


### PR DESCRIPTION
## What is the purpose of the change

Related issue: https://github.com/flink-extended/flink-remote-shuffle/issues/77

*Fix ShuffleReadClient block when create channel*


## Brief change log

  - * Improve ShuffleClient close*


## Verifying this change

This change is a trivial rework without any test coverage.

