### PR TITLE
[FRS-89] Fix incompatibility with the new version of Flink

### DIFF
--- a/shuffle-plugin/src/main/java/com/alibaba/flink/shuffle/plugin/transfer/RemoteShuffleInputGate.java
+++ b/shuffle-plugin/src/main/java/com/alibaba/flink/shuffle/plugin/transfer/RemoteShuffleInputGate.java
@@ -34,6 +34,7 @@ import org.apache.flink.runtime.checkpoint.CheckpointOptions;
 import org.apache.flink.runtime.checkpoint.channel.ChannelStateWriter;
 import org.apache.flink.runtime.checkpoint.channel.InputChannelInfo;
 import org.apache.flink.runtime.checkpoint.channel.ResultSubpartitionInfo;
+import org.apache.flink.runtime.clusterframework.types.ResourceID;
 import org.apache.flink.runtime.deployment.InputGateDeploymentDescriptor;
 import org.apache.flink.runtime.deployment.SubpartitionIndexRange;
 import org.apache.flink.runtime.event.AbstractEvent;
@@ -57,6 +58,7 @@ import org.apache.flink.runtime.io.network.partition.consumer.RemoteInputChannel
 import org.apache.flink.runtime.io.network.partition.consumer.SingleInputGate;
 import org.apache.flink.runtime.jobgraph.IntermediateDataSetID;
 import org.apache.flink.runtime.shuffle.ShuffleDescriptor;
+import org.apache.flink.runtime.taskmanager.TaskManagerLocation;
 import org.apache.flink.runtime.throughput.ThroughputCalculator;
 import org.apache.flink.util.CloseableIterator;
 import org.apache.flink.util.FlinkRuntimeException;
@@ -72,6 +74,7 @@ import org.slf4j.LoggerFactory;
 import javax.annotation.concurrent.GuardedBy;
 
 import java.io.IOException;
+import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -728,7 +731,10 @@ public class RemoteShuffleInputGate extends IndexedInputGate {
                     channelIndex,
                     new ResultPartitionID(),
                     0,
-                    new ConnectionID(new InetSocketAddress("", 0), 0),
+                    new ConnectionID(
+                            new TaskManagerLocation(
+                                    ResourceID.generate(), InetAddress.getLoopbackAddress(), 1),
+                            0),
                     new LocalConnectionManager(),
                     0,
                     0,


### PR DESCRIPTION
<!--

*Thank you very much for contributing to remote-shuffle-service-for-flink. To help the community review your issue or contribution in the best possible way，please take a few minutes to fulfill following items.*

-->

## What is the purpose of the change

*Fix incompatibility with the new version of Flink*

This change will not affect the compatibility of RSS and lower versions of Flink. Because Flink ConnectionID has two construction methods, only one of which has changed. Previously, it was affected because the construction method used was changed. Now it is changed to the ConnectionID construction method that has not changed for several years, so it is compatible with the historical version of Flink.


## Brief change log
  - Modify the FakedRemoteInputChannel construction method.


## Verifying this change

This change is a trivial code cleanup without any test coverage.
